### PR TITLE
move ActivityRoute to its own file

### DIFF
--- a/navigation/api/navigation.api
+++ b/navigation/api/navigation.api
@@ -5,6 +5,11 @@ public abstract interface class com/freeletics/khonshu/navigation/ActivityRoute 
 	public abstract fun fillInIntent ()Landroid/content/Intent;
 }
 
+public final class com/freeletics/khonshu/navigation/ActivityRouteKt {
+	public static final fun getRoute (Landroid/app/Activity;)Lcom/freeletics/khonshu/navigation/InternalActivityRoute;
+	public static final fun requireRoute (Landroid/app/Activity;)Lcom/freeletics/khonshu/navigation/InternalActivityRoute;
+}
+
 public abstract interface class com/freeletics/khonshu/navigation/BaseRoute : android/os/Parcelable {
 }
 
@@ -102,11 +107,6 @@ public abstract interface class com/freeletics/khonshu/navigation/NavRoot : com/
 }
 
 public abstract interface class com/freeletics/khonshu/navigation/NavRoute : com/freeletics/khonshu/navigation/BaseRoute {
-}
-
-public final class com/freeletics/khonshu/navigation/NavRouteKt {
-	public static final fun getRoute (Landroid/app/Activity;)Lcom/freeletics/khonshu/navigation/InternalActivityRoute;
-	public static final fun requireRoute (Landroid/app/Activity;)Lcom/freeletics/khonshu/navigation/InternalActivityRoute;
 }
 
 public final class com/freeletics/khonshu/navigation/NavigationResultRequest : com/freeletics/khonshu/navigation/ResultOwner {

--- a/navigation/src/main/kotlin/com/freeletics/khonshu/navigation/ActivityRoute.kt
+++ b/navigation/src/main/kotlin/com/freeletics/khonshu/navigation/ActivityRoute.kt
@@ -1,0 +1,55 @@
+package com.freeletics.khonshu.navigation
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Parcelable
+import com.freeletics.khonshu.navigation.internal.InternalNavigationApi
+
+/**
+ * Represents the route to an `Activity`. Should be used through []
+ */
+public sealed interface ActivityRoute : Parcelable {
+    public fun fillInIntent(): Intent
+}
+
+/**
+ * Represents the route to an `Activity` within the current app. The instance of this route
+ * will be added to the resulting `Intent` and can be accessed in the launched `Activity` by calling
+ * [getRoute] or [requireRoute].
+ */
+public abstract class InternalActivityRoute : ActivityRoute {
+    final override fun fillInIntent(): Intent {
+        return Intent().putExtra(EXTRA_ROUTE, this)
+    }
+}
+
+/**
+ * Represents the route to an `Activity` in another app. [fillInIntent] can be used to dynamically
+ * add extras to the resulting `Intent`.
+ */
+public interface ExternalActivityRoute : ActivityRoute {
+    override fun fillInIntent(): Intent {
+        return Intent()
+    }
+}
+
+/**
+ * Returns the [ActivityRoute] that was used to navigate to this [Activity].
+ */
+public fun <T : InternalActivityRoute> Activity.requireRoute(): T {
+    return requireNotNull(getRoute()) {
+        "Error extracting ActivityRoute from Activity's Intent"
+    }
+}
+
+/**
+ * Returns the [ActivityRoute] that was used to navigate to this [Activity] if it's present in
+ * Activity's Intent.
+ */
+public fun <T : InternalActivityRoute> Activity.getRoute(): T? {
+    @Suppress("DEPRECATION")
+    return intent.extras?.getParcelable(EXTRA_ROUTE)
+}
+
+@InternalNavigationApi
+public const val EXTRA_ROUTE: String = "com.freeletics.khonshu.navigation.ROUTE"

--- a/navigation/src/main/kotlin/com/freeletics/khonshu/navigation/NavRoute.kt
+++ b/navigation/src/main/kotlin/com/freeletics/khonshu/navigation/NavRoute.kt
@@ -1,9 +1,6 @@
 package com.freeletics.khonshu.navigation
 
-import android.app.Activity
-import android.content.Intent
 import android.os.Parcelable
-import com.freeletics.khonshu.navigation.internal.InternalNavigationApi
 
 public sealed interface BaseRoute : Parcelable
 
@@ -24,52 +21,3 @@ public interface NavRoute : BaseRoute
  * available to the target screens.
  */
 public interface NavRoot : BaseRoute
-
-/**
- * Represents the route to an `Activity`. Should be used through []
- */
-public sealed interface ActivityRoute : Parcelable {
-    public fun fillInIntent(): Intent
-}
-
-/**
- * Represents the route to an `Activity` within the current app. The instance of this route
- * will be added to the resulting `Intent` and can be accessed in the launched `Activity` by calling
- * [getRoute] or [requireRoute].
- */
-public abstract class InternalActivityRoute : ActivityRoute {
-    final override fun fillInIntent(): Intent {
-        return Intent().putExtra(EXTRA_ROUTE, this)
-    }
-}
-
-/**
- * Represents the route to an `Activity` in another app. [fillInIntent] can be used to dynamically
- * add extras to the resulting `Intent`.
- */
-public interface ExternalActivityRoute : ActivityRoute {
-    override fun fillInIntent(): Intent {
-        return Intent()
-    }
-}
-
-/**
- * Returns the [ActivityRoute] that was used to navigate to this [Activity].
- */
-public fun <T : InternalActivityRoute> Activity.requireRoute(): T {
-    return requireNotNull(getRoute()) {
-        "Error extracting ActivityRoute from Activity's Intent"
-    }
-}
-
-/**
- * Returns the [ActivityRoute] that was used to navigate to this [Activity] if it's present in
- * Activity's Intent.
- */
-public fun <T : InternalActivityRoute> Activity.getRoute(): T? {
-    @Suppress("DEPRECATION")
-    return intent.extras?.getParcelable(EXTRA_ROUTE)
-}
-
-@InternalNavigationApi
-public const val EXTRA_ROUTE: String = "com.freeletics.khonshu.navigation.ROUTE"


### PR DESCRIPTION
I need to move some things around for KSP. The main reason here is to separate ActivityRoute since it has an Android dependency while NavRoute has not. That way the compiler artifact will be able to reference NavRoute directly since it's java only (other than parcelable).