### PR TITLE
introduce ComponentProvider

### DIFF
--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestCompose.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestCompose.kt
@@ -208,17 +208,20 @@ internal class FileGeneratorTestCompose {
         val expected = """
             package com.test
 
+            import android.content.Context
             import androidx.compose.runtime.Composable
             import androidx.compose.runtime.remember
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.compose.ui.platform.LocalContext
             import androidx.lifecycle.SavedStateHandle
             import com.freeletics.khonshu.codegen.ScopeTo
+            import com.freeletics.khonshu.codegen.`internal`.ComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
             import com.freeletics.khonshu.codegen.`internal`.asComposeState
             import com.freeletics.khonshu.codegen.`internal`.component
             import com.freeletics.khonshu.navigation.NavEventNavigator
             import com.freeletics.khonshu.navigation.`internal`.InternalNavigationApi
+            import com.freeletics.khonshu.navigation.`internal`.NavigationExecutor
             import com.freeletics.khonshu.navigation.`internal`.destinationId
             import com.freeletics.khonshu.navigation.compose.LocalNavigationExecutor
             import com.freeletics.khonshu.navigation.compose.NavDestination
@@ -268,6 +271,20 @@ internal class FileGeneratorTestCompose {
                 public fun khonshuTestComponentFactory(): Factory
               }
             }
+            
+            @OptIn(InternalCodegenApi::class)
+            public object KhonshuTestComponentProvider : ComponentProvider<TestRoute, KhonshuTestComponent> {
+              @OptIn(InternalNavigationApi::class)
+              override fun provide(
+                route: TestRoute,
+                executor: NavigationExecutor,
+                context: Context,
+              ): KhonshuTestComponent = component(route.destinationId, route, executor, context,
+                  TestParentScope::class, TestDestinationScope::class) { parentComponent:
+                  KhonshuTestComponent.ParentComponent, savedStateHandle, testRoute ->
+                parentComponent.khonshuTestComponentFactory().create(savedStateHandle, testRoute)
+              }
+            }
 
             @Module
             @ContributesTo(TestRoute::class)
@@ -282,11 +299,7 @@ internal class FileGeneratorTestCompose {
               val context = LocalContext.current
               val executor = LocalNavigationExecutor.current
               val component = remember(context, executor, testRoute) {
-                component(testRoute.destinationId, testRoute, executor, context, TestParentScope::class,
-                    TestDestinationScope::class) { parentComponent: KhonshuTestComponent.ParentComponent,
-                    savedStateHandle, testRouteForComponent ->
-                  parentComponent.khonshuTestComponentFactory().create(savedStateHandle, testRouteForComponent)
-                }
+                KhonshuTestComponentProvider.provide(testRoute, executor, context)
               }
 
               NavigationSetup(component.navEventNavigator)
@@ -374,6 +387,7 @@ internal class FileGeneratorTestCompose {
             import androidx.lifecycle.SavedStateHandle
             import com.freeletics.khonshu.codegen.NavEntry
             import com.freeletics.khonshu.codegen.ScopeTo
+            import com.freeletics.khonshu.codegen.`internal`.ComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
             import com.freeletics.khonshu.codegen.`internal`.NavDestinationComponent
             import com.freeletics.khonshu.codegen.`internal`.NavEntryComponentGetter
@@ -436,6 +450,20 @@ internal class FileGeneratorTestCompose {
                 public fun khonshuTestComponentFactory(): Factory
               }
             }
+            
+            @OptIn(InternalCodegenApi::class)
+            public object KhonshuTestComponentProvider : ComponentProvider<TestRoute, KhonshuTestComponent> {
+              @OptIn(InternalNavigationApi::class)
+              override fun provide(
+                route: TestRoute,
+                executor: NavigationExecutor,
+                context: Context,
+              ): KhonshuTestComponent = component(route.destinationId, route, executor, context,
+                  TestParentScope::class, TestDestinationScope::class) { parentComponent:
+                  KhonshuTestComponent.ParentComponent, savedStateHandle, testRoute ->
+                parentComponent.khonshuTestComponentFactory().create(savedStateHandle, testRoute)
+              }
+            }
 
             @Module
             @ContributesTo(TestRoute::class)
@@ -450,11 +478,7 @@ internal class FileGeneratorTestCompose {
               val context = LocalContext.current
               val executor = LocalNavigationExecutor.current
               val component = remember(context, executor, testRoute) {
-                component(testRoute.destinationId, testRoute, executor, context, TestParentScope::class,
-                    TestDestinationScope::class) { parentComponent: KhonshuTestComponent.ParentComponent,
-                    savedStateHandle, testRouteForComponent ->
-                  parentComponent.khonshuTestComponentFactory().create(savedStateHandle, testRouteForComponent)
-                }
+                KhonshuTestComponentProvider.provide(testRoute, executor, context)
               }
 
               NavigationSetup(component.navEventNavigator)
@@ -600,6 +624,7 @@ internal class FileGeneratorTestCompose {
             import com.freeletics.khonshu.codegen.AppScope
             import com.freeletics.khonshu.codegen.NavEntry
             import com.freeletics.khonshu.codegen.ScopeTo
+            import com.freeletics.khonshu.codegen.`internal`.ComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
             import com.freeletics.khonshu.codegen.`internal`.NavDestinationComponent
             import com.freeletics.khonshu.codegen.`internal`.NavEntryComponentGetter
@@ -660,6 +685,20 @@ internal class FileGeneratorTestCompose {
                 public fun khonshuTestComponentFactory(): Factory
               }
             }
+            
+            @OptIn(InternalCodegenApi::class)
+            public object KhonshuTestComponentProvider : ComponentProvider<TestRoute, KhonshuTestComponent> {
+              @OptIn(InternalNavigationApi::class)
+              override fun provide(
+                route: TestRoute,
+                executor: NavigationExecutor,
+                context: Context,
+              ): KhonshuTestComponent = component(route.destinationId, route, executor, context,
+                  AppScope::class, AppScope::class) { parentComponent: KhonshuTestComponent.ParentComponent,
+                  savedStateHandle, testRoute ->
+                parentComponent.khonshuTestComponentFactory().create(savedStateHandle, testRoute)
+              }
+            }
 
             @Module
             @ContributesTo(TestRoute::class)
@@ -674,11 +713,7 @@ internal class FileGeneratorTestCompose {
               val context = LocalContext.current
               val executor = LocalNavigationExecutor.current
               val component = remember(context, executor, testRoute) {
-                component(testRoute.destinationId, testRoute, executor, context, AppScope::class,
-                    AppScope::class) { parentComponent: KhonshuTestComponent.ParentComponent, savedStateHandle,
-                    testRouteForComponent ->
-                  parentComponent.khonshuTestComponentFactory().create(savedStateHandle, testRouteForComponent)
-                }
+                KhonshuTestComponentProvider.provide(testRoute, executor, context)
               }
 
               NavigationSetup(component.navEventNavigator)

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestComposeFragment.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestComposeFragment.kt
@@ -227,6 +227,7 @@ internal class FileGeneratorTestComposeFragment {
         val expected = """
             package com.test
 
+            import android.content.Context
             import android.os.Bundle
             import android.view.LayoutInflater
             import android.view.View
@@ -239,11 +240,13 @@ internal class FileGeneratorTestComposeFragment {
             import androidx.fragment.app.Fragment
             import androidx.lifecycle.SavedStateHandle
             import com.freeletics.khonshu.codegen.ScopeTo
+            import com.freeletics.khonshu.codegen.`internal`.ComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
             import com.freeletics.khonshu.codegen.`internal`.asComposeState
             import com.freeletics.khonshu.codegen.`internal`.component
             import com.freeletics.khonshu.navigation.NavEventNavigator
             import com.freeletics.khonshu.navigation.`internal`.InternalNavigationApi
+            import com.freeletics.khonshu.navigation.`internal`.NavigationExecutor
             import com.freeletics.khonshu.navigation.`internal`.destinationId
             import com.freeletics.khonshu.navigation.fragment.NavDestination
             import com.freeletics.khonshu.navigation.fragment.ScreenDestination
@@ -294,6 +297,20 @@ internal class FileGeneratorTestComposeFragment {
                 public fun khonshuTestComponentFactory(): Factory
               }
             }
+            
+            @OptIn(InternalCodegenApi::class)
+            public object KhonshuTestComponentProvider : ComponentProvider<TestRoute, KhonshuTestComponent> {
+              @OptIn(InternalNavigationApi::class)
+              override fun provide(
+                route: TestRoute,
+                executor: NavigationExecutor,
+                context: Context,
+              ): KhonshuTestComponent = component(route.destinationId, route, executor, context,
+                  TestParentScope::class, TestDestinationScope::class) { parentComponent:
+                  KhonshuTestComponent.ParentComponent, savedStateHandle, testRoute ->
+                parentComponent.khonshuTestComponentFactory().create(savedStateHandle, testRoute)
+              }
+            }
 
             @Module
             @ContributesTo(TestRoute::class)
@@ -315,12 +332,8 @@ internal class FileGeneratorTestComposeFragment {
                 if (!::khonshuTestComponent.isInitialized) {
                   val testRoute = requireRoute<TestRoute>()
                   val executor = findNavigationExecutor()
-                  khonshuTestComponent = component(testRoute.destinationId, testRoute, executor,
-                      requireContext(), TestParentScope::class, TestDestinationScope::class) { parentComponent:
-                      KhonshuTestComponent.ParentComponent, savedStateHandle, testRouteForComponent ->
-                    parentComponent.khonshuTestComponentFactory().create(savedStateHandle,
-                        testRouteForComponent)
-                  }
+                  khonshuTestComponent = KhonshuTestComponentProvider.provide(testRoute, executor,
+                      requireContext())
             
                   handleNavigation(this, khonshuTestComponent.navEventNavigator)
                 }
@@ -420,6 +433,7 @@ internal class FileGeneratorTestComposeFragment {
             import androidx.lifecycle.SavedStateHandle
             import com.freeletics.khonshu.codegen.NavEntry
             import com.freeletics.khonshu.codegen.ScopeTo
+            import com.freeletics.khonshu.codegen.`internal`.ComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
             import com.freeletics.khonshu.codegen.`internal`.NavDestinationComponent
             import com.freeletics.khonshu.codegen.`internal`.NavEntryComponentGetter
@@ -483,6 +497,20 @@ internal class FileGeneratorTestComposeFragment {
                 public fun khonshuTestComponentFactory(): Factory
               }
             }
+            
+            @OptIn(InternalCodegenApi::class)
+            public object KhonshuTestComponentProvider : ComponentProvider<TestRoute, KhonshuTestComponent> {
+              @OptIn(InternalNavigationApi::class)
+              override fun provide(
+                route: TestRoute,
+                executor: NavigationExecutor,
+                context: Context,
+              ): KhonshuTestComponent = component(route.destinationId, route, executor, context,
+                  TestParentScope::class, TestDestinationScope::class) { parentComponent:
+                  KhonshuTestComponent.ParentComponent, savedStateHandle, testRoute ->
+                parentComponent.khonshuTestComponentFactory().create(savedStateHandle, testRoute)
+              }
+            }
 
             @Module
             @ContributesTo(TestRoute::class)
@@ -504,12 +532,8 @@ internal class FileGeneratorTestComposeFragment {
                 if (!::khonshuTestComponent.isInitialized) {
                   val testRoute = requireRoute<TestRoute>()
                   val executor = findNavigationExecutor()
-                  khonshuTestComponent = component(testRoute.destinationId, testRoute, executor,
-                      requireContext(), TestParentScope::class, TestDestinationScope::class) { parentComponent:
-                      KhonshuTestComponent.ParentComponent, savedStateHandle, testRouteForComponent ->
-                    parentComponent.khonshuTestComponentFactory().create(savedStateHandle,
-                        testRouteForComponent)
-                  }
+                  khonshuTestComponent = KhonshuTestComponentProvider.provide(testRoute, executor,
+                      requireContext())
 
                   handleNavigation(this, khonshuTestComponent.navEventNavigator)
                 }
@@ -667,6 +691,7 @@ internal class FileGeneratorTestComposeFragment {
             import com.freeletics.khonshu.codegen.AppScope
             import com.freeletics.khonshu.codegen.NavEntry
             import com.freeletics.khonshu.codegen.ScopeTo
+            import com.freeletics.khonshu.codegen.`internal`.ComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
             import com.freeletics.khonshu.codegen.`internal`.NavDestinationComponent
             import com.freeletics.khonshu.codegen.`internal`.NavEntryComponentGetter
@@ -728,6 +753,20 @@ internal class FileGeneratorTestComposeFragment {
                 public fun khonshuTestComponentFactory(): Factory
               }
             }
+            
+            @OptIn(InternalCodegenApi::class)
+            public object KhonshuTestComponentProvider : ComponentProvider<TestRoute, KhonshuTestComponent> {
+              @OptIn(InternalNavigationApi::class)
+              override fun provide(
+                route: TestRoute,
+                executor: NavigationExecutor,
+                context: Context,
+              ): KhonshuTestComponent = component(route.destinationId, route, executor, context,
+                  AppScope::class, AppScope::class) { parentComponent: KhonshuTestComponent.ParentComponent,
+                  savedStateHandle, testRoute ->
+                parentComponent.khonshuTestComponentFactory().create(savedStateHandle, testRoute)
+              }
+            }
 
             @Module
             @ContributesTo(TestRoute::class)
@@ -749,12 +788,8 @@ internal class FileGeneratorTestComposeFragment {
                 if (!::khonshuTestComponent.isInitialized) {
                   val testRoute = requireRoute<TestRoute>()
                   val executor = findNavigationExecutor()
-                  khonshuTestComponent = component(testRoute.destinationId, testRoute, executor,
-                      requireContext(), AppScope::class, AppScope::class) { parentComponent:
-                      KhonshuTestComponent.ParentComponent, savedStateHandle, testRouteForComponent ->
-                    parentComponent.khonshuTestComponentFactory().create(savedStateHandle,
-                        testRouteForComponent)
-                  }
+                  khonshuTestComponent = KhonshuTestComponentProvider.provide(testRoute, executor,
+                      requireContext())
 
                   handleNavigation(this, khonshuTestComponent.navEventNavigator)
                 }

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestRendererFragment.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestRendererFragment.kt
@@ -190,6 +190,7 @@ internal class FileGeneratorTestRendererFragment {
         val expected = """
             package com.test
 
+            import android.content.Context
             import android.os.Bundle
             import android.view.LayoutInflater
             import android.view.View
@@ -197,10 +198,12 @@ internal class FileGeneratorTestRendererFragment {
             import androidx.fragment.app.Fragment
             import androidx.lifecycle.SavedStateHandle
             import com.freeletics.khonshu.codegen.ScopeTo
+            import com.freeletics.khonshu.codegen.`internal`.ComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
             import com.freeletics.khonshu.codegen.`internal`.component
             import com.freeletics.khonshu.navigation.NavEventNavigator
             import com.freeletics.khonshu.navigation.`internal`.InternalNavigationApi
+            import com.freeletics.khonshu.navigation.`internal`.NavigationExecutor
             import com.freeletics.khonshu.navigation.`internal`.destinationId
             import com.freeletics.khonshu.navigation.fragment.NavDestination
             import com.freeletics.khonshu.navigation.fragment.ScreenDestination
@@ -253,6 +256,21 @@ internal class FileGeneratorTestRendererFragment {
                 public fun khonshuTestRendererComponentFactory(): Factory
               }
             }
+            
+            @OptIn(InternalCodegenApi::class)
+            public object KhonshuTestRendererComponentProvider :
+                ComponentProvider<TestRoute, KhonshuTestRendererComponent> {
+              @OptIn(InternalNavigationApi::class)
+              override fun provide(
+                route: TestRoute,
+                executor: NavigationExecutor,
+                context: Context,
+              ): KhonshuTestRendererComponent = component(route.destinationId, route, executor, context,
+                  TestParentScope::class, TestDestinationScope::class) { parentComponent:
+                  KhonshuTestRendererComponent.ParentComponent, savedStateHandle, testRoute ->
+                parentComponent.khonshuTestRendererComponentFactory().create(savedStateHandle, testRoute)
+              }
+            }
 
             @Module
             @ContributesTo(TestRoute::class)
@@ -274,12 +292,8 @@ internal class FileGeneratorTestRendererFragment {
                 if (!::khonshuTestRendererComponent.isInitialized) {
                   val testRoute = requireRoute<TestRoute>()
                   val executor = findNavigationExecutor()
-                  khonshuTestRendererComponent = component(testRoute.destinationId, testRoute, executor,
-                      requireContext(), TestParentScope::class, TestDestinationScope::class) { parentComponent:
-                      KhonshuTestRendererComponent.ParentComponent, savedStateHandle, testRouteForComponent ->
-                    parentComponent.khonshuTestRendererComponentFactory().create(savedStateHandle,
-                        testRouteForComponent)
-                  }
+                  khonshuTestRendererComponent = KhonshuTestRendererComponentProvider.provide(testRoute,
+                      executor, requireContext())
             
                   handleNavigation(this, khonshuTestRendererComponent.navEventNavigator)
                 }
@@ -355,6 +369,7 @@ internal class FileGeneratorTestRendererFragment {
             import androidx.lifecycle.SavedStateHandle
             import com.freeletics.khonshu.codegen.NavEntry
             import com.freeletics.khonshu.codegen.ScopeTo
+            import com.freeletics.khonshu.codegen.`internal`.ComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
             import com.freeletics.khonshu.codegen.`internal`.NavDestinationComponent
             import com.freeletics.khonshu.codegen.`internal`.NavEntryComponentGetter
@@ -419,6 +434,21 @@ internal class FileGeneratorTestRendererFragment {
                 public fun khonshuTestRendererComponentFactory(): Factory
               }
             }
+            
+            @OptIn(InternalCodegenApi::class)
+            public object KhonshuTestRendererComponentProvider :
+                ComponentProvider<TestRoute, KhonshuTestRendererComponent> {
+              @OptIn(InternalNavigationApi::class)
+              override fun provide(
+                route: TestRoute,
+                executor: NavigationExecutor,
+                context: Context,
+              ): KhonshuTestRendererComponent = component(route.destinationId, route, executor, context,
+                  TestParentScope::class, TestDestinationScope::class) { parentComponent:
+                  KhonshuTestRendererComponent.ParentComponent, savedStateHandle, testRoute ->
+                parentComponent.khonshuTestRendererComponentFactory().create(savedStateHandle, testRoute)
+              }
+            }
 
             @Module
             @ContributesTo(TestRoute::class)
@@ -440,12 +470,8 @@ internal class FileGeneratorTestRendererFragment {
                 if (!::khonshuTestRendererComponent.isInitialized) {
                   val testRoute = requireRoute<TestRoute>()
                   val executor = findNavigationExecutor()
-                  khonshuTestRendererComponent = component(testRoute.destinationId, testRoute, executor,
-                      requireContext(), TestParentScope::class, TestDestinationScope::class) { parentComponent:
-                      KhonshuTestRendererComponent.ParentComponent, savedStateHandle, testRouteForComponent ->
-                    parentComponent.khonshuTestRendererComponentFactory().create(savedStateHandle,
-                        testRouteForComponent)
-                  }
+                  khonshuTestRendererComponent = KhonshuTestRendererComponentProvider.provide(testRoute,
+                      executor, requireContext())
 
                   handleNavigation(this, khonshuTestRendererComponent.navEventNavigator)
                 }
@@ -579,6 +605,7 @@ internal class FileGeneratorTestRendererFragment {
             import com.freeletics.khonshu.codegen.AppScope
             import com.freeletics.khonshu.codegen.NavEntry
             import com.freeletics.khonshu.codegen.ScopeTo
+            import com.freeletics.khonshu.codegen.`internal`.ComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
             import com.freeletics.khonshu.codegen.`internal`.NavDestinationComponent
             import com.freeletics.khonshu.codegen.`internal`.NavEntryComponentGetter
@@ -641,6 +668,21 @@ internal class FileGeneratorTestRendererFragment {
                 public fun khonshuTestRendererComponentFactory(): Factory
               }
             }
+            
+            @OptIn(InternalCodegenApi::class)
+            public object KhonshuTestRendererComponentProvider :
+                ComponentProvider<TestRoute, KhonshuTestRendererComponent> {
+              @OptIn(InternalNavigationApi::class)
+              override fun provide(
+                route: TestRoute,
+                executor: NavigationExecutor,
+                context: Context,
+              ): KhonshuTestRendererComponent = component(route.destinationId, route, executor, context,
+                  AppScope::class, AppScope::class) { parentComponent:
+                  KhonshuTestRendererComponent.ParentComponent, savedStateHandle, testRoute ->
+                parentComponent.khonshuTestRendererComponentFactory().create(savedStateHandle, testRoute)
+              }
+            }
 
             @Module
             @ContributesTo(TestRoute::class)
@@ -662,12 +704,8 @@ internal class FileGeneratorTestRendererFragment {
                 if (!::khonshuTestRendererComponent.isInitialized) {
                   val testRoute = requireRoute<TestRoute>()
                   val executor = findNavigationExecutor()
-                  khonshuTestRendererComponent = component(testRoute.destinationId, testRoute, executor,
-                      requireContext(), AppScope::class, AppScope::class) { parentComponent:
-                      KhonshuTestRendererComponent.ParentComponent, savedStateHandle, testRouteForComponent ->
-                    parentComponent.khonshuTestRendererComponentFactory().create(savedStateHandle,
-                        testRouteForComponent)
-                  }
+                  khonshuTestRendererComponent = KhonshuTestRendererComponentProvider.provide(testRoute,
+                      executor, requireContext())
 
                   handleNavigation(this, khonshuTestRendererComponent.navEventNavigator)
                 }

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/FileGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/FileGenerator.kt
@@ -6,6 +6,7 @@ import com.freeletics.khonshu.codegen.ComposeScreenData
 import com.freeletics.khonshu.codegen.NavEntryData
 import com.freeletics.khonshu.codegen.RendererFragmentData
 import com.freeletics.khonshu.codegen.codegen.common.ComponentGenerator
+import com.freeletics.khonshu.codegen.codegen.common.ComponentProviderGenerator
 import com.freeletics.khonshu.codegen.codegen.common.ComposeGenerator
 import com.freeletics.khonshu.codegen.codegen.common.ModuleGenerator
 import com.freeletics.khonshu.codegen.codegen.compose.ComposeScreenGenerator
@@ -35,6 +36,7 @@ public class FileGenerator {
 
         return FileSpec.builder(data.packageName, "Khonshu${data.baseName}")
             .addType(componentGenerator.generate())
+            .addComponentProviderType(data)
             .addType(moduleGenerator.generate())
             .addFunction(composeScreenGenerator.generate())
             .addFunction(composeGenerator.generate())
@@ -51,6 +53,7 @@ public class FileGenerator {
 
         return FileSpec.builder(data.packageName, "Khonshu${data.baseName}")
             .addType(componentGenerator.generate())
+            .addComponentProviderType(data)
             .addType(moduleGenerator.generate())
             .addType(composeFragmentGenerator.generate())
             .addFunction(composeGenerator.generate())
@@ -66,11 +69,19 @@ public class FileGenerator {
 
         return FileSpec.builder(data.packageName, "Khonshu${data.baseName}")
             .addType(componentGenerator.generate())
+            .addComponentProviderType(data)
             .addType(moduleGenerator.generate())
             .addType(rendererFragmentGenerator.generate())
             .addNavDestinationTypes(data)
             .addNavEntryTypes(data.navEntryData)
             .build()
+    }
+
+    private fun FileSpec.Builder.addComponentProviderType(data: BaseData) = apply {
+        if (data.navigation != null) {
+            val componentProviderGenerator = ComponentProviderGenerator(data)
+            addType(componentProviderGenerator.generate())
+        }
     }
 
     private fun FileSpec.Builder.addNavDestinationTypes(data: BaseData) = apply {

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/common/ComponentProviderGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/common/ComponentProviderGenerator.kt
@@ -1,0 +1,63 @@
+package com.freeletics.khonshu.codegen.codegen.common
+
+import com.freeletics.khonshu.codegen.BaseData
+import com.freeletics.khonshu.codegen.codegen.Generator
+import com.freeletics.khonshu.codegen.codegen.util.componentProvider
+import com.freeletics.khonshu.codegen.codegen.util.context
+import com.freeletics.khonshu.codegen.codegen.util.destinationId
+import com.freeletics.khonshu.codegen.codegen.util.getComponent
+import com.freeletics.khonshu.codegen.codegen.util.internalNavigatorApi
+import com.freeletics.khonshu.codegen.codegen.util.navigationExecutor
+import com.freeletics.khonshu.codegen.codegen.util.optInAnnotation
+import com.freeletics.khonshu.codegen.codegen.util.propertyName
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier.OVERRIDE
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.TypeSpec
+
+internal val Generator<out BaseData>.componentProviderClassName
+    get() = ClassName("Khonshu${data.baseName}ComponentProvider")
+
+internal class ComponentProviderGenerator(
+    override val data: BaseData,
+) : Generator<BaseData>() {
+
+    internal fun generate(): TypeSpec {
+        return TypeSpec.objectBuilder(componentProviderClassName)
+            .addAnnotation(optInAnnotation())
+            .addSuperinterface(
+                componentProvider
+                    .parameterizedBy(data.navigation!!.route, retainedComponentClassName),
+            )
+            .addFunction(provideFunction())
+            .build()
+    }
+
+    private fun provideFunction(): FunSpec {
+        return FunSpec.builder("provide")
+            .addModifiers(OVERRIDE)
+            .addAnnotation(optInAnnotation(internalNavigatorApi))
+            .addParameter("route", data.navigation!!.route)
+            .addParameter("executor", navigationExecutor)
+            .addParameter("context", context)
+            .returns(retainedComponentClassName)
+            .beginControlFlow(
+                "return %M(route.%M, route, executor, context, %T::class, %T::class) " +
+                    "{ parentComponent: %T, savedStateHandle, %L ->",
+                getComponent,
+                destinationId,
+                data.parentScope,
+                data.navigation!!.destinationScope,
+                retainedParentComponentClassName,
+                data.navigation!!.route.propertyName,
+            )
+            .addStatement(
+                "parentComponent.%L().%L(savedStateHandle, %L)",
+                retainedParentComponentGetterName,
+                retainedComponentFactoryCreateName,
+                data.navigation!!.route.propertyName,
+            )
+            .endControlFlow()
+            .build()
+    }
+}

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/compose/ComposeScreenGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/compose/ComposeScreenGenerator.kt
@@ -2,6 +2,7 @@ package com.freeletics.khonshu.codegen.codegen.compose
 
 import com.freeletics.khonshu.codegen.ComposeScreenData
 import com.freeletics.khonshu.codegen.codegen.Generator
+import com.freeletics.khonshu.codegen.codegen.common.componentProviderClassName
 import com.freeletics.khonshu.codegen.codegen.common.composableName
 import com.freeletics.khonshu.codegen.codegen.common.retainedComponentFactoryCreateName
 import com.freeletics.khonshu.codegen.codegen.common.retainedParentComponentClassName
@@ -11,7 +12,6 @@ import com.freeletics.khonshu.codegen.codegen.util.asParameter
 import com.freeletics.khonshu.codegen.codegen.util.composable
 import com.freeletics.khonshu.codegen.codegen.util.composeLocalNavigationExecutor
 import com.freeletics.khonshu.codegen.codegen.util.composeNavigationHandler
-import com.freeletics.khonshu.codegen.codegen.util.destinationId
 import com.freeletics.khonshu.codegen.codegen.util.getComponent
 import com.freeletics.khonshu.codegen.codegen.util.internalNavigatorApi
 import com.freeletics.khonshu.codegen.codegen.util.localContext
@@ -45,18 +45,7 @@ internal class ComposeScreenGenerator(
                 if (data.navigation != null) {
                     it.addStatement("val executor = %M.current", composeLocalNavigationExecutor)
                     it.beginControlFlow("val component = %M(context, executor, %N)", remember, parameter)
-                    it.beginControlFlow(
-                        "%M(%N.%M, %N, executor, context, %T::class, %T::class) { " +
-                            "parentComponent: %T, savedStateHandle, %L ->",
-                        getComponent,
-                        parameter,
-                        destinationId,
-                        parameter,
-                        data.parentScope,
-                        data.navigation.destinationScope,
-                        retainedParentComponentClassName,
-                        innerParameterName,
-                    )
+                    it.addStatement("%T.provide(%N, executor, context)", componentProviderClassName, parameter)
                 } else {
                     it.addStatement("val viewModelStoreOwner = checkNotNull(%T.current)", localViewModelStoreOwner)
                     it.beginControlFlow("val component = %M(viewModelStoreOwner, context, arguments)", remember)
@@ -69,15 +58,15 @@ internal class ComposeScreenGenerator(
                         retainedParentComponentClassName,
                         innerParameterName,
                     )
+                    it.addStatement(
+                        "parentComponent.%L().%L(savedStateHandle, %L)",
+                        retainedParentComponentGetterName,
+                        retainedComponentFactoryCreateName,
+                        innerParameterName,
+                    )
+                    it.endControlFlow()
                 }
             }
-            .addStatement(
-                "parentComponent.%L().%L(savedStateHandle, %L)",
-                retainedParentComponentGetterName,
-                retainedComponentFactoryCreateName,
-                innerParameterName,
-            )
-            .endControlFlow()
             .endControlFlow()
             .addCode("\n")
             .addCode(composableNavigationSetup())

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/util/External.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/util/External.kt
@@ -28,6 +28,7 @@ internal val asComposeState = MemberName("com.freeletics.khonshu.codegen.interna
 internal val InternalCodegenApi = ClassName("com.freeletics.khonshu.codegen.internal", "InternalCodegenApi")
 internal val getComponent = MemberName("com.freeletics.khonshu.codegen.internal", "component")
 internal val getNavEntryComponent = MemberName("com.freeletics.khonshu.codegen.internal", "navEntryComponent")
+internal val componentProvider = ClassName("com.freeletics.khonshu.codegen.internal", "ComponentProvider")
 internal val navEntryComponentGetter = ClassName("com.freeletics.khonshu.codegen.internal", "NavEntryComponentGetter")
 internal val navEntryComponentGetterKey = ClassName(
     "com.freeletics.khonshu.codegen.internal",

--- a/codegen/src/main/kotlin/com/freeletics/khonshu/codegen/internal/ComponentProvider.kt
+++ b/codegen/src/main/kotlin/com/freeletics/khonshu/codegen/internal/ComponentProvider.kt
@@ -29,10 +29,15 @@ public inline fun <reified C : Any, P : Any> component(
     }
 }
 
+@InternalCodegenApi
+public interface ComponentProvider<R : BaseRoute, T> {
+    public fun provide(route: R, executor: NavigationExecutor, context: Context): T
+}
+
 /**
  * Creates a [ViewModel] for the given [destinationId]. The `ViewModel.Factory` will use [parentScope]
  * to lookup a parent component instance. That component will then be passed to the given [factory]
- * together with a [SavedStateHandle] and the passed in [destination].
+ * together with a [SavedStateHandle] and the passed in [destinationId].
  *
  * To be used in generated code.
  */


### PR DESCRIPTION
This moves the code to obtain the generated component from being directly in the Fragment or Composable to an object that implements `ComponentProvider`. The goal is to make that snippet reusable without duplicating it which will allow us to remove the extra `NavEntryComponentGetter` that we have for shared scopes in follow ups.