### PR TITLE
update naming of ComposableParameter functions

### DIFF
--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/anvil/ComposeParser.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/anvil/ComposeParser.kt
@@ -23,9 +23,9 @@ internal fun TopLevelFunctionReference.toComposeScreenData(): ComposeScreenData?
         parentScope = annotation.parentScope,
         stateMachine = stateMachine.asClassName(),
         navigation = null,
-        composableParameter = getComposeParameters(stateParameter, actionParameter),
-        stateParameter = getStateParameter(stateParameter),
-        sendActionParameter = getSendActionParameter(actionParameter),
+        composableParameter = getInjectedParameters(stateParameter, actionParameter),
+        stateParameter = getParameterWithType(stateParameter),
+        sendActionParameter = getParameterWithType(actionParameter),
     )
 }
 
@@ -51,8 +51,8 @@ internal fun TopLevelFunctionReference.toComposeScreenDestinationData(): Compose
         parentScope = annotation.parentScope,
         stateMachine = stateMachine.asClassName(),
         navigation = navigation,
-        composableParameter = getComposeParameters(stateParameter, actionParameter),
-        stateParameter = getStateParameter(stateParameter),
-        sendActionParameter = getSendActionParameter(actionParameter),
+        composableParameter = getInjectedParameters(stateParameter, actionParameter),
+        stateParameter = getParameterWithType(stateParameter),
+        sendActionParameter = getParameterWithType(actionParameter),
     )
 }

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/anvil/FragmentParser.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/anvil/FragmentParser.kt
@@ -65,9 +65,9 @@ internal fun TopLevelFunctionReference.toComposeFragmentData(): ComposeFragmentD
         stateMachine = stateMachine.asClassName(),
         fragmentBaseClass = annotation.fragmentBaseClass(3),
         navigation = null,
-        composableParameter = getComposeParameters(stateParameter, actionParameter),
-        stateParameter = getStateParameter(stateParameter),
-        sendActionParameter = getSendActionParameter(actionParameter),
+        composableParameter = getInjectedParameters(stateParameter, actionParameter),
+        stateParameter = getParameterWithType(stateParameter),
+        sendActionParameter = getParameterWithType(actionParameter),
     )
 }
 
@@ -94,8 +94,8 @@ internal fun TopLevelFunctionReference.toComposeFragmentDestinationData(): Compo
         stateMachine = stateMachine.asClassName(),
         fragmentBaseClass = annotation.fragmentBaseClass(5),
         navigation = navigation,
-        composableParameter = getComposeParameters(stateParameter, actionParameter),
-        stateParameter = getStateParameter(stateParameter),
-        sendActionParameter = getSendActionParameter(actionParameter),
+        composableParameter = getInjectedParameters(stateParameter, actionParameter),
+        stateParameter = getParameterWithType(stateParameter),
+        sendActionParameter = getParameterWithType(actionParameter),
     )
 }

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/anvil/Reference.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/anvil/Reference.kt
@@ -1,6 +1,5 @@
 package com.freeletics.khonshu.codegen.parser.anvil
 
-import com.freeletics.khonshu.codegen.ComposableParameter
 import com.squareup.anvil.compiler.internal.reference.AnnotatedReference
 import com.squareup.anvil.compiler.internal.reference.AnnotationReference
 import com.squareup.anvil.compiler.internal.reference.AnvilCompilationExceptionAnnotationReference
@@ -8,7 +7,6 @@ import com.squareup.anvil.compiler.internal.reference.AnvilCompilationExceptionC
 import com.squareup.anvil.compiler.internal.reference.ClassReference
 import com.squareup.anvil.compiler.internal.reference.MemberFunctionReference
 import com.squareup.anvil.compiler.internal.reference.MemberPropertyReference
-import com.squareup.anvil.compiler.internal.reference.ParameterReference
 import com.squareup.anvil.compiler.internal.reference.TopLevelFunctionReference
 import com.squareup.anvil.compiler.internal.reference.TypeReference
 import com.squareup.anvil.compiler.internal.reference.argumentAt
@@ -49,13 +47,6 @@ internal fun AnnotationReference.requireEnumArgument(name: String, index: Int): 
 
 internal fun AnnotationReference.optionalEnumArgument(name: String, index: Int): String? {
     return argumentAt(name, index)?.value<FqName>()?.shortName()?.asString()
-}
-
-internal fun ParameterReference.toComposableParameter(): ComposableParameter {
-    return ComposableParameter(
-        name = name,
-        typeName = type().asTypeName(),
-    )
 }
 
 internal val AnnotatedReference.packageName: String


### PR DESCRIPTION
- instead of having `getSendActionParameter` and `getStateParameter` with basically the same implementation `getParameterWithType`
- rename `getComposeParameters` to `getInjectedParameters` to make its behavior clearer and also share the logic for it with `getParameterWithType`