### PR TITLE
added multinav event

### DIFF
--- a/navigation/api/navigation.api
+++ b/navigation/api/navigation.api
@@ -79,6 +79,7 @@ public class com/freeletics/khonshu/navigation/NavEventNavigator {
 	public final fun backPresses ()Lkotlinx/coroutines/flow/Flow;
 	public final fun backPresses (Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public final fun deliverNavigationResult (Lcom/freeletics/khonshu/navigation/NavigationResultRequest$Key;Landroid/os/Parcelable;)V
+	public final fun navigate (Lkotlin/jvm/functions/Function1;)V
 	public final fun navigateBack ()V
 	public final fun navigateBackTo-UamjCxQ (Lkotlin/reflect/KClass;Z)V
 	public static synthetic fun navigateBackTo-UamjCxQ$default (Lcom/freeletics/khonshu/navigation/NavEventNavigator;Lkotlin/reflect/KClass;ZILjava/lang/Object;)V
@@ -170,6 +171,15 @@ public final class com/freeletics/khonshu/navigation/internal/InitialValue$Creat
 }
 
 public abstract interface annotation class com/freeletics/khonshu/navigation/internal/InternalNavigationApi : java/lang/annotation/Annotation {
+}
+
+public final class com/freeletics/khonshu/navigation/internal/NavEventCollector {
+	public final fun navigateBack ()V
+	public final fun navigateBackTo-UamjCxQ (Lkotlin/reflect/KClass;Z)V
+	public final fun navigateTo (Lcom/freeletics/khonshu/navigation/NavRoute;)V
+	public final fun navigateToRoot (Lcom/freeletics/khonshu/navigation/NavRoot;Z)V
+	public final fun navigateUp ()V
+	public final fun resetToRoot (Lcom/freeletics/khonshu/navigation/NavRoot;)V
 }
 
 public final class com/freeletics/khonshu/navigation/internal/NavigationSetupKt {

--- a/navigation/src/main/kotlin/com/freeletics/khonshu/navigation/NavEventNavigator.kt
+++ b/navigation/src/main/kotlin/com/freeletics/khonshu/navigation/NavEventNavigator.kt
@@ -10,9 +10,12 @@ import com.freeletics.khonshu.navigation.internal.NavEvent
 import com.freeletics.khonshu.navigation.internal.NavEvent.ActivityResultEvent
 import com.freeletics.khonshu.navigation.internal.NavEvent.BackEvent
 import com.freeletics.khonshu.navigation.internal.NavEvent.BackToEvent
+import com.freeletics.khonshu.navigation.internal.NavEvent.MultiNavEvent
 import com.freeletics.khonshu.navigation.internal.NavEvent.NavigateToActivityEvent
 import com.freeletics.khonshu.navigation.internal.NavEvent.NavigateToEvent
 import com.freeletics.khonshu.navigation.internal.NavEvent.UpEvent
+import com.freeletics.khonshu.navigation.internal.NavEventCollector
+import com.freeletics.khonshu.navigation.internal.Navigator
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.trySendBlocking
@@ -159,6 +162,17 @@ public open class NavEventNavigator {
     public fun navigateBack() {
         val event = BackEvent
         sendNavEvent(event)
+    }
+
+    /**
+     * Triggers a new [NavEvent] that collects and combines the nav events sent in the block so they can be
+     * handled individually.
+     *
+     * Note: This should be used when navigating multiple times fe calling `navigateBackTo` followed by `navigateTo`.
+     */
+    public fun navigate(block: Navigator.() -> Unit) {
+        val navEvents = NavEventCollector().apply(block).navEvents
+        sendNavEvent(MultiNavEvent(navEvents))
     }
 
     /**

--- a/navigation/src/main/kotlin/com/freeletics/khonshu/navigation/NavEventNavigator.kt
+++ b/navigation/src/main/kotlin/com/freeletics/khonshu/navigation/NavEventNavigator.kt
@@ -15,7 +15,6 @@ import com.freeletics.khonshu.navigation.internal.NavEvent.NavigateToActivityEve
 import com.freeletics.khonshu.navigation.internal.NavEvent.NavigateToEvent
 import com.freeletics.khonshu.navigation.internal.NavEvent.UpEvent
 import com.freeletics.khonshu.navigation.internal.NavEventCollector
-import com.freeletics.khonshu.navigation.internal.Navigator
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.trySendBlocking
@@ -168,9 +167,10 @@ public open class NavEventNavigator {
      * Triggers a new [NavEvent] that collects and combines the nav events sent in the block so they can be
      * handled individually.
      *
-     * Note: This should be used when navigating multiple times fe calling `navigateBackTo` followed by `navigateTo`.
+     * Note: This should be used when navigating multiple times, for example calling `navigateBackTo`
+     * followed by `navigateTo`.
      */
-    public fun navigate(block: Navigator.() -> Unit) {
+    public fun navigate(block: NavEventCollector.() -> Unit) {
         val navEvents = NavEventCollector().apply(block).navEvents
         sendNavEvent(MultiNavEvent(navEvents))
     }

--- a/navigation/src/main/kotlin/com/freeletics/khonshu/navigation/internal/NavEvent.kt
+++ b/navigation/src/main/kotlin/com/freeletics/khonshu/navigation/internal/NavEvent.kt
@@ -66,6 +66,6 @@ public sealed interface NavEvent {
     @InternalNavigationApi
     @Poko
     public class MultiNavEvent(
-        internal val navEvents: List<NavEvent>
+        internal val navEvents: List<NavEvent>,
     ) : NavEvent
 }

--- a/navigation/src/main/kotlin/com/freeletics/khonshu/navigation/internal/NavEvent.kt
+++ b/navigation/src/main/kotlin/com/freeletics/khonshu/navigation/internal/NavEvent.kt
@@ -62,4 +62,10 @@ public sealed interface NavEvent {
         internal val key: NavigationResultRequest.Key<O>,
         internal val result: O,
     ) : NavEvent
+
+    @InternalNavigationApi
+    @Poko
+    public class MultiNavEvent(
+        internal val navEvents: List<NavEvent>
+    ) : NavEvent
 }

--- a/navigation/src/main/kotlin/com/freeletics/khonshu/navigation/internal/NavEventCollector.kt
+++ b/navigation/src/main/kotlin/com/freeletics/khonshu/navigation/internal/NavEventCollector.kt
@@ -3,10 +3,10 @@ package com.freeletics.khonshu.navigation.internal
 import com.freeletics.khonshu.navigation.NavRoot
 import com.freeletics.khonshu.navigation.NavRoute
 
-public class NavEventCollector internal constructor(){
+public class NavEventCollector internal constructor() {
 
     private val _navEvents = mutableListOf<NavEvent>()
-    internal val navEvents : List<NavEvent> = _navEvents
+    internal val navEvents: List<NavEvent> = _navEvents
 
     public fun navigateTo(route: NavRoute) {
         val event = NavEvent.NavigateToEvent(route)

--- a/navigation/src/main/kotlin/com/freeletics/khonshu/navigation/internal/NavEventCollector.kt
+++ b/navigation/src/main/kotlin/com/freeletics/khonshu/navigation/internal/NavEventCollector.kt
@@ -1,0 +1,51 @@
+package com.freeletics.khonshu.navigation.internal
+
+import com.freeletics.khonshu.navigation.NavRoot
+import com.freeletics.khonshu.navigation.NavRoute
+import kotlin.reflect.KClass
+
+
+public interface Navigator {
+    public fun navigateTo(route: NavRoute)
+    public fun navigateToRoot(root: NavRoot, restoreRootState: Boolean = false)
+    public fun navigateUp()
+    public fun navigateBack()
+    public fun <T : NavRoute> navigateBackTo(navRoute: KClass<T> , inclusive: Boolean = false)
+    public fun resetToRoot(root: NavRoot)
+}
+
+internal class NavEventCollector : Navigator {
+
+    private val _navEvents = mutableListOf<NavEvent>()
+    val navEvents : List<NavEvent> = _navEvents
+
+    override fun navigateTo(route: NavRoute) {
+        val event = NavEvent.NavigateToEvent(route)
+        _navEvents.add(event)
+    }
+
+    override fun navigateToRoot(root: NavRoot, restoreRootState: Boolean) {
+        val event = NavEvent.NavigateToRootEvent(root, restoreRootState)
+        _navEvents.add(event)
+    }
+
+    override fun navigateUp() {
+        val event = NavEvent.UpEvent
+        _navEvents.add(event)
+    }
+
+    override fun navigateBack() {
+        val event = NavEvent.BackEvent
+        _navEvents.add(event)
+    }
+
+    override fun <T : NavRoute> navigateBackTo(navRoute: KClass<T>, inclusive: Boolean) {
+        val event = NavEvent.BackToEvent(DestinationId(navRoute), inclusive)
+        _navEvents.add(event)
+    }
+
+    override fun resetToRoot(root: NavRoot) {
+        val event = NavEvent.ResetToRoot(root)
+        _navEvents.add(event)
+    }
+}

--- a/navigation/src/main/kotlin/com/freeletics/khonshu/navigation/internal/NavEventCollector.kt
+++ b/navigation/src/main/kotlin/com/freeletics/khonshu/navigation/internal/NavEventCollector.kt
@@ -2,49 +2,43 @@ package com.freeletics.khonshu.navigation.internal
 
 import com.freeletics.khonshu.navigation.NavRoot
 import com.freeletics.khonshu.navigation.NavRoute
-import kotlin.reflect.KClass
 
-
-public interface Navigator {
-    public fun navigateTo(route: NavRoute)
-    public fun navigateToRoot(root: NavRoot, restoreRootState: Boolean = false)
-    public fun navigateUp()
-    public fun navigateBack()
-    public fun <T : NavRoute> navigateBackTo(navRoute: KClass<T> , inclusive: Boolean = false)
-    public fun resetToRoot(root: NavRoot)
-}
-
-internal class NavEventCollector : Navigator {
+public class NavEventCollector internal constructor(){
 
     private val _navEvents = mutableListOf<NavEvent>()
-    val navEvents : List<NavEvent> = _navEvents
+    internal val navEvents : List<NavEvent> = _navEvents
 
-    override fun navigateTo(route: NavRoute) {
+    public fun navigateTo(route: NavRoute) {
         val event = NavEvent.NavigateToEvent(route)
         _navEvents.add(event)
     }
 
-    override fun navigateToRoot(root: NavRoot, restoreRootState: Boolean) {
+    public fun navigateToRoot(root: NavRoot, restoreRootState: Boolean) {
         val event = NavEvent.NavigateToRootEvent(root, restoreRootState)
         _navEvents.add(event)
     }
 
-    override fun navigateUp() {
+    public fun navigateUp() {
         val event = NavEvent.UpEvent
         _navEvents.add(event)
     }
 
-    override fun navigateBack() {
+    public fun navigateBack() {
         val event = NavEvent.BackEvent
         _navEvents.add(event)
     }
 
-    override fun <T : NavRoute> navigateBackTo(navRoute: KClass<T>, inclusive: Boolean) {
-        val event = NavEvent.BackToEvent(DestinationId(navRoute), inclusive)
+    public inline fun <reified T : NavRoute> navigateBackTo(inclusive: Boolean) {
+        navigateBackTo(DestinationId(T::class), inclusive)
+    }
+
+    @PublishedApi
+    internal fun <T : NavRoute> navigateBackTo(destination: DestinationId<T>, inclusive: Boolean) {
+        val event = NavEvent.BackToEvent(destination, inclusive)
         _navEvents.add(event)
     }
 
-    override fun resetToRoot(root: NavRoot) {
+    public fun resetToRoot(root: NavRoot) {
         val event = NavEvent.ResetToRoot(root)
         _navEvents.add(event)
     }

--- a/navigation/src/main/kotlin/com/freeletics/khonshu/navigation/internal/NavigationSetup.kt
+++ b/navigation/src/main/kotlin/com/freeletics/khonshu/navigation/internal/NavigationSetup.kt
@@ -64,6 +64,9 @@ private fun NavigationExecutor.navigate(
         is NavEvent.DestinationResultEvent<*> -> {
             savedStateHandleFor(event.key.destinationId)[event.key.requestKey] = event.result
         }
+        is NavEvent.MultiNavEvent -> {
+            event.navEvents.forEach { navigate(it, activityLaunchers) }
+        }
     }
 }
 

--- a/navigation/src/test/kotlin/com/freeletics/khonshu/navigation/NavEventNavigatorTest.kt
+++ b/navigation/src/test/kotlin/com/freeletics/khonshu/navigation/NavEventNavigatorTest.kt
@@ -205,8 +205,8 @@ internal class NavEventNavigatorTest {
                     listOf(
                         NavEvent.BackToEvent(DestinationId(SimpleRoute::class), true),
                         NavigateToEvent(SimpleRoute(1)),
-                        NavEvent.BackEvent
-                    )
+                        NavEvent.BackEvent,
+                    ),
                 ),
             )
 

--- a/navigation/src/test/kotlin/com/freeletics/khonshu/navigation/NavEventNavigatorTest.kt
+++ b/navigation/src/test/kotlin/com/freeletics/khonshu/navigation/NavEventNavigatorTest.kt
@@ -190,6 +190,31 @@ internal class NavEventNavigatorTest {
     }
 
     @Test
+    fun `navigate event with multiple nav directions is received`(): Unit = runBlocking {
+        val navigator = TestNavigator()
+
+        navigator.navEvents.test {
+            navigator.navigate {
+                navigateBackTo(SimpleRoute::class, true)
+                navigateTo(SimpleRoute(1))
+                navigateBack()
+            }
+
+            assertThat(awaitItem()).isEqualTo(
+                NavEvent.MultiNavEvent(
+                    listOf(
+                        NavEvent.BackToEvent(DestinationId(SimpleRoute::class), true),
+                        NavigateToEvent(SimpleRoute(1)),
+                        NavEvent.BackEvent
+                    )
+                ),
+            )
+
+            cancel()
+        }
+    }
+
+    @Test
     fun `backPresses sends out events`(): Unit = runBlocking {
         val navigator = TestNavigator()
 

--- a/navigation/src/test/kotlin/com/freeletics/khonshu/navigation/NavEventNavigatorTest.kt
+++ b/navigation/src/test/kotlin/com/freeletics/khonshu/navigation/NavEventNavigatorTest.kt
@@ -195,7 +195,7 @@ internal class NavEventNavigatorTest {
 
         navigator.navEvents.test {
             navigator.navigate {
-                navigateBackTo(SimpleRoute::class, true)
+                navigateBackTo<SimpleRoute>(true)
                 navigateTo(SimpleRoute(1))
                 navigateBack()
             }

--- a/navigation/src/test/kotlin/com/freeletics/khonshu/navigation/internal/NavigationSetupTest.kt
+++ b/navigation/src/test/kotlin/com/freeletics/khonshu/navigation/internal/NavigationSetupTest.kt
@@ -142,6 +142,26 @@ internal class NavigationSetupTest {
     }
 
     @Test
+    fun `MultiNavEvent is handled properly and events are forwarded to executor`() = runBlocking {
+        setup()
+
+        navigator.navigate {
+            navigateBackTo(SimpleRoute::class, true)
+            navigateTo(SimpleRoute(1))
+            navigateBack()
+        }
+
+        assertThat(executor.received.awaitItem())
+            .isEqualTo(NavEvent.BackToEvent(DestinationId(SimpleRoute::class), inclusive = true))
+
+        assertThat(executor.received.awaitItem())
+            .isEqualTo(NavEvent.NavigateToEvent(SimpleRoute(1)))
+
+        assertThat(executor.received.awaitItem())
+            .isEqualTo(NavEvent.BackEvent)
+    }
+
+    @Test
     fun `DestinationResultEvent is forwarded to executor`() = runBlocking {
         setup()
 

--- a/navigation/src/test/kotlin/com/freeletics/khonshu/navigation/internal/NavigationSetupTest.kt
+++ b/navigation/src/test/kotlin/com/freeletics/khonshu/navigation/internal/NavigationSetupTest.kt
@@ -146,7 +146,7 @@ internal class NavigationSetupTest {
         setup()
 
         navigator.navigate {
-            navigateBackTo(SimpleRoute::class, true)
+            navigateBackTo<SimpleRoute>(true)
             navigateTo(SimpleRoute(1))
             navigateBack()
         }


### PR DESCRIPTION
This adds a MultiNavEvent to combine multiple navigation calls from one navigator. 

When triggering multiple navigation events from a navigator it would sometimes happen that only the first one would actually be triggered. This would combine the nav events into ensuring that all of them are followed through.