### PR TITLE
make NavEventNavigator open instead of abstract

### DIFF
--- a/navigator/runtime/api/navigator-runtime.api
+++ b/navigator/runtime/api/navigator-runtime.api
@@ -5,7 +5,7 @@ public final class com/freeletics/mad/navigator/ActivityResultRequest : com/free
 public abstract interface class com/freeletics/mad/navigator/BaseRoute {
 }
 
-public abstract class com/freeletics/mad/navigator/NavEventNavigator {
+public class com/freeletics/mad/navigator/NavEventNavigator {
 	public fun <init> ()V
 	public final fun backPresses ()Lkotlinx/coroutines/flow/Flow;
 	public final fun backPresses (Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;

--- a/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
+++ b/navigator/runtime/src/main/java/com/freeletics/mad/navigator/NavEventNavigator.kt
@@ -35,7 +35,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
  * permission requests can be handled through [registerForActivityResult]/[navigateForResult]
  * and [registerForPermissionsResult]/[requestPermissions] respectively.
  */
-public abstract class NavEventNavigator {
+public open class NavEventNavigator {
 
     private val _navEvents = Channel<NavEvent>(Channel.UNLIMITED)
 


### PR DESCRIPTION
For simple projects it's a lot of boilerplate to always extend the class and it's perfectly fine to just use it as is.