### PR TITLE
make it possible to directly use generated component as parent

### DIFF
--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestCompose.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestCompose.kt
@@ -222,6 +222,8 @@ internal class FileGeneratorTestCompose {
             import com.freeletics.khonshu.codegen.ScopeTo
             import com.freeletics.khonshu.codegen.`internal`.ComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
+            import com.freeletics.khonshu.codegen.`internal`.NavComponentProvider
+            import com.freeletics.khonshu.codegen.`internal`.NavDestinationComponent
             import com.freeletics.khonshu.codegen.`internal`.asComposeState
             import com.freeletics.khonshu.codegen.`internal`.component
             import com.freeletics.khonshu.navigation.NavEventNavigator
@@ -239,11 +241,13 @@ internal class FileGeneratorTestCompose {
             import dagger.BindsInstance
             import dagger.Module
             import dagger.Provides
+            import dagger.multibindings.IntoMap
             import dagger.multibindings.IntoSet
             import dagger.multibindings.Multibinds
             import java.io.Closeable
             import kotlin.OptIn
             import kotlin.collections.Set
+            import kotlin.jvm.JvmSuppressWildcards
             import kotlinx.coroutines.launch
 
             @OptIn(InternalCodegenApi::class)
@@ -292,6 +296,10 @@ internal class FileGeneratorTestCompose {
                 parentComponent.khonshuTestComponentFactory().create(savedStateHandle, testRoute)
               }
             }
+            
+            @ContributesTo(TestDestinationScope::class)
+            @OptIn(InternalCodegenApi::class)
+            public interface KhonshuTestNavDestinationComponent : NavDestinationComponent
 
             @Module
             @ContributesTo(TestRoute::class)
@@ -330,6 +338,7 @@ internal class FileGeneratorTestCompose {
               }
             }
             
+            @OptIn(InternalCodegenApi::class)
             @Module
             @ContributesTo(TestDestinationScope::class)
             public object KhonshuTestNavDestinationModule {
@@ -338,6 +347,12 @@ internal class FileGeneratorTestCompose {
               public fun provideNavDestination(): NavDestination = ScreenDestination<TestRoute> {
                 KhonshuTest(it)
               }
+
+              @Provides
+              @IntoMap
+              @NavComponentProvider(TestRoute::class)
+              public fun bindComponentProvider(): @JvmSuppressWildcards ComponentProvider<*, *> =
+                  KhonshuTestComponentProvider
             }
             
         """.trimIndent()
@@ -397,6 +412,7 @@ internal class FileGeneratorTestCompose {
             import com.freeletics.khonshu.codegen.ScopeTo
             import com.freeletics.khonshu.codegen.`internal`.ComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
+            import com.freeletics.khonshu.codegen.`internal`.NavComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.NavDestinationComponent
             import com.freeletics.khonshu.codegen.`internal`.NavEntryComponentGetter
             import com.freeletics.khonshu.codegen.`internal`.NavEntryComponentGetterKey
@@ -419,6 +435,7 @@ internal class FileGeneratorTestCompose {
             import dagger.BindsInstance
             import dagger.Module
             import dagger.Provides
+            import dagger.multibindings.IntoMap
             import dagger.multibindings.IntoSet
             import dagger.multibindings.Multibinds
             import java.io.Closeable
@@ -426,6 +443,7 @@ internal class FileGeneratorTestCompose {
             import kotlin.Any
             import kotlin.OptIn
             import kotlin.collections.Set
+            import kotlin.jvm.JvmSuppressWildcards
             import kotlinx.coroutines.launch
 
             @OptIn(InternalCodegenApi::class)
@@ -474,6 +492,10 @@ internal class FileGeneratorTestCompose {
                 parentComponent.khonshuTestComponentFactory().create(savedStateHandle, testRoute)
               }
             }
+            
+            @ContributesTo(TestDestinationScope::class)
+            @OptIn(InternalCodegenApi::class)
+            public interface KhonshuTestNavDestinationComponent : NavDestinationComponent
 
             @Module
             @ContributesTo(TestRoute::class)
@@ -512,6 +534,7 @@ internal class FileGeneratorTestCompose {
               }
             }
 
+            @OptIn(InternalCodegenApi::class)
             @Module
             @ContributesTo(TestDestinationScope::class)
             public object KhonshuTestNavDestinationModule {
@@ -520,6 +543,12 @@ internal class FileGeneratorTestCompose {
               public fun provideNavDestination(): NavDestination = ScreenDestination<TestRoute> {
                 KhonshuTest(it)
               }
+
+              @Provides
+              @IntoMap
+              @NavComponentProvider(TestRoute::class)
+              public fun bindComponentProvider(): @JvmSuppressWildcards ComponentProvider<*, *> =
+                  KhonshuTestComponentProvider
             }
 
             @OptIn(InternalCodegenApi::class)
@@ -637,6 +666,7 @@ internal class FileGeneratorTestCompose {
             import com.freeletics.khonshu.codegen.ScopeTo
             import com.freeletics.khonshu.codegen.`internal`.ComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
+            import com.freeletics.khonshu.codegen.`internal`.NavComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.NavDestinationComponent
             import com.freeletics.khonshu.codegen.`internal`.NavEntryComponentGetter
             import com.freeletics.khonshu.codegen.`internal`.NavEntryComponentGetterKey
@@ -657,6 +687,7 @@ internal class FileGeneratorTestCompose {
             import dagger.BindsInstance
             import dagger.Module
             import dagger.Provides
+            import dagger.multibindings.IntoMap
             import dagger.multibindings.IntoSet
             import dagger.multibindings.Multibinds
             import java.io.Closeable
@@ -664,6 +695,7 @@ internal class FileGeneratorTestCompose {
             import kotlin.Any
             import kotlin.OptIn
             import kotlin.collections.Set
+            import kotlin.jvm.JvmSuppressWildcards
             import kotlinx.coroutines.launch
 
             @OptIn(InternalCodegenApi::class)
@@ -713,6 +745,10 @@ internal class FileGeneratorTestCompose {
               }
             }
 
+            @ContributesTo(AppScope::class)
+            @OptIn(InternalCodegenApi::class)
+            public interface KhonshuTestNavDestinationComponent : NavDestinationComponent
+
             @Module
             @ContributesTo(TestRoute::class)
             public interface KhonshuTestModule {
@@ -750,6 +786,7 @@ internal class FileGeneratorTestCompose {
               }
             }
 
+            @OptIn(InternalCodegenApi::class)
             @Module
             @ContributesTo(AppScope::class)
             public object KhonshuTestNavDestinationModule {
@@ -758,6 +795,12 @@ internal class FileGeneratorTestCompose {
               public fun provideNavDestination(): NavDestination = ScreenDestination<TestRoute> {
                 KhonshuTest(it)
               }
+
+              @Provides
+              @IntoMap
+              @NavComponentProvider(TestRoute::class)
+              public fun bindComponentProvider(): @JvmSuppressWildcards ComponentProvider<*, *> =
+                  KhonshuTestComponentProvider
             }
 
             @OptIn(InternalCodegenApi::class)

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestComposeFragment.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestComposeFragment.kt
@@ -247,6 +247,8 @@ internal class FileGeneratorTestComposeFragment {
             import com.freeletics.khonshu.codegen.ScopeTo
             import com.freeletics.khonshu.codegen.`internal`.ComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
+            import com.freeletics.khonshu.codegen.`internal`.NavComponentProvider
+            import com.freeletics.khonshu.codegen.`internal`.NavDestinationComponent
             import com.freeletics.khonshu.codegen.`internal`.asComposeState
             import com.freeletics.khonshu.codegen.`internal`.component
             import com.freeletics.khonshu.navigation.NavEventNavigator
@@ -265,11 +267,13 @@ internal class FileGeneratorTestComposeFragment {
             import dagger.BindsInstance
             import dagger.Module
             import dagger.Provides
+            import dagger.multibindings.IntoMap
             import dagger.multibindings.IntoSet
             import dagger.multibindings.Multibinds
             import java.io.Closeable
             import kotlin.OptIn
             import kotlin.collections.Set
+            import kotlin.jvm.JvmSuppressWildcards
             import kotlinx.coroutines.launch
 
             @OptIn(InternalCodegenApi::class)
@@ -318,6 +322,10 @@ internal class FileGeneratorTestComposeFragment {
                 parentComponent.khonshuTestComponentFactory().create(savedStateHandle, testRoute)
               }
             }
+
+            @ContributesTo(TestDestinationScope::class)
+            @OptIn(InternalCodegenApi::class)
+            public interface KhonshuTestNavDestinationComponent : NavDestinationComponent
 
             @Module
             @ContributesTo(TestRoute::class)
@@ -370,7 +378,8 @@ internal class FileGeneratorTestComposeFragment {
                 )
               }
             }
-            
+
+            @OptIn(InternalCodegenApi::class)
             @Module
             @ContributesTo(TestDestinationScope::class)
             public object KhonshuTestNavDestinationModule {
@@ -378,6 +387,12 @@ internal class FileGeneratorTestComposeFragment {
               @IntoSet
               public fun provideNavDestination(): NavDestination = ScreenDestination<TestRoute,
                   KhonshuTestFragment>()
+
+              @Provides
+              @IntoMap
+              @NavComponentProvider(TestRoute::class)
+              public fun bindComponentProvider(): @JvmSuppressWildcards ComponentProvider<*, *> =
+                  KhonshuTestComponentProvider
             }
             
         """.trimIndent()
@@ -443,6 +458,7 @@ internal class FileGeneratorTestComposeFragment {
             import com.freeletics.khonshu.codegen.ScopeTo
             import com.freeletics.khonshu.codegen.`internal`.ComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
+            import com.freeletics.khonshu.codegen.`internal`.NavComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.NavDestinationComponent
             import com.freeletics.khonshu.codegen.`internal`.NavEntryComponentGetter
             import com.freeletics.khonshu.codegen.`internal`.NavEntryComponentGetterKey
@@ -466,6 +482,7 @@ internal class FileGeneratorTestComposeFragment {
             import dagger.BindsInstance
             import dagger.Module
             import dagger.Provides
+            import dagger.multibindings.IntoMap
             import dagger.multibindings.IntoSet
             import dagger.multibindings.Multibinds
             import java.io.Closeable
@@ -473,6 +490,7 @@ internal class FileGeneratorTestComposeFragment {
             import kotlin.Any
             import kotlin.OptIn
             import kotlin.collections.Set
+            import kotlin.jvm.JvmSuppressWildcards
             import kotlinx.coroutines.launch
 
             @OptIn(InternalCodegenApi::class)
@@ -521,6 +539,10 @@ internal class FileGeneratorTestComposeFragment {
                 parentComponent.khonshuTestComponentFactory().create(savedStateHandle, testRoute)
               }
             }
+            
+            @ContributesTo(TestDestinationScope::class)
+            @OptIn(InternalCodegenApi::class)
+            public interface KhonshuTestNavDestinationComponent : NavDestinationComponent
 
             @Module
             @ContributesTo(TestRoute::class)
@@ -574,6 +596,7 @@ internal class FileGeneratorTestComposeFragment {
               }
             }
 
+            @OptIn(InternalCodegenApi::class)
             @Module
             @ContributesTo(TestDestinationScope::class)
             public object KhonshuTestNavDestinationModule {
@@ -581,6 +604,12 @@ internal class FileGeneratorTestComposeFragment {
               @IntoSet
               public fun provideNavDestination(): NavDestination = ScreenDestination<TestRoute,
                   KhonshuTestFragment>()
+
+              @Provides
+              @IntoMap
+              @NavComponentProvider(TestRoute::class)
+              public fun bindComponentProvider(): @JvmSuppressWildcards ComponentProvider<*, *> =
+                  KhonshuTestComponentProvider
             }
 
             @OptIn(InternalCodegenApi::class)
@@ -704,6 +733,7 @@ internal class FileGeneratorTestComposeFragment {
             import com.freeletics.khonshu.codegen.ScopeTo
             import com.freeletics.khonshu.codegen.`internal`.ComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
+            import com.freeletics.khonshu.codegen.`internal`.NavComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.NavDestinationComponent
             import com.freeletics.khonshu.codegen.`internal`.NavEntryComponentGetter
             import com.freeletics.khonshu.codegen.`internal`.NavEntryComponentGetterKey
@@ -725,6 +755,7 @@ internal class FileGeneratorTestComposeFragment {
             import dagger.BindsInstance
             import dagger.Module
             import dagger.Provides
+            import dagger.multibindings.IntoMap
             import dagger.multibindings.IntoSet
             import dagger.multibindings.Multibinds
             import java.io.Closeable
@@ -732,6 +763,7 @@ internal class FileGeneratorTestComposeFragment {
             import kotlin.Any
             import kotlin.OptIn
             import kotlin.collections.Set
+            import kotlin.jvm.JvmSuppressWildcards
             import kotlinx.coroutines.launch
 
             @OptIn(InternalCodegenApi::class)
@@ -780,6 +812,10 @@ internal class FileGeneratorTestComposeFragment {
                 parentComponent.khonshuTestComponentFactory().create(savedStateHandle, testRoute)
               }
             }
+
+            @ContributesTo(AppScope::class)
+            @OptIn(InternalCodegenApi::class)
+            public interface KhonshuTestNavDestinationComponent : NavDestinationComponent
 
             @Module
             @ContributesTo(TestRoute::class)
@@ -833,6 +869,7 @@ internal class FileGeneratorTestComposeFragment {
               }
             }
 
+            @OptIn(InternalCodegenApi::class)
             @Module
             @ContributesTo(AppScope::class)
             public object KhonshuTestNavDestinationModule {
@@ -840,6 +877,12 @@ internal class FileGeneratorTestComposeFragment {
               @IntoSet
               public fun provideNavDestination(): NavDestination = ScreenDestination<TestRoute,
                   KhonshuTestFragment>()
+
+              @Provides
+              @IntoMap
+              @NavComponentProvider(TestRoute::class)
+              public fun bindComponentProvider(): @JvmSuppressWildcards ComponentProvider<*, *> =
+                  KhonshuTestComponentProvider
             }
 
             @OptIn(InternalCodegenApi::class)

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestRendererFragment.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestRendererFragment.kt
@@ -205,6 +205,8 @@ internal class FileGeneratorTestRendererFragment {
             import com.freeletics.khonshu.codegen.ScopeTo
             import com.freeletics.khonshu.codegen.`internal`.ComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
+            import com.freeletics.khonshu.codegen.`internal`.NavComponentProvider
+            import com.freeletics.khonshu.codegen.`internal`.NavDestinationComponent
             import com.freeletics.khonshu.codegen.`internal`.component
             import com.freeletics.khonshu.navigation.NavEventNavigator
             import com.freeletics.khonshu.navigation.`internal`.InternalNavigationApi
@@ -223,11 +225,13 @@ internal class FileGeneratorTestRendererFragment {
             import dagger.BindsInstance
             import dagger.Module
             import dagger.Provides
+            import dagger.multibindings.IntoMap
             import dagger.multibindings.IntoSet
             import dagger.multibindings.Multibinds
             import java.io.Closeable
             import kotlin.OptIn
             import kotlin.collections.Set
+            import kotlin.jvm.JvmSuppressWildcards
 
             @OptIn(InternalCodegenApi::class)
             @ScopeTo(TestRoute::class)
@@ -278,6 +282,10 @@ internal class FileGeneratorTestRendererFragment {
                 parentComponent.khonshuTestRendererComponentFactory().create(savedStateHandle, testRoute)
               }
             }
+            
+            @ContributesTo(TestDestinationScope::class)
+            @OptIn(InternalCodegenApi::class)
+            public interface KhonshuTestRendererNavDestinationComponent : NavDestinationComponent
 
             @Module
             @ContributesTo(TestRoute::class)
@@ -312,6 +320,7 @@ internal class FileGeneratorTestRendererFragment {
               }
             }
             
+            @OptIn(InternalCodegenApi::class)
             @Module
             @ContributesTo(TestDestinationScope::class)
             public object KhonshuTestRendererNavDestinationModule {
@@ -319,6 +328,12 @@ internal class FileGeneratorTestRendererFragment {
               @IntoSet
               public fun provideNavDestination(): NavDestination = ScreenDestination<TestRoute,
                   KhonshuTestRendererFragment>()
+
+              @Provides
+              @IntoMap
+              @NavComponentProvider(TestRoute::class)
+              public fun bindComponentProvider(): @JvmSuppressWildcards ComponentProvider<*, *> =
+                  KhonshuTestRendererComponentProvider
             }
             
         """.trimIndent()
@@ -379,6 +394,7 @@ internal class FileGeneratorTestRendererFragment {
             import com.freeletics.khonshu.codegen.ScopeTo
             import com.freeletics.khonshu.codegen.`internal`.ComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
+            import com.freeletics.khonshu.codegen.`internal`.NavComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.NavDestinationComponent
             import com.freeletics.khonshu.codegen.`internal`.NavEntryComponentGetter
             import com.freeletics.khonshu.codegen.`internal`.NavEntryComponentGetterKey
@@ -402,6 +418,7 @@ internal class FileGeneratorTestRendererFragment {
             import dagger.BindsInstance
             import dagger.Module
             import dagger.Provides
+            import dagger.multibindings.IntoMap
             import dagger.multibindings.IntoSet
             import dagger.multibindings.Multibinds
             import java.io.Closeable
@@ -409,6 +426,7 @@ internal class FileGeneratorTestRendererFragment {
             import kotlin.Any
             import kotlin.OptIn
             import kotlin.collections.Set
+            import kotlin.jvm.JvmSuppressWildcards
 
             @OptIn(InternalCodegenApi::class)
             @ScopeTo(TestRoute::class)
@@ -459,6 +477,10 @@ internal class FileGeneratorTestRendererFragment {
                 parentComponent.khonshuTestRendererComponentFactory().create(savedStateHandle, testRoute)
               }
             }
+            
+            @ContributesTo(TestDestinationScope::class)
+            @OptIn(InternalCodegenApi::class)
+            public interface KhonshuTestRendererNavDestinationComponent : NavDestinationComponent
 
             @Module
             @ContributesTo(TestRoute::class)
@@ -493,6 +515,7 @@ internal class FileGeneratorTestRendererFragment {
               }
             }
 
+            @OptIn(InternalCodegenApi::class)
             @Module
             @ContributesTo(TestDestinationScope::class)
             public object KhonshuTestRendererNavDestinationModule {
@@ -500,6 +523,12 @@ internal class FileGeneratorTestRendererFragment {
               @IntoSet
               public fun provideNavDestination(): NavDestination = ScreenDestination<TestRoute,
                   KhonshuTestRendererFragment>()
+
+              @Provides
+              @IntoMap
+              @NavComponentProvider(TestRoute::class)
+              public fun bindComponentProvider(): @JvmSuppressWildcards ComponentProvider<*, *> =
+                  KhonshuTestRendererComponentProvider
             }
 
             @OptIn(InternalCodegenApi::class)
@@ -618,6 +647,7 @@ internal class FileGeneratorTestRendererFragment {
             import com.freeletics.khonshu.codegen.ScopeTo
             import com.freeletics.khonshu.codegen.`internal`.ComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
+            import com.freeletics.khonshu.codegen.`internal`.NavComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.NavDestinationComponent
             import com.freeletics.khonshu.codegen.`internal`.NavEntryComponentGetter
             import com.freeletics.khonshu.codegen.`internal`.NavEntryComponentGetterKey
@@ -639,6 +669,7 @@ internal class FileGeneratorTestRendererFragment {
             import dagger.BindsInstance
             import dagger.Module
             import dagger.Provides
+            import dagger.multibindings.IntoMap
             import dagger.multibindings.IntoSet
             import dagger.multibindings.Multibinds
             import java.io.Closeable
@@ -646,6 +677,7 @@ internal class FileGeneratorTestRendererFragment {
             import kotlin.Any
             import kotlin.OptIn
             import kotlin.collections.Set
+            import kotlin.jvm.JvmSuppressWildcards
 
             @OptIn(InternalCodegenApi::class)
             @ScopeTo(TestRoute::class)
@@ -696,6 +728,10 @@ internal class FileGeneratorTestRendererFragment {
                 parentComponent.khonshuTestRendererComponentFactory().create(savedStateHandle, testRoute)
               }
             }
+            
+            @ContributesTo(AppScope::class)
+            @OptIn(InternalCodegenApi::class)
+            public interface KhonshuTestRendererNavDestinationComponent : NavDestinationComponent
 
             @Module
             @ContributesTo(TestRoute::class)
@@ -730,6 +766,7 @@ internal class FileGeneratorTestRendererFragment {
               }
             }
 
+            @OptIn(InternalCodegenApi::class)
             @Module
             @ContributesTo(AppScope::class)
             public object KhonshuTestRendererNavDestinationModule {
@@ -737,6 +774,12 @@ internal class FileGeneratorTestRendererFragment {
               @IntoSet
               public fun provideNavDestination(): NavDestination = ScreenDestination<TestRoute,
                   KhonshuTestRendererFragment>()
+
+              @Provides
+              @IntoMap
+              @NavComponentProvider(TestRoute::class)
+              public fun bindComponentProvider(): @JvmSuppressWildcards ComponentProvider<*, *> =
+                  KhonshuTestRendererComponentProvider
             }
 
             @OptIn(InternalCodegenApi::class)

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/FileGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/FileGenerator.kt
@@ -81,6 +81,8 @@ public class FileGenerator {
         if (data.navigation != null) {
             val componentProviderGenerator = ComponentProviderGenerator(data)
             addType(componentProviderGenerator.generate())
+            val destinationComponentGenerator = NavDestinationComponentGenerator(data)
+            addType(destinationComponentGenerator.generate())
         }
     }
 

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/nav/NavDestinationModuleGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/nav/NavDestinationModuleGenerator.kt
@@ -3,14 +3,22 @@ package com.freeletics.khonshu.codegen.codegen.nav
 import com.freeletics.khonshu.codegen.BaseData
 import com.freeletics.khonshu.codegen.Navigation
 import com.freeletics.khonshu.codegen.codegen.Generator
+import com.freeletics.khonshu.codegen.codegen.common.componentProviderClassName
 import com.freeletics.khonshu.codegen.codegen.common.composableName
 import com.freeletics.khonshu.codegen.codegen.fragment.fragmentName
+import com.freeletics.khonshu.codegen.codegen.util.componentProvider
 import com.freeletics.khonshu.codegen.codegen.util.contributesToAnnotation
+import com.freeletics.khonshu.codegen.codegen.util.intoMap
 import com.freeletics.khonshu.codegen.codegen.util.intoSet
 import com.freeletics.khonshu.codegen.codegen.util.module
+import com.freeletics.khonshu.codegen.codegen.util.navComponentProvider
+import com.freeletics.khonshu.codegen.codegen.util.optInAnnotation
 import com.freeletics.khonshu.codegen.codegen.util.provides
+import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.STAR
 import com.squareup.kotlinpoet.TypeSpec
 
 internal class NavDestinationModuleGenerator(
@@ -21,22 +29,24 @@ internal class NavDestinationModuleGenerator(
 
     internal fun generate(): TypeSpec {
         return TypeSpec.objectBuilder(moduleClassName)
+            .addAnnotation(optInAnnotation())
             .addAnnotation(module)
             .addAnnotation(contributesToAnnotation(data.navigation!!.destinationScope))
-            .addFunction(providesFunction())
+            .addFunction(providesDestination())
+            .addFunction(providesComponentProvider())
             .build()
     }
 
-    private fun providesFunction(): FunSpec {
+    private fun providesDestination(): FunSpec {
         return FunSpec.builder("provideNavDestination")
             .addAnnotation(provides)
             .addAnnotation(intoSet)
             .returns(data.navigation!!.destinationClass)
-            .addCode(providesCode())
+            .addCode(providesDestinationCode())
             .build()
     }
 
-    private fun providesCode(): CodeBlock {
+    private fun providesDestinationCode(): CodeBlock {
         val navigation = data.navigation!!
         return when (data.navigation!!) {
             is Navigation.Compose -> {
@@ -59,5 +69,26 @@ internal class NavDestinationModuleGenerator(
                 )
             }
         }
+    }
+
+    private fun providesComponentProvider(): FunSpec {
+        return FunSpec.builder("bindComponentProvider")
+            .addAnnotation(provides)
+            .addAnnotation(intoMap)
+            .addAnnotation(mapKeyAnnotation())
+            .returns(
+                componentProvider.parameterizedBy(
+                    STAR,
+                    STAR,
+                ).copy(annotations = listOf(AnnotationSpec.builder(JvmSuppressWildcards::class).build())),
+            )
+            .addStatement("return %T", componentProviderClassName)
+            .build()
+    }
+
+    private fun mapKeyAnnotation(): AnnotationSpec {
+        return AnnotationSpec.builder(navComponentProvider)
+            .addMember("%T::class", data.scope)
+            .build()
     }
 }

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/util/External.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/util/External.kt
@@ -29,6 +29,7 @@ internal val InternalCodegenApi = ClassName("com.freeletics.khonshu.codegen.inte
 internal val getComponent = MemberName("com.freeletics.khonshu.codegen.internal", "component")
 internal val getNavEntryComponent = MemberName("com.freeletics.khonshu.codegen.internal", "navEntryComponent")
 internal val componentProvider = ClassName("com.freeletics.khonshu.codegen.internal", "ComponentProvider")
+internal val navComponentProvider = ClassName("com.freeletics.khonshu.codegen.internal", "NavComponentProvider")
 internal val navEntryComponentGetter = ClassName("com.freeletics.khonshu.codegen.internal", "NavEntryComponentGetter")
 internal val navEntryComponentGetterKey = ClassName(
     "com.freeletics.khonshu.codegen.internal",
@@ -76,6 +77,7 @@ internal val inject = ClassName("javax.inject", "Inject")
 internal val provides = ClassName("dagger", "Provides")
 internal val multibinds = ClassName("dagger.multibindings", "Multibinds")
 internal val intoSet = ClassName("dagger.multibindings", "IntoSet")
+internal val intoMap = ClassName("dagger.multibindings", "IntoMap")
 internal val bindsInstance = ClassName("dagger", "BindsInstance")
 internal val module = ClassName("dagger", "Module")
 

--- a/codegen/api/codegen.api
+++ b/codegen/api/codegen.api
@@ -6,6 +6,10 @@ public abstract interface annotation class com/freeletics/khonshu/codegen/NavEnt
 public final class com/freeletics/khonshu/codegen/internal/CollectAsStateKt {
 }
 
+public abstract interface class com/freeletics/khonshu/codegen/internal/ComponentProvider {
+	public abstract fun provide (Lcom/freeletics/khonshu/navigation/BaseRoute;Lcom/freeletics/khonshu/navigation/internal/NavigationExecutor;Landroid/content/Context;)Ljava/lang/Object;
+}
+
 public final class com/freeletics/khonshu/codegen/internal/ComponentProviderKt {
 	public static final fun findComponentByScope (Landroid/content/Context;Lkotlin/reflect/KClass;)Ljava/lang/Object;
 	public static final fun findComponentByScope (Landroid/content/Context;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;Lcom/freeletics/khonshu/navigation/internal/NavigationExecutor;)Ljava/lang/Object;

--- a/codegen/src/main/kotlin/com/freeletics/khonshu/codegen/internal/NavDestinationComponent.kt
+++ b/codegen/src/main/kotlin/com/freeletics/khonshu/codegen/internal/NavDestinationComponent.kt
@@ -1,6 +1,19 @@
 package com.freeletics.khonshu.codegen.internal
 
+import dagger.MapKey
+import kotlin.reflect.KClass
+
 @InternalCodegenApi
 public interface NavDestinationComponent {
     public val navEntryComponentGetters: @JvmSuppressWildcards Map<Class<*>, NavEntryComponentGetter>
+    public val componentProviders: @JvmSuppressWildcards Map<Class<*>, ComponentProvider<*, *>>
 }
+
+/**
+ * Used when binding a [ComponentProvider] into a map using the scope class as key.
+ *
+ * To be used in generated code.
+ */
+@MapKey
+@InternalCodegenApi
+public annotation class NavComponentProvider(val value: KClass<*>)

--- a/docs/codegen/get-started.md
+++ b/docs/codegen/get-started.md
@@ -180,8 +180,9 @@ with `Context.getSystemService(name)` using the fully qualified name of the give
 key for the lookup. It is expected that the app will provide it through its `Application` class or an
 `Activity`.
 
-For convenience purposes the generated component will make a `SavedStateHandle`
-available which can be injected to classes like the state machine to save state.
+For convenience purposes the generated component will make the `Bundle` with arguments and a 
+`SavedStateHandle` available which can be injected to classes like the state machine to save state.
+When injecting either of them the `@ForScope(ExampleScope::class)` qualifier needs to be used.
 
 
 ## Example
@@ -195,7 +196,10 @@ sealed interface ExampleScope
 // state machine survives orientation changes
 @ScopeTo(ExampleScope::class)
 internal class ExampleStateMachine @Inject constructor(
+    @ForScope(ExampleScope::class) 
     val bundle: Bundle, // the arguments passed to this screen
+    @ForScope(ExampleScope::class) 
+    val savedStateHandle: SavedStateHandle // a saved state handle tied to this screen 
     val repository: ExampleRepository, // a repository that pas provided somewhere in the app
 ) : StateMachine<ExampleState, ExampleAction> { 
     // ... 

--- a/docs/codegen/navigation.md
+++ b/docs/codegen/navigation.md
@@ -81,11 +81,23 @@ scope (usually an app wide or an Activity level scope). With that it's not neces
 to manually create a `Set` of all destinations anymore. It can simply be injected.
 
 The integration of Khonshu's Codegen and Navigation libraries also expects a `NavEventNavigator`
-to be injectable. This can be easily achieved by adding
-`@ScopeTo(ExampleScope::class) @ContributesBinding(ExampleScope::class, NavEventNavigator::class)`
+to be injectable. This can be easily achieved by adding `@ScopeTo(ExampleScope::class)
+@ForScope(ExampleScope::class) @ContributesBinding(ExampleScope::class, NavEventNavigator::class)`
 to a subclass of it. The generated code will automatically take care of setting up
 the navigator by calling `NavigationSetup` for compose and `handleNavigation`
 for Fragments inside the generated code.
+
+
+## Sharing objects between screens
+
+Sometimes it is needed to share an object between 2 or more screens, for example
+in a flow of screens that are connected to each other and work on the same data.
+This is possible by using the route of the first screen in the flow as `parentScope`
+for the other scopes. Internally this will cause the generated component for the
+first screen to become the parent for the components of the other screens.
+
+This then allows injecting anything that is available in the scope of the first screen,
+including the `SavedStateHandle` and route of the initial/parent screen.
 
 
 ## Example
@@ -105,6 +117,7 @@ internal class ExampleStateMachine @Inject constructor(
 
 // scope the navigator so that everything interacts with the same instance
 @ScopeTo(ExampleRoute::class)
+@ForScope(ExampleRoute::class)
 // make ExampleNavigator available as NavEventNavigator so that the generated code can automatically
 // set up the navigation handling
 @ContributesBinding(ExampleRoute::class, NavEventNavigator::class)


### PR DESCRIPTION
For now this uses the existing mechanism that we have for `NavEntryComponent` through `NavEntryComponentGetter` and `NavDestinationComponent`. The next 2 follow ups are first deleting `NavEntryComponent` and then improving the look up mechanism to be much simpler. However to keep changes here smaller it makes more sense to use the existing mechanism for now.

`NavDestinationComponent` has a `Map<Class<*>, ComponentProvider<*, *>`. We provide the generated `ComponentProvider` into this using the `scope` (in practice a route class) to it. We're also contributing `NavDestinationComponent` to the destination scope that we can use that for the look up. This now allows screen with `ExampleARoute` to use `ExampleParentRoute` as parent scope. The component will be looked up by getting `NavDestinationComponent` and retrieving the component provider from the map by using `ExampleParentRoute` as key.