### PR TITLE
add @Language annotation to test code

### DIFF
--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestCompose.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestCompose.kt
@@ -1,3 +1,4 @@
+@file:Suppress("RedundantVisibilityModifier", "TestFunctionName")
 package com.freeletics.khonshu.codegen.codegen
 
 import com.freeletics.khonshu.codegen.AppScope
@@ -13,6 +14,7 @@ import com.squareup.kotlinpoet.SET
 import com.squareup.kotlinpoet.STRING
 import com.squareup.kotlinpoet.UNIT
 import com.squareup.kotlinpoet.asClassName
+import org.intellij.lang.annotations.Language
 import org.junit.Test
 
 internal class FileGeneratorTestCompose {
@@ -51,6 +53,7 @@ internal class FileGeneratorTestCompose {
 
     @Test
     fun `generates code for ComposeScreenData`() {
+        @Language("kotlin")
         val source = """
             package com.test
             
@@ -71,6 +74,7 @@ internal class FileGeneratorTestCompose {
             ) {}
         """.trimIndent()
 
+        @Language("kotlin")
         val expected = """
             package com.test
 
@@ -168,6 +172,7 @@ internal class FileGeneratorTestCompose {
             navigation = navigation,
         )
 
+        @Language("kotlin")
         val source = """
             package com.test
             
@@ -192,6 +197,7 @@ internal class FileGeneratorTestCompose {
             ) {}
         """.trimIndent()
 
+        @Language("kotlin")
         val expected = """
             package com.test
 
@@ -311,6 +317,7 @@ internal class FileGeneratorTestCompose {
             navEntryData = navEntryData,
         )
 
+        @Language("kotlin")
         val source = """
             package com.test
             
@@ -340,6 +347,7 @@ internal class FileGeneratorTestCompose {
             ) {}
         """.trimIndent()
 
+        @Language("kotlin")
         val expected = """
             package com.test
 
@@ -532,6 +540,7 @@ internal class FileGeneratorTestCompose {
             ),
         )
 
+        @Language("kotlin")
         val source = """
             package com.test
             
@@ -556,6 +565,7 @@ internal class FileGeneratorTestCompose {
             ) {}
         """.trimIndent()
 
+        @Language("kotlin")
         val expected = """
             package com.test
 
@@ -757,6 +767,7 @@ internal class FileGeneratorTestCompose {
             ),
         )
 
+        @Language("kotlin")
         val source = """
             package com.test
             
@@ -782,6 +793,7 @@ internal class FileGeneratorTestCompose {
             ) {}
         """.trimIndent()
 
+        @Language("kotlin")
         val expected = """
             package com.test
 
@@ -898,6 +910,7 @@ internal class FileGeneratorTestCompose {
             sendActionParameter = null,
         )
 
+        @Language("kotlin")
         val source = """
             package com.test
             
@@ -917,6 +930,7 @@ internal class FileGeneratorTestCompose {
             ) {}
         """.trimIndent()
 
+        @Language("kotlin")
         val expected = """
             package com.test
 
@@ -1009,6 +1023,7 @@ internal class FileGeneratorTestCompose {
             stateParameter = null,
         )
 
+        @Language("kotlin")
         val source = """
             package com.test
             
@@ -1028,6 +1043,7 @@ internal class FileGeneratorTestCompose {
             ) {}
         """.trimIndent()
 
+        @Language("kotlin")
         val expected = """
             package com.test
 

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestCompose.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestCompose.kt
@@ -1,4 +1,5 @@
 @file:Suppress("RedundantVisibilityModifier", "TestFunctionName")
+
 package com.freeletics.khonshu.codegen.codegen
 
 import com.freeletics.khonshu.codegen.AppScope

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestComposeFragment.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestComposeFragment.kt
@@ -1,3 +1,4 @@
+@file:Suppress("RedundantVisibilityModifier", "TestFunctionName")
 package com.freeletics.khonshu.codegen.codegen
 
 import com.freeletics.khonshu.codegen.AppScope
@@ -13,6 +14,7 @@ import com.squareup.kotlinpoet.SET
 import com.squareup.kotlinpoet.STRING
 import com.squareup.kotlinpoet.UNIT
 import com.squareup.kotlinpoet.asClassName
+import org.intellij.lang.annotations.Language
 import org.junit.Test
 
 internal class FileGeneratorTestComposeFragment {
@@ -52,6 +54,7 @@ internal class FileGeneratorTestComposeFragment {
 
     @Test
     fun `generates code for ComposeFragmentData`() {
+        @Language("kotlin")
         val source = """
             package com.test
             
@@ -72,6 +75,7 @@ internal class FileGeneratorTestComposeFragment {
             ) {}
         """.trimIndent()
 
+        @Language("kotlin")
         val expected = """
             package com.test
 
@@ -192,6 +196,7 @@ internal class FileGeneratorTestComposeFragment {
             navigation = navigation,
         )
 
+        @Language("kotlin")
         val source = """
             package com.test
             
@@ -216,6 +221,7 @@ internal class FileGeneratorTestComposeFragment {
             ) {}
         """.trimIndent()
 
+        @Language("kotlin")
         val expected = """
             package com.test
 
@@ -359,6 +365,7 @@ internal class FileGeneratorTestComposeFragment {
             navEntryData = navEntryData,
         )
 
+        @Language("kotlin")
         val source = """
             package com.test
             
@@ -388,6 +395,7 @@ internal class FileGeneratorTestComposeFragment {
             ) {}
         """.trimIndent()
 
+        @Language("kotlin")
         val expected = """
             package com.test
 
@@ -604,6 +612,7 @@ internal class FileGeneratorTestComposeFragment {
             ),
         )
 
+        @Language("kotlin")
         val source = """
             package com.test
             
@@ -628,6 +637,7 @@ internal class FileGeneratorTestComposeFragment {
             ) {}
         """.trimIndent()
 
+        @Language("kotlin")
         val expected = """
             package com.test
 
@@ -836,6 +846,7 @@ internal class FileGeneratorTestComposeFragment {
             fragmentBaseClass = ClassName("androidx.fragment.app", "DialogFragment"),
         )
 
+        @Language("kotlin")
         val source = """
             package com.test
             
@@ -858,6 +869,7 @@ internal class FileGeneratorTestComposeFragment {
             ) {}
         """.trimIndent()
 
+        @Language("kotlin")
         val expected = """
             package com.test
 
@@ -995,6 +1007,7 @@ internal class FileGeneratorTestComposeFragment {
             ),
         )
 
+        @Language("kotlin")
         val source = """
             package com.test
             
@@ -1020,6 +1033,7 @@ internal class FileGeneratorTestComposeFragment {
             ) {}
         """.trimIndent()
 
+        @Language("kotlin")
         val expected = """
             package com.test
 
@@ -1159,6 +1173,7 @@ internal class FileGeneratorTestComposeFragment {
             sendActionParameter = null,
         )
 
+        @Language("kotlin")
         val source = """
             package com.test
             
@@ -1178,6 +1193,7 @@ internal class FileGeneratorTestComposeFragment {
             ) {}
         """.trimIndent()
 
+        @Language("kotlin")
         val expected = """
             package com.test
 
@@ -1293,6 +1309,7 @@ internal class FileGeneratorTestComposeFragment {
             stateParameter = null,
         )
 
+        @Language("kotlin")
         val source = """
             package com.test
             
@@ -1312,6 +1329,7 @@ internal class FileGeneratorTestComposeFragment {
             ) {}
         """.trimIndent()
 
+        @Language("kotlin")
         val expected = """
             package com.test
 

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestComposeFragment.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestComposeFragment.kt
@@ -1,4 +1,5 @@
 @file:Suppress("RedundantVisibilityModifier", "TestFunctionName")
+
 package com.freeletics.khonshu.codegen.codegen
 
 import com.freeletics.khonshu.codegen.AppScope

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestRendererFragment.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestRendererFragment.kt
@@ -1,4 +1,5 @@
 @file:Suppress("RedundantVisibilityModifier", "TestFunctionName")
+
 package com.freeletics.khonshu.codegen.codegen
 
 import com.freeletics.khonshu.codegen.AppScope
@@ -739,6 +740,7 @@ internal class FileGeneratorTestRendererFragment {
         val dialogFragment = data.copy(
             fragmentBaseClass = ClassName("androidx.fragment.app", "DialogFragment"),
         )
+
         @Language("kotlin")
         val source = """
             package com.test

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestRendererFragment.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestRendererFragment.kt
@@ -1,3 +1,4 @@
+@file:Suppress("RedundantVisibilityModifier", "TestFunctionName")
 package com.freeletics.khonshu.codegen.codegen
 
 import com.freeletics.khonshu.codegen.AppScope
@@ -6,6 +7,7 @@ import com.freeletics.khonshu.codegen.Navigation
 import com.freeletics.khonshu.codegen.RendererFragmentData
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.asClassName
+import org.intellij.lang.annotations.Language
 import org.junit.Test
 
 internal class FileGeneratorTestRendererFragment {
@@ -37,6 +39,7 @@ internal class FileGeneratorTestRendererFragment {
 
     @Test
     fun `generates code for RendererFragmentData`() {
+        @Language("kotlin")
         val source = """
             package com.test
             
@@ -58,6 +61,7 @@ internal class FileGeneratorTestRendererFragment {
             }
         """.trimIndent()
 
+        @Language("kotlin")
         val expected = """
             package com.test
 
@@ -155,6 +159,7 @@ internal class FileGeneratorTestRendererFragment {
             navigation = navigation,
         )
 
+        @Language("kotlin")
         val source = """
             package com.test
             
@@ -179,6 +184,7 @@ internal class FileGeneratorTestRendererFragment {
             }
         """.trimIndent()
 
+        @Language("kotlin")
         val expected = """
             package com.test
 
@@ -299,6 +305,7 @@ internal class FileGeneratorTestRendererFragment {
             navEntryData = navEntryData,
         )
 
+        @Language("kotlin")
         val source = """
             package com.test
             
@@ -328,6 +335,7 @@ internal class FileGeneratorTestRendererFragment {
             }
         """.trimIndent()
 
+        @Language("kotlin")
         val expected = """
             package com.test
 
@@ -521,6 +529,7 @@ internal class FileGeneratorTestRendererFragment {
             ),
         )
 
+        @Language("kotlin")
         val source = """
             package com.test
             
@@ -545,6 +554,7 @@ internal class FileGeneratorTestRendererFragment {
             }
         """.trimIndent()
 
+        @Language("kotlin")
         val expected = """
             package com.test
 
@@ -729,6 +739,7 @@ internal class FileGeneratorTestRendererFragment {
         val dialogFragment = data.copy(
             fragmentBaseClass = ClassName("androidx.fragment.app", "DialogFragment"),
         )
+        @Language("kotlin")
         val source = """
             package com.test
             
@@ -752,6 +763,7 @@ internal class FileGeneratorTestRendererFragment {
             }
         """.trimIndent()
 
+        @Language("kotlin")
         val expected = """
             package com.test
 

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/TestHelper.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/TestHelper.kt
@@ -21,7 +21,7 @@ public fun test(data: BaseData, fileName: String, source: String, expectedCode: 
 }
 
 private fun compile(fileName: String, source: String, data: BaseData, expectedCode: String) {
-    val generatedCode = when(data) {
+    val generatedCode = when (data) {
         is ComposeFragmentData -> FileGenerator().generate(data).toString()
         is ComposeScreenData -> FileGenerator().generate(data).toString()
         is RendererFragmentData -> FileGenerator().generate(data).toString()


### PR DESCRIPTION
Makes reading the code in strings nicer since this adds highlighting to it. The suppresses are for not valid warnings that this highlighting shows in those strings.

Also improved the naming and structure of the test helpers a bit.