### PR TITLE
rewrite type parameter resolution to do a single pass

### DIFF
--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/anvil/ComposeParser.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/anvil/ComposeParser.kt
@@ -4,7 +4,6 @@ import com.freeletics.khonshu.codegen.ComposeScreenData
 import com.freeletics.khonshu.codegen.Navigation
 import com.freeletics.khonshu.codegen.codegen.util.codegenComposeDestinationFqName
 import com.freeletics.khonshu.codegen.codegen.util.composeFqName
-import com.freeletics.khonshu.codegen.codegen.util.stateMachineFqName
 import com.squareup.anvil.compiler.internal.reference.TopLevelFunctionReference
 import com.squareup.anvil.compiler.internal.reference.asClassName
 
@@ -12,9 +11,7 @@ internal fun TopLevelFunctionReference.toComposeScreenData(): ComposeScreenData?
     val annotation = findAnnotation(composeFqName) ?: return null
 
     val stateMachine = annotation.stateMachineReference
-    val stateMachineSuperType = stateMachine.superTypeReference(stateMachineFqName)
-    val stateParameter = stateMachine.stateMachineStateParameter(stateMachineSuperType)
-    val actionParameter = stateMachine.stateMachineActionFunctionParameter(stateMachineSuperType)
+    val (stateParameter, actionParameter) = stateMachine.stateMachineParameters()
 
     return ComposeScreenData(
         baseName = name,
@@ -33,9 +30,7 @@ internal fun TopLevelFunctionReference.toComposeScreenDestinationData(): Compose
     val annotation = findAnnotation(codegenComposeDestinationFqName) ?: return null
 
     val stateMachine = annotation.stateMachineReference
-    val stateMachineSuperType = stateMachine.superTypeReference(stateMachineFqName)
-    val stateParameter = stateMachine.stateMachineStateParameter(stateMachineSuperType)
-    val actionParameter = stateMachine.stateMachineActionFunctionParameter(stateMachineSuperType)
+    val (stateParameter, actionParameter) = stateMachine.stateMachineParameters()
 
     val navigation = Navigation.Compose(
         route = annotation.route,

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/anvil/FragmentParser.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/anvil/FragmentParser.kt
@@ -7,7 +7,6 @@ import com.freeletics.khonshu.codegen.codegen.util.composeFragmentDestinationFqN
 import com.freeletics.khonshu.codegen.codegen.util.composeFragmentFqName
 import com.freeletics.khonshu.codegen.codegen.util.rendererFragmentDestinationFqName
 import com.freeletics.khonshu.codegen.codegen.util.rendererFragmentFqName
-import com.freeletics.khonshu.codegen.codegen.util.stateMachineFqName
 import com.squareup.anvil.compiler.internal.reference.ClassReference
 import com.squareup.anvil.compiler.internal.reference.TopLevelFunctionReference
 import com.squareup.anvil.compiler.internal.reference.asClassName
@@ -53,9 +52,7 @@ internal fun TopLevelFunctionReference.toComposeFragmentData(): ComposeFragmentD
     val annotation = findAnnotation(composeFragmentFqName) ?: return null
 
     val stateMachine = annotation.stateMachineReference
-    val stateMachineSuperType = stateMachine.superTypeReference(stateMachineFqName)
-    val stateParameter = stateMachine.stateMachineStateParameter(stateMachineSuperType)
-    val actionParameter = stateMachine.stateMachineActionFunctionParameter(stateMachineSuperType)
+    val (stateParameter, actionParameter) = stateMachine.stateMachineParameters()
 
     return ComposeFragmentData(
         baseName = name,
@@ -75,9 +72,7 @@ internal fun TopLevelFunctionReference.toComposeFragmentDestinationData(): Compo
     val annotation = findAnnotation(composeFragmentDestinationFqName) ?: return null
 
     val stateMachine = annotation.stateMachineReference
-    val stateMachineSuperType = stateMachine.superTypeReference(stateMachineFqName)
-    val stateParameter = stateMachine.stateMachineStateParameter(stateMachineSuperType)
-    val actionParameter = stateMachine.stateMachineActionFunctionParameter(stateMachineSuperType)
+    val (stateParameter, actionParameter) = stateMachine.stateMachineParameters()
 
     val navigation = Navigation.Fragment(
         route = annotation.route,


### PR DESCRIPTION
We have this code to resolve the type parameters of `StateMachine` from a concrete implementation, which we then use to identify the state and sendAction parameters in a compose function. Right now we're first collecting type references for all super types and then we go through that twice to actually resolve the type parameters. While looking into a solution for this in KSP I came up with a better implementation. With this it only requires a single pass instead of 3. More description is directly on the code.