### PR TITLE
move anvil parser

### DIFF
--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestCompose.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestCompose.kt
@@ -49,11 +49,11 @@ internal class FileGeneratorTestCompose {
         @Language("kotlin")
         val source = """
             package com.test
-            
+
             import androidx.compose.runtime.Composable
             import com.freeletics.khonshu.codegen.compose.ComposeScreen
             import com.test.parent.TestParentScope
-            
+
             @ComposeScreen(
               scope = TestScreen::class,
               parentScope = TestParentScope::class,
@@ -105,7 +105,7 @@ internal class FileGeneratorTestCompose {
 
               @get:ForScope(TestScreen::class)
               public val closeables: Set<Closeable>
-    
+
               override fun close() {
                 closeables.forEach {
                   it.close()
@@ -147,7 +147,7 @@ internal class FileGeneratorTestCompose {
 
               KhonshuTest(component)
             }
-            
+
             @Composable
             @OptIn(InternalCodegenApi::class)
             private fun KhonshuTest(component: KhonshuTestComponent) {
@@ -162,7 +162,7 @@ internal class FileGeneratorTestCompose {
                 )
               }
             }
-            
+
         """.trimIndent()
 
         test(data, "com/test/Test.kt", source, expected)
@@ -179,13 +179,13 @@ internal class FileGeneratorTestCompose {
         @Language("kotlin")
         val source = """
             package com.test
-            
+
             import androidx.compose.runtime.Composable
             import com.freeletics.khonshu.codegen.compose.ComposeDestination
             import com.freeletics.khonshu.codegen.compose.DestinationType
             import com.test.destination.TestDestinationScope
             import com.test.parent.TestParentRoute
-            
+
             @ComposeDestination(
               route = TestRoute::class,
               parentScope = TestParentRoute::class,
@@ -253,7 +253,7 @@ internal class FileGeneratorTestCompose {
 
               @get:ForScope(TestRoute::class)
               public val closeables: Set<Closeable>
-    
+
               override fun close() {
                 closeables.forEach {
                   it.close()
@@ -271,7 +271,7 @@ internal class FileGeneratorTestCompose {
                 public fun khonshuTestComponentFactory(): Factory
               }
             }
-            
+
             @OptIn(InternalCodegenApi::class)
             public object KhonshuTestComponentProvider : ComponentProvider<TestRoute, KhonshuTestComponent> {
               @OptIn(InternalNavigationApi::class)
@@ -285,7 +285,7 @@ internal class FileGeneratorTestCompose {
                 parentComponent.khonshuTestComponentFactory().create(savedStateHandle, testRoute)
               }
             }
-            
+
             @Module
             @ContributesTo(TestRoute::class)
             public interface KhonshuTestModule {
@@ -307,7 +307,7 @@ internal class FileGeneratorTestCompose {
 
               KhonshuTest(component)
             }
-            
+
             @Composable
             @OptIn(InternalCodegenApi::class)
             private fun KhonshuTest(component: KhonshuTestComponent) {
@@ -322,7 +322,7 @@ internal class FileGeneratorTestCompose {
                 )
               }
             }
-            
+
             @OptIn(InternalCodegenApi::class)
             @Module
             @ContributesTo(TestDestinationScope::class)
@@ -335,7 +335,7 @@ internal class FileGeneratorTestCompose {
                 KhonshuTest(it)
               }
             }
-            
+
         """.trimIndent()
 
         test(withNavigation, "com/test/Test.kt", source, expected)
@@ -356,11 +356,11 @@ internal class FileGeneratorTestCompose {
         @Language("kotlin")
         val source = """
             package com.test
-            
+
             import androidx.compose.runtime.Composable
             import com.freeletics.khonshu.codegen.compose.ComposeDestination
             import com.freeletics.khonshu.codegen.compose.DestinationType
-            
+
             @ComposeDestination(
               route = TestRoute::class,
               stateMachine = TestStateMachine::class,
@@ -425,7 +425,7 @@ internal class FileGeneratorTestCompose {
 
               @get:ForScope(TestRoute::class)
               public val closeables: Set<Closeable>
-    
+
               override fun close() {
                 closeables.forEach {
                   it.close()
@@ -443,7 +443,7 @@ internal class FileGeneratorTestCompose {
                 public fun khonshuTestComponentFactory(): Factory
               }
             }
-            
+
             @OptIn(InternalCodegenApi::class)
             public object KhonshuTestComponentProvider : ComponentProvider<TestRoute, KhonshuTestComponent> {
               @OptIn(InternalNavigationApi::class)
@@ -540,12 +540,12 @@ internal class FileGeneratorTestCompose {
         @Language("kotlin")
         val source = """
             package com.test
-            
+
             import androidx.compose.runtime.Composable
             import com.freeletics.khonshu.codegen.compose.ComposeScreen
             import com.test.other.TestClass2
             import com.test.parent.TestParentScope
-            
+
             @ComposeScreen(
               scope = TestScreen::class,
               parentScope = TestParentScope::class,
@@ -606,14 +606,14 @@ internal class FileGeneratorTestCompose {
               public val testClass: TestClass
 
               public val test: TestClass2
-            
+
               public val testSet: Set<String>
 
               public val testMap: Map<String, Int>
 
               @get:ForScope(TestScreen::class)
               public val closeables: Set<Closeable>
-    
+
               override fun close() {
                 closeables.forEach {
                   it.close()
@@ -655,7 +655,7 @@ internal class FileGeneratorTestCompose {
 
               KhonshuTest2(component)
             }
-            
+
             @Composable
             @OptIn(InternalCodegenApi::class)
             private fun KhonshuTest2(component: KhonshuTest2Component) {
@@ -678,7 +678,7 @@ internal class FileGeneratorTestCompose {
                 )
               }
             }
-            
+
         """.trimIndent()
 
         test(withInjectedParameters, "com/test/Test2.kt", source, expected)
@@ -693,11 +693,11 @@ internal class FileGeneratorTestCompose {
         @Language("kotlin")
         val source = """
             package com.test
-            
+
             import androidx.compose.runtime.Composable
             import com.freeletics.khonshu.codegen.compose.ComposeScreen
             import com.test.parent.TestParentScope
-            
+
             @ComposeScreen(
               scope = TestScreen::class,
               parentScope = TestParentScope::class,
@@ -746,7 +746,7 @@ internal class FileGeneratorTestCompose {
 
               @get:ForScope(TestScreen::class)
               public val closeables: Set<Closeable>
-    
+
               override fun close() {
                 closeables.forEach {
                   it.close()
@@ -788,7 +788,7 @@ internal class FileGeneratorTestCompose {
 
               KhonshuTest(component)
             }
-            
+
             @Composable
             @OptIn(InternalCodegenApi::class)
             private fun KhonshuTest(component: KhonshuTestComponent) {
@@ -801,7 +801,7 @@ internal class FileGeneratorTestCompose {
                 )
               }
             }
-            
+
         """.trimIndent()
 
         test(withoutSendAction, "com/test/Test.kt", source, expected)
@@ -816,11 +816,11 @@ internal class FileGeneratorTestCompose {
         @Language("kotlin")
         val source = """
             package com.test
-            
+
             import androidx.compose.runtime.Composable
             import com.freeletics.khonshu.codegen.compose.ComposeScreen
             import com.test.parent.TestParentScope
-            
+
             @ComposeScreen(
               scope = TestScreen::class,
               parentScope = TestParentScope::class,
@@ -871,7 +871,7 @@ internal class FileGeneratorTestCompose {
 
               @get:ForScope(TestScreen::class)
               public val closeables: Set<Closeable>
-    
+
               override fun close() {
                 closeables.forEach {
                   it.close()
@@ -913,7 +913,7 @@ internal class FileGeneratorTestCompose {
 
               KhonshuTest(component)
             }
-            
+
             @Composable
             @OptIn(InternalCodegenApi::class)
             private fun KhonshuTest(component: KhonshuTestComponent) {
@@ -927,7 +927,7 @@ internal class FileGeneratorTestCompose {
                 )
               }
             }
-            
+
         """.trimIndent()
 
         test(withoutSendAction, "com/test/Test.kt", source, expected)

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestComposeFragment.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestComposeFragment.kt
@@ -50,11 +50,11 @@ internal class FileGeneratorTestComposeFragment {
         @Language("kotlin")
         val source = """
             package com.test
-            
+
             import androidx.compose.runtime.Composable
             import com.freeletics.khonshu.codegen.fragment.ComposeFragment
             import com.test.parent.TestParentScope
-            
+
             @ComposeFragment(
               scope = TestScreen::class,
               parentScope = TestParentScope::class,
@@ -110,7 +110,7 @@ internal class FileGeneratorTestComposeFragment {
 
               @get:ForScope(TestScreen::class)
               public val closeables: Set<Closeable>
-    
+
               override fun close() {
                 closeables.forEach {
                   it.close()
@@ -137,11 +137,11 @@ internal class FileGeneratorTestComposeFragment {
               @ForScope(TestScreen::class)
               public fun bindCloseables(): Set<Closeable>
             }
-            
+
             @OptIn(InternalCodegenApi::class)
             public class KhonshuTestFragment : Fragment() {
               private lateinit var khonshuTestComponent: KhonshuTestComponent
-            
+
               override fun onCreateView(
                 inflater: LayoutInflater,
                 container: ViewGroup?,
@@ -181,7 +181,7 @@ internal class FileGeneratorTestComposeFragment {
                 )
               }
             }
-            
+
         """.trimIndent()
 
         test(data, "com/test/Test.kt", source, expected)
@@ -198,13 +198,13 @@ internal class FileGeneratorTestComposeFragment {
         @Language("kotlin")
         val source = """
             package com.test
-            
+
             import androidx.compose.runtime.Composable
             import com.freeletics.khonshu.codegen.fragment.ComposeDestination
             import com.freeletics.khonshu.codegen.fragment.DestinationType
             import com.test.destination.TestDestinationScope
             import com.test.parent.TestParentRoute
-            
+
             @ComposeDestination(
               route = TestRoute::class,
               parentScope = TestParentRoute::class,
@@ -279,7 +279,7 @@ internal class FileGeneratorTestComposeFragment {
 
               @get:ForScope(TestRoute::class)
               public val closeables: Set<Closeable>
-    
+
               override fun close() {
                 closeables.forEach {
                   it.close()
@@ -297,7 +297,7 @@ internal class FileGeneratorTestComposeFragment {
                 public fun khonshuTestComponentFactory(): Factory
               }
             }
-            
+
             @OptIn(InternalCodegenApi::class)
             public object KhonshuTestComponentProvider : ComponentProvider<TestRoute, KhonshuTestComponent> {
               @OptIn(InternalNavigationApi::class)
@@ -319,11 +319,11 @@ internal class FileGeneratorTestComposeFragment {
               @ForScope(TestRoute::class)
               public fun bindCloseables(): Set<Closeable>
             }
-            
+
             @OptIn(InternalCodegenApi::class)
             public class KhonshuTestFragment : Fragment() {
               private lateinit var khonshuTestComponent: KhonshuTestComponent
-            
+
               @OptIn(InternalNavigationApi::class)
               override fun onCreateView(
                 inflater: LayoutInflater,
@@ -335,10 +335,10 @@ internal class FileGeneratorTestComposeFragment {
                   val executor = findNavigationExecutor()
                   khonshuTestComponent = KhonshuTestComponentProvider.provide(testRoute, executor,
                       requireContext())
-            
+
                   handleNavigation(this, khonshuTestComponent.navEventNavigator)
                 }
-            
+
                 return ComposeView(requireContext()).apply {
                   setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
 
@@ -374,7 +374,7 @@ internal class FileGeneratorTestComposeFragment {
               public fun provideNavDestination(): NavDestination = ScreenDestination<TestRoute,
                   KhonshuTestFragment>(KhonshuTestComponentProvider)
             }
-            
+
         """.trimIndent()
 
         test(withNavigation, "com/test/Test.kt", source, expected)
@@ -395,11 +395,11 @@ internal class FileGeneratorTestComposeFragment {
         @Language("kotlin")
         val source = """
             package com.test
-            
+
             import androidx.compose.runtime.Composable
             import com.freeletics.khonshu.codegen.fragment.ComposeDestination
             import com.freeletics.khonshu.codegen.fragment.DestinationType
-            
+
             @ComposeDestination(
               route = TestRoute::class,
               stateMachine = TestStateMachine::class,
@@ -471,7 +471,7 @@ internal class FileGeneratorTestComposeFragment {
 
               @get:ForScope(TestRoute::class)
               public val closeables: Set<Closeable>
-    
+
               override fun close() {
                 closeables.forEach {
                   it.close()
@@ -489,7 +489,7 @@ internal class FileGeneratorTestComposeFragment {
                 public fun khonshuTestComponentFactory(): Factory
               }
             }
-            
+
             @OptIn(InternalCodegenApi::class)
             public object KhonshuTestComponentProvider : ComponentProvider<TestRoute, KhonshuTestComponent> {
               @OptIn(InternalNavigationApi::class)
@@ -581,12 +581,12 @@ internal class FileGeneratorTestComposeFragment {
         @Language("kotlin")
         val source = """
             package com.test
-            
+
             import androidx.compose.runtime.Composable
             import androidx.fragment.app.DialogFragment
             import com.freeletics.khonshu.codegen.fragment.ComposeFragment
             import com.test.parent.TestParentScope
-            
+
             @ComposeFragment(
               scope = TestScreen::class,
               parentScope = TestParentScope::class,
@@ -643,7 +643,7 @@ internal class FileGeneratorTestComposeFragment {
 
               @get:ForScope(TestScreen::class)
               public val closeables: Set<Closeable>
-    
+
               override fun close() {
                 closeables.forEach {
                   it.close()
@@ -670,11 +670,11 @@ internal class FileGeneratorTestComposeFragment {
               @ForScope(TestScreen::class)
               public fun bindCloseables(): Set<Closeable>
             }
-            
+
             @OptIn(InternalCodegenApi::class)
             public class KhonshuTestFragment : DialogFragment() {
               private lateinit var khonshuTestComponent: KhonshuTestComponent
-            
+
               override fun onCreateView(
                 inflater: LayoutInflater,
                 container: ViewGroup?,
@@ -747,12 +747,12 @@ internal class FileGeneratorTestComposeFragment {
         @Language("kotlin")
         val source = """
             package com.test
-            
+
             import androidx.compose.runtime.Composable
             import com.freeletics.khonshu.codegen.fragment.ComposeFragment
             import com.test.other.TestClass2
             import com.test.parent.TestParentScope
-            
+
             @ComposeFragment(
               scope = TestScreen::class,
               parentScope = TestParentScope::class,
@@ -817,14 +817,14 @@ internal class FileGeneratorTestComposeFragment {
               public val testClass: TestClass
 
               public val test: TestClass2
-            
+
               public val testSet: Set<String>
 
               public val testMap: Map<String, Int>
 
               @get:ForScope(TestScreen::class)
               public val closeables: Set<Closeable>
-    
+
               override fun close() {
                 closeables.forEach {
                   it.close()
@@ -851,11 +851,11 @@ internal class FileGeneratorTestComposeFragment {
               @ForScope(TestScreen::class)
               public fun bindCloseables(): Set<Closeable>
             }
-            
+
             @OptIn(InternalCodegenApi::class)
             public class KhonshuTest2Fragment : Fragment() {
               private lateinit var khonshuTest2Component: KhonshuTest2Component
-            
+
               override fun onCreateView(
                 inflater: LayoutInflater,
                 container: ViewGroup?,
@@ -903,7 +903,7 @@ internal class FileGeneratorTestComposeFragment {
                 )
               }
             }
-            
+
         """.trimIndent()
 
         test(withInjectedParameters, "com/test/Test2.kt", source, expected)
@@ -918,11 +918,11 @@ internal class FileGeneratorTestComposeFragment {
         @Language("kotlin")
         val source = """
             package com.test
-            
+
             import androidx.compose.runtime.Composable
             import com.freeletics.khonshu.codegen.fragment.ComposeFragment
             import com.test.parent.TestParentScope
-            
+
             @ComposeFragment(
               scope = TestScreen::class,
               parentScope = TestParentScope::class,
@@ -975,7 +975,7 @@ internal class FileGeneratorTestComposeFragment {
 
               @get:ForScope(TestScreen::class)
               public val closeables: Set<Closeable>
-    
+
               override fun close() {
                 closeables.forEach {
                   it.close()
@@ -1002,11 +1002,11 @@ internal class FileGeneratorTestComposeFragment {
               @ForScope(TestScreen::class)
               public fun bindCloseables(): Set<Closeable>
             }
-            
+
             @OptIn(InternalCodegenApi::class)
             public class KhonshuTestFragment : Fragment() {
               private lateinit var khonshuTestComponent: KhonshuTestComponent
-            
+
               override fun onCreateView(
                 inflater: LayoutInflater,
                 container: ViewGroup?,
@@ -1044,7 +1044,7 @@ internal class FileGeneratorTestComposeFragment {
                 )
               }
             }
-            
+
         """.trimIndent()
 
         test(withoutSendAction, "com/test/Test.kt", source, expected)
@@ -1059,11 +1059,11 @@ internal class FileGeneratorTestComposeFragment {
         @Language("kotlin")
         val source = """
             package com.test
-            
+
             import androidx.compose.runtime.Composable
             import com.freeletics.khonshu.codegen.fragment.ComposeFragment
             import com.test.parent.TestParentScope
-            
+
             @ComposeFragment(
               scope = TestScreen::class,
               parentScope = TestParentScope::class,
@@ -1118,7 +1118,7 @@ internal class FileGeneratorTestComposeFragment {
 
               @get:ForScope(TestScreen::class)
               public val closeables: Set<Closeable>
-    
+
               override fun close() {
                 closeables.forEach {
                   it.close()
@@ -1145,11 +1145,11 @@ internal class FileGeneratorTestComposeFragment {
               @ForScope(TestScreen::class)
               public fun bindCloseables(): Set<Closeable>
             }
-            
+
             @OptIn(InternalCodegenApi::class)
             public class KhonshuTestFragment : Fragment() {
               private lateinit var khonshuTestComponent: KhonshuTestComponent
-            
+
               override fun onCreateView(
                 inflater: LayoutInflater,
                 container: ViewGroup?,
@@ -1188,7 +1188,7 @@ internal class FileGeneratorTestComposeFragment {
                 )
               }
             }
-            
+
         """.trimIndent()
 
         test(withoutSendAction, "com/test/Test.kt", source, expected)

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestRendererFragment.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestRendererFragment.kt
@@ -35,13 +35,13 @@ internal class FileGeneratorTestRendererFragment {
         @Language("kotlin")
         val source = """
             package com.test
-            
+
             import android.view.View
             import com.freeletics.khonshu.codegen.fragment.RendererFragment
             import com.gabrielittner.renderer.ViewRenderer
             import com.test.destination.TestDestinationScope
             import com.test.parent.TestParentScope
-            
+
             @RendererFragment(
               scope = TestScreen::class,
               parentScope = TestParentScope::class,
@@ -49,7 +49,7 @@ internal class FileGeneratorTestRendererFragment {
             )
             public class TestRenderer(view: View) : ViewRenderer<TestState, TestAction>(view) {
               override fun renderToView(state: TestState) {}
-            
+
               public abstract class Factory : ViewRenderer.Factory<TestBinding, TestRenderer>({ _, _, _ -> TestBinding() })
             }
         """.trimIndent()
@@ -92,7 +92,7 @@ internal class FileGeneratorTestRendererFragment {
 
               @get:ForScope(TestScreen::class)
               public val closeables: Set<Closeable>
-    
+
               override fun close() {
                 closeables.forEach {
                   it.close()
@@ -119,7 +119,7 @@ internal class FileGeneratorTestRendererFragment {
               @ForScope(TestScreen::class)
               public fun bindCloseables(): Set<Closeable>
             }
-            
+
             @OptIn(InternalCodegenApi::class)
             public class KhonshuTestRendererFragment : Fragment() {
               private lateinit var khonshuTestRendererComponent: KhonshuTestRendererComponent
@@ -138,13 +138,13 @@ internal class FileGeneratorTestRendererFragment {
                         argumentsForComponent)
                   }
                 }
-            
+
                 val renderer = khonshuTestRendererComponent.testRendererFactory.inflate(inflater, container)
                 connect(renderer, khonshuTestRendererComponent.testStateMachine)
                 return renderer.rootView
               }
             }
-            
+
         """.trimIndent()
 
         test(data, "com/test/TestRenderer.kt", source, expected)
@@ -161,14 +161,14 @@ internal class FileGeneratorTestRendererFragment {
         @Language("kotlin")
         val source = """
             package com.test
-            
+
             import android.view.View
             import com.freeletics.khonshu.codegen.fragment.RendererDestination
             import com.freeletics.khonshu.codegen.fragment.DestinationType
             import com.gabrielittner.renderer.ViewRenderer
             import com.test.destination.TestDestinationScope
             import com.test.parent.TestParentRoute
-            
+
             @RendererDestination(
               route = TestRoute::class,
               parentScope = TestParentRoute::class,
@@ -178,7 +178,7 @@ internal class FileGeneratorTestRendererFragment {
             )
             public class TestRenderer(view: View) : ViewRenderer<TestState, TestAction>(view) {
               override fun renderToView(state: TestState) {}
-            
+
               public abstract class Factory : ViewRenderer.Factory<TestBinding, TestRenderer>({ _, _, _ -> TestBinding() })
             }
         """.trimIndent()
@@ -238,7 +238,7 @@ internal class FileGeneratorTestRendererFragment {
 
               @get:ForScope(TestRoute::class)
               public val closeables: Set<Closeable>
-    
+
               override fun close() {
                 closeables.forEach {
                   it.close()
@@ -256,7 +256,7 @@ internal class FileGeneratorTestRendererFragment {
                 public fun khonshuTestRendererComponentFactory(): Factory
               }
             }
-            
+
             @OptIn(InternalCodegenApi::class)
             public object KhonshuTestRendererComponentProvider :
                 ComponentProvider<TestRoute, KhonshuTestRendererComponent> {
@@ -279,7 +279,7 @@ internal class FileGeneratorTestRendererFragment {
               @ForScope(TestRoute::class)
               public fun bindCloseables(): Set<Closeable>
             }
-            
+
             @OptIn(InternalCodegenApi::class)
             public class KhonshuTestRendererFragment : Fragment() {
               private lateinit var khonshuTestRendererComponent: KhonshuTestRendererComponent
@@ -295,16 +295,16 @@ internal class FileGeneratorTestRendererFragment {
                   val executor = findNavigationExecutor()
                   khonshuTestRendererComponent = KhonshuTestRendererComponentProvider.provide(testRoute,
                       executor, requireContext())
-            
+
                   handleNavigation(this, khonshuTestRendererComponent.navEventNavigator)
                 }
-            
+
                 val renderer = khonshuTestRendererComponent.testRendererFactory.inflate(inflater, container)
                 connect(renderer, khonshuTestRendererComponent.testStateMachine)
                 return renderer.rootView
               }
             }
-            
+
             @OptIn(InternalCodegenApi::class)
             @Module
             @ContributesTo(TestDestinationScope::class)
@@ -315,7 +315,7 @@ internal class FileGeneratorTestRendererFragment {
               public fun provideNavDestination(): NavDestination = ScreenDestination<TestRoute,
                   KhonshuTestRendererFragment>(KhonshuTestRendererComponentProvider)
             }
-            
+
         """.trimIndent()
 
         test(withNavigation, "com/test/TestRenderer.kt", source, expected)
@@ -336,12 +336,12 @@ internal class FileGeneratorTestRendererFragment {
         @Language("kotlin")
         val source = """
             package com.test
-            
+
             import android.view.View
             import com.freeletics.khonshu.codegen.fragment.RendererDestination
             import com.freeletics.khonshu.codegen.fragment.DestinationType
             import com.gabrielittner.renderer.ViewRenderer
-            
+
             @RendererDestination(
               route = TestRoute::class,
               stateMachine = TestStateMachine::class,
@@ -349,7 +349,7 @@ internal class FileGeneratorTestRendererFragment {
             )
             public class TestRenderer(view: View) : ViewRenderer<TestState, TestAction>(view) {
               override fun renderToView(state: TestState) {}
-            
+
               public abstract class Factory : ViewRenderer.Factory<TestBinding, TestRenderer>({ _, _, _ -> TestBinding() })
             }
         """.trimIndent()
@@ -408,7 +408,7 @@ internal class FileGeneratorTestRendererFragment {
 
               @get:ForScope(TestRoute::class)
               public val closeables: Set<Closeable>
-    
+
               override fun close() {
                 closeables.forEach {
                   it.close()
@@ -426,7 +426,7 @@ internal class FileGeneratorTestRendererFragment {
                 public fun khonshuTestRendererComponentFactory(): Factory
               }
             }
-            
+
             @OptIn(InternalCodegenApi::class)
             public object KhonshuTestRendererComponentProvider :
                 ComponentProvider<TestRoute, KhonshuTestRendererComponent> {
@@ -500,14 +500,14 @@ internal class FileGeneratorTestRendererFragment {
         @Language("kotlin")
         val source = """
             package com.test
-            
+
             import android.view.View
             import androidx.fragment.app.DialogFragment
             import com.freeletics.khonshu.codegen.fragment.RendererFragment
             import com.freeletics.khonshu.codegen.fragment.DestinationType
             import com.gabrielittner.renderer.ViewRenderer
             import com.test.parent.TestParentScope
-            
+
             @RendererFragment(
               scope = TestScreen::class,
               parentScope = TestParentScope::class,
@@ -516,7 +516,7 @@ internal class FileGeneratorTestRendererFragment {
             )
             public class TestRenderer(view: View) : ViewRenderer<TestState, TestAction>(view) {
               override fun renderToView(state: TestState) {}
-            
+
               public abstract class Factory : ViewRenderer.Factory<TestBinding, TestRenderer>({ _, _, _ -> TestBinding() })
             }
         """.trimIndent()
@@ -559,7 +559,7 @@ internal class FileGeneratorTestRendererFragment {
 
               @get:ForScope(TestScreen::class)
               public val closeables: Set<Closeable>
-    
+
               override fun close() {
                 closeables.forEach {
                   it.close()
@@ -586,7 +586,7 @@ internal class FileGeneratorTestRendererFragment {
               @ForScope(TestScreen::class)
               public fun bindCloseables(): Set<Closeable>
             }
-            
+
             @OptIn(InternalCodegenApi::class)
             public class KhonshuTestRendererFragment : DialogFragment() {
               private lateinit var khonshuTestRendererComponent: KhonshuTestRendererComponent
@@ -605,7 +605,7 @@ internal class FileGeneratorTestRendererFragment {
                         argumentsForComponent)
                   }
                 }
-            
+
                 val renderer = khonshuTestRendererComponent.testRendererFactory.inflate(inflater, container)
                 connect(renderer, khonshuTestRendererComponent.testStateMachine)
                 return renderer.rootView

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/KhonshuCodeGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/KhonshuCodeGenerator.kt
@@ -1,12 +1,12 @@
 package com.freeletics.khonshu.codegen
 
 import com.freeletics.khonshu.codegen.codegen.FileGenerator
-import com.freeletics.khonshu.codegen.parser.toComposeFragmentData
-import com.freeletics.khonshu.codegen.parser.toComposeFragmentDestinationData
-import com.freeletics.khonshu.codegen.parser.toComposeScreenData
-import com.freeletics.khonshu.codegen.parser.toComposeScreenDestinationData
-import com.freeletics.khonshu.codegen.parser.toRendererFragmentData
-import com.freeletics.khonshu.codegen.parser.toRendererFragmentDestinationData
+import com.freeletics.khonshu.codegen.parser.anvil.toComposeFragmentData
+import com.freeletics.khonshu.codegen.parser.anvil.toComposeFragmentDestinationData
+import com.freeletics.khonshu.codegen.parser.anvil.toComposeScreenData
+import com.freeletics.khonshu.codegen.parser.anvil.toComposeScreenDestinationData
+import com.freeletics.khonshu.codegen.parser.anvil.toRendererFragmentData
+import com.freeletics.khonshu.codegen.parser.anvil.toRendererFragmentDestinationData
 import com.google.auto.service.AutoService
 import com.squareup.anvil.compiler.api.AnvilContext
 import com.squareup.anvil.compiler.api.CodeGenerator

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/anvil/CommonParser.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/anvil/CommonParser.kt
@@ -1,4 +1,4 @@
-package com.freeletics.khonshu.codegen.parser
+package com.freeletics.khonshu.codegen.parser.anvil
 
 import com.freeletics.khonshu.codegen.ComposableParameter
 import com.freeletics.khonshu.codegen.codegen.util.appScope

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/anvil/ComposeParser.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/anvil/ComposeParser.kt
@@ -1,4 +1,4 @@
-package com.freeletics.khonshu.codegen.parser
+package com.freeletics.khonshu.codegen.parser.anvil
 
 import com.freeletics.khonshu.codegen.ComposeScreenData
 import com.freeletics.khonshu.codegen.Navigation

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/anvil/FragmentParser.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/anvil/FragmentParser.kt
@@ -1,4 +1,4 @@
-package com.freeletics.khonshu.codegen.parser
+package com.freeletics.khonshu.codegen.parser.anvil
 
 import com.freeletics.khonshu.codegen.ComposeFragmentData
 import com.freeletics.khonshu.codegen.Navigation

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/anvil/Reference.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/anvil/Reference.kt
@@ -1,4 +1,4 @@
-package com.freeletics.khonshu.codegen.parser
+package com.freeletics.khonshu.codegen.parser.anvil
 
 import com.freeletics.khonshu.codegen.ComposableParameter
 import com.squareup.anvil.compiler.internal.reference.AnnotatedReference

--- a/codegen-compiler/src/test/kotlin/com/freeletics/khonshu/codegen/parser/anvil/ReferenceTest.kt
+++ b/codegen-compiler/src/test/kotlin/com/freeletics/khonshu/codegen/parser/anvil/ReferenceTest.kt
@@ -1,4 +1,4 @@
-package com.freeletics.khonshu.codegen.parser
+package com.freeletics.khonshu.codegen.parser.anvil
 
 import com.freeletics.khonshu.codegen.compileAnvil
 import com.google.common.truth.Truth.assertThat
@@ -23,19 +23,19 @@ internal class ReferenceTest {
         compile(
             """
             package com.freeletics.test
-              
+
             interface StateMachine<State, Action>
             class Implementation : StateMachine<String, Int>
-            
+
             interface StateMachineWithShortTypeParameters<S, A> : StateMachine<S, A>
             class ImplementationWithShortTypeParameters : StateMachineWithShortTypeParameters<Long, Boolean>
-            
+
             interface StateMachineWithSwappedParameters<A2, S2> : StateMachine<S2, A2>
             class ImplementationWithWithSwappedParameters : StateMachineWithSwappedParameters<Int, String>
-            
+
             interface StateMachineWithExtraParameters<T1, T2, S3, A3, T3> : StateMachine<S3, A3>
             class ImplementationWithWithExtraParameters : StateMachineWithExtraParameters<Boolean, Long, Short, String, Int>
-    
+
             abstract class Hierarchy1<A4, S4>: StateMachineWithShortTypeParameters<S4, A4>
             abstract class Hierarchy2<T1, T2, S5, A5, T3>: Hierarchy1<A5, S5>()
             class HierarchyImplementation : Hierarchy2<Boolean, Long, Short, String, Int>()
@@ -94,12 +94,12 @@ internal class ReferenceTest {
                 package com.freeletics.test
 
                 import com.freeletics.khonshu.codegen.parser.TestStateMachine
-                                
-                class CreateCustomActivityStateMachine : 
+
+                class CreateCustomActivityStateMachine :
                     TestStateMachine<CreateCustomActivityState, CreateCustomActivityAction>(
                         DefaultCreateCustomActivityLoadingState,
                     )
-                
+
                 sealed interface CreateCustomActivityState
                 object DefaultCreateCustomActivityLoadingState : CreateCustomActivityState
                 sealed interface CreateCustomActivityAction


### PR DESCRIPTION
Moved the Anvil parsing code to a subpackage to prepare adding equivalents for ksp. Android Studio also decided to remove some trailing whitespace in the tests