### PR TITLE
unify test helpers

### DIFF
--- a/codegen-compiler-test/codegen-compiler-test.gradle.kts
+++ b/codegen-compiler-test/codegen-compiler-test.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     testImplementation(projects.navigationFragment)
     testImplementation(projects.navigationCompose)
     testImplementation(projects.stateMachine)
+    testImplementation(libs.anvil.annotations)
     testImplementation(libs.androidx.compose.runtime)
     testImplementation(libs.androidx.viewbinding)
     testImplementation(libs.renderer)
@@ -31,9 +32,7 @@ dependencies {
     testImplementation(libs.truth)
     testImplementation(libs.kotlin.compile.testing)
     testImplementation(libs.androidx.compose.compiler)
-    testImplementation(libs.anvil.annotations)
     testImplementation(testFixtures(projects.codegenCompiler))
-    testImplementation(testFixtures(libs.anvil.compiler.utils))
 }
 
 // exclude external dependency on state machine connect, we include the local module instead

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/TestHelper.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/TestHelper.kt
@@ -1,19 +1,17 @@
 package com.freeletics.khonshu.codegen.codegen
 
 import androidx.compose.compiler.plugins.kotlin.ComposePluginRegistrar
-import com.freeletics.khonshu.codegen.AnvilCompilation
 import com.freeletics.khonshu.codegen.BaseData
 import com.freeletics.khonshu.codegen.ComposeFragmentData
 import com.freeletics.khonshu.codegen.ComposeScreenData
+import com.freeletics.khonshu.codegen.KhonshuCompilation.Companion.anvilCompilation
+import com.freeletics.khonshu.codegen.KhonshuCompilation.Companion.simpleCompilation
 import com.freeletics.khonshu.codegen.RendererFragmentData
+import com.freeletics.khonshu.codegen.testFileName
 import com.google.common.truth.Truth.assertThat
-import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
-import com.tschuchort.compiletesting.SourceFile
-import java.io.File
-import java.nio.file.Files
 
-public fun test(data: BaseData, fileName: String, source: String, expectedCode: String) {
+internal fun test(data: BaseData, fileName: String, source: String, expectedCode: String) {
     compile(fileName = fileName, source = source, data = data, expectedCode = expectedCode)
     compileWithAnvil(fileName = fileName, source = source, expectedCode = expectedCode)
 }
@@ -25,57 +23,25 @@ private fun compile(fileName: String, source: String, data: BaseData, expectedCo
         is RendererFragmentData -> FileGenerator().generate(data).toString()
     }
 
-    val compilation = KotlinCompilation().apply {
-        configure()
-
+    simpleCompilation(
         sources = listOf(
-            sourceFile(fileName, source),
-            sourceFile(fileName.testFileName(), generatedCode),
-        )
+            fileName to source,
+            fileName.testFileName() to generatedCode,
+        ),
+        compilerPlugins = listOf(ComposePluginRegistrar()),
+    ).compile {
+        assertThat(it.exitCode).isEqualTo(ExitCode.OK)
+        assertThat(generatedCode).isEqualTo(expectedCode)
     }
-
-    assertThat(compilation.compile().exitCode).isEqualTo(ExitCode.OK)
-    assertThat(generatedCode).isEqualTo(expectedCode)
 }
 
 private fun compileWithAnvil(fileName: String, source: String, expectedCode: String) {
-    val compilation = AnvilCompilation().apply {
-        configureAnvil()
-        kotlinCompilation.configure()
-        kotlinCompilation.sources = listOf(
-            kotlinCompilation.sourceFile(fileName, source),
-        )
+    anvilCompilation(
+        source = source,
+        fileName = fileName,
+        compilerPlugins = listOf(ComposePluginRegistrar()),
+    ).compile {
+        assertThat(it.exitCode).isEqualTo(ExitCode.OK)
+        assertThat(generatedFileFor(fileName)).isEqualTo(expectedCode)
     }
-
-    assertThat(compilation.compile().exitCode).isEqualTo(ExitCode.OK)
-    assertThat(compilation.kotlinCompilation.generatedFile(fileName)).isEqualTo(expectedCode)
-}
-
-private fun KotlinCompilation.sourceFile(name: String, content: String): SourceFile {
-    val path = "${workingDir.absolutePath}/sources/src/main/kotlin/$name"
-    Files.createDirectories(File(path).parentFile!!.toPath())
-    return SourceFile.kotlin(path, content)
-}
-
-private fun KotlinCompilation.generatedFile(name: String): String {
-    val path = "${workingDir.absolutePath}/build/anvil/${name.testFileName()}"
-    return File(path).readText()
-}
-
-private fun String.testFileName(): String {
-    val path = substringBeforeLast("/")
-    val name = substringAfterLast("/")
-    return "$path/Khonshu$name"
-}
-
-private fun KotlinCompilation.configure() {
-    compilerPluginRegistrars = compilerPluginRegistrars + listOf(ComposePluginRegistrar())
-    kotlincArguments = kotlincArguments + listOf(
-        "-P",
-        "plugin:androidx.compose.compiler.plugins.kotlin:suppressKotlinVersionCompatibilityCheck=1.7.22",
-    )
-    jvmTarget = "11"
-    inheritClassPath = true
-    messageOutputStream = System.out // see diagnostics in real time
-    allWarningsAsErrors = true
 }

--- a/codegen-compiler/codegen-compiler.gradle.kts
+++ b/codegen-compiler/codegen-compiler.gradle.kts
@@ -28,13 +28,12 @@ dependencies {
     testImplementation(libs.kotlin.compile.testing)
     testImplementation(libs.coroutines.core)
     testImplementation(libs.flowredux)
-    testImplementation(testFixtures(libs.anvil.compiler.utils))
 
-    testFixturesApi(testFixtures(libs.anvil.compiler.utils))
     testFixturesApi(libs.kotlin.compile.testing)
     testFixturesImplementation(libs.anvil.compiler)
+    testFixturesImplementation(testFixtures(libs.anvil.compiler.utils))
     testFixturesImplementation(libs.dagger.compiler)
-    testFixturesImplementation("com.google.auto.value:auto-value:1.10.2")
+    testFixturesImplementation(libs.auto.value)
 }
 
 // exclude external dependency on state machine connect, we include the local module instead

--- a/codegen-compiler/src/test/kotlin/com/freeletics/khonshu/codegen/parser/anvil/AllSuperTypesTest.kt
+++ b/codegen-compiler/src/test/kotlin/com/freeletics/khonshu/codegen/parser/anvil/AllSuperTypesTest.kt
@@ -1,10 +1,9 @@
 package com.freeletics.khonshu.codegen.parser.anvil
 
+import com.freeletics.khonshu.codegen.KhonshuCompilation.Companion.anvilCompilation
 import com.freeletics.khonshu.codegen.codegen.util.stateMachine
-import com.freeletics.khonshu.codegen.compileAnvil
+import com.freeletics.khonshu.codegen.simpleCodeGenerator
 import com.google.common.truth.Truth.assertThat
-import com.squareup.anvil.compiler.api.CodeGenerator
-import com.squareup.anvil.compiler.internal.testing.simpleCodeGenerator
 import com.squareup.kotlinpoet.BOOLEAN
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.INT
@@ -13,9 +12,7 @@ import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.SHORT
 import com.squareup.kotlinpoet.STRING
 import com.squareup.kotlinpoet.TypeName
-import com.tschuchort.compiletesting.JvmCompilationResult
-import com.tschuchort.compiletesting.KotlinCompilation
-import org.intellij.lang.annotations.Language
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
 import org.junit.Test
 
 internal class AllSuperTypesTest {
@@ -28,7 +25,7 @@ internal class AllSuperTypesTest {
 
     @Test
     fun `type parameters are resolved`() {
-        compile(
+        anvilCompilation(
             """
             package com.freeletics.test
 
@@ -95,18 +92,16 @@ internal class AllSuperTypesTest {
                         }
                         else -> throw NotImplementedError(psiRef.shortName)
                     }
-
-                    null
                 },
             ),
-        ) {
-            assertThat(exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        ).compile {
+            assertThat(it.exitCode).isEqualTo(ExitCode.OK)
         }
     }
 
     @Test
     fun `type parameters are resolved for external classes`() {
-        compile(
+        anvilCompilation(
             """
                 package com.freeletics.test
 
@@ -137,30 +132,10 @@ internal class AllSuperTypesTest {
                         -> {}
                         else -> throw NotImplementedError(psiRef.shortName)
                     }
-
-                    null
                 },
             ),
-        ) {
-            assertThat(exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        ).compile {
+            assertThat(it.exitCode).isEqualTo(ExitCode.OK)
         }
-    }
-
-    private fun compile(
-        @Language("kotlin") vararg sources: String,
-        previousCompilationResult: JvmCompilationResult? = null,
-        enableDaggerAnnotationProcessor: Boolean = false,
-        codeGenerators: List<CodeGenerator> = emptyList(),
-        allWarningsAsErrors: Boolean = true,
-        block: JvmCompilationResult.() -> Unit = { },
-    ): JvmCompilationResult {
-        return compileAnvil(
-            sources = sources,
-            allWarningsAsErrors = allWarningsAsErrors,
-            previousCompilationResult = previousCompilationResult,
-            enableDaggerAnnotationProcessor = enableDaggerAnnotationProcessor,
-            codeGenerators = codeGenerators,
-            block = block,
-        )
     }
 }

--- a/codegen-compiler/src/testFixtures/kotlin/com/freeletics/khonshu/codegen/AnvilCompilation.kt
+++ b/codegen-compiler/src/testFixtures/kotlin/com/freeletics/khonshu/codegen/AnvilCompilation.kt
@@ -6,33 +6,26 @@ import com.squareup.anvil.annotations.ExperimentalAnvilApi
 import com.squareup.anvil.compiler.AnvilCommandLineProcessor
 import com.squareup.anvil.compiler.AnvilComponentRegistrar
 import com.squareup.anvil.compiler.api.CodeGenerator
-import com.tschuchort.compiletesting.JvmCompilationResult
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.PluginOption
-import com.tschuchort.compiletesting.SourceFile
-import com.tschuchort.compiletesting.addPreviousResultToClasspath
 import dagger.internal.codegen.ComponentProcessor
 import java.io.File
-import java.io.OutputStream
-import java.nio.file.Files
-import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.config.JvmTarget
 
 /**
  * A simple API over a [KotlinCompilation] with extra configuration support for Anvil.
  */
 @ExperimentalAnvilApi
-public class AnvilCompilation internal constructor(
-    public val kotlinCompilation: KotlinCompilation,
+internal class AnvilCompilation internal constructor(
+    val kotlinCompilation: KotlinCompilation,
 ) {
 
-    private var isCompiled = false
     private var anvilConfigured = false
 
     /** Configures this the Anvil behavior of this compilation. */
     @Suppress("SuspiciousCollectionReassignment")
     @ExperimentalAnvilApi
-    public fun configureAnvil(
+    fun configureAnvil(
         enableDaggerAnnotationProcessor: Boolean = false,
         generateDaggerFactories: Boolean = false,
         generateDaggerFactoriesOnly: Boolean = false,
@@ -41,7 +34,6 @@ public class AnvilCompilation internal constructor(
         codeGenerators: List<CodeGenerator> = emptyList(),
         enableAnvil: Boolean = true,
     ): AnvilCompilation = apply {
-        checkNotCompiled()
         check(!anvilConfigured) { "Anvil should not be configured twice." }
 
         anvilConfigured = true
@@ -93,85 +85,8 @@ public class AnvilCompilation internal constructor(
         }
     }
 
-    /** Adds the given sources to this compilation with their packages and names inferred. */
-    public fun addSources(@Language("kotlin") vararg sources: String): AnvilCompilation = apply {
-        checkNotCompiled()
-        kotlinCompilation.sources += sources.mapIndexed { index, content ->
-            val packageDir = content.lines()
-                .firstOrNull { it.trim().startsWith("package ") }
-                ?.substringAfter("package ")
-                ?.replace('.', '/')
-                ?.let { "$it/" }
-                ?: ""
-
-            val name = "${kotlinCompilation.workingDir.absolutePath}/sources/src/main/java/" +
-                "$packageDir/Source$index.kt"
-
-            Files.createDirectories(File(name).parentFile.toPath())
-
-            SourceFile.kotlin(name, contents = content, trimIndent = true)
-        }
-    }
-
-    public fun addPreviousCompilationResult(result: JvmCompilationResult): AnvilCompilation = apply {
-        checkNotCompiled()
-        kotlinCompilation.addPreviousResultToClasspath(result)
-    }
-
-    public fun jvmTarget(jvmTarget: JvmTarget) {
-        checkNotCompiled()
-        kotlinCompilation.jvmTarget = jvmTarget.description
-    }
-
-    /**
-     * Returns an Anvil-generated file with the given [packageName] and [fileName] from its expected
-     * path.
-     */
-    public fun generatedAnvilFile(
-        packageName: String,
-        fileName: String,
-    ): File {
-        check(isCompiled) {
-            "No compilation run yet! Call compile() first."
-        }
-        return File(
-            kotlinCompilation.workingDir,
-            "build/anvil/${packageName.replace('.', File.separatorChar)}/$fileName.kt",
-        )
-            .apply {
-                check(exists()) {
-                    "Generated file not found!"
-                }
-            }
-    }
-
-    private fun checkNotCompiled() {
-        check(!isCompiled) {
-            "Already compiled! Create a new compilation if you want to compile again."
-        }
-    }
-
-    /**
-     * Compiles the underlying [KotlinCompilation]. Note that if [configureAnvil] has not been called
-     * prior to this, it will be configured with default behavior.
-     */
-    public fun compile(
-        @Language("kotlin") vararg sources: String,
-        block: JvmCompilationResult.() -> Unit = {},
-    ): JvmCompilationResult {
-        checkNotCompiled()
-        if (!anvilConfigured) {
-            // Configure with default behaviors
-            configureAnvil()
-        }
-        addSources(*sources)
-        isCompiled = true
-
-        return kotlinCompilation.compile().apply(block)
-    }
-
-    public companion object {
-        public operator fun invoke(): AnvilCompilation {
+    internal companion object {
+        operator fun invoke(): AnvilCompilation {
             return AnvilCompilation(
                 KotlinCompilation().apply {
                     // Sensible default behaviors
@@ -182,61 +97,4 @@ public class AnvilCompilation internal constructor(
             )
         }
     }
-}
-
-/**
- * Helpful for testing code generators in unit tests end to end.
- *
- * This covers common cases, but is built upon reusable logic in [AnvilCompilation] and
- * [AnvilCompilation.configureAnvil]. Consider using those APIs if more advanced configuration
- * is needed.
- */
-@ExperimentalAnvilApi
-public fun compileAnvil(
-    @Language("kotlin") vararg sources: String,
-    enableDaggerAnnotationProcessor: Boolean = false,
-    generateDaggerFactories: Boolean = false,
-    generateDaggerFactoriesOnly: Boolean = false,
-    disableComponentMerging: Boolean = false,
-    allWarningsAsErrors: Boolean = true,
-    messageOutputStream: OutputStream = System.out,
-    workingDir: File? = null,
-    enableExperimentalAnvilApis: Boolean = true,
-    previousCompilationResult: JvmCompilationResult? = null,
-    codeGenerators: List<CodeGenerator> = emptyList(),
-    moduleName: String? = null,
-    jvmTarget: JvmTarget? = null,
-    block: JvmCompilationResult.() -> Unit = { },
-): JvmCompilationResult {
-    return AnvilCompilation()
-        .apply {
-            kotlinCompilation.apply {
-                this.allWarningsAsErrors = allWarningsAsErrors
-                this.messageOutputStream = messageOutputStream
-                if (workingDir != null) {
-                    this.workingDir = workingDir
-                }
-                if (moduleName != null) {
-                    this.moduleName = moduleName
-                }
-            }
-
-            if (jvmTarget != null) {
-                jvmTarget(jvmTarget)
-            }
-
-            if (previousCompilationResult != null) {
-                addPreviousCompilationResult(previousCompilationResult)
-            }
-        }
-        .configureAnvil(
-            enableDaggerAnnotationProcessor = enableDaggerAnnotationProcessor,
-            generateDaggerFactories = generateDaggerFactories,
-            generateDaggerFactoriesOnly = generateDaggerFactoriesOnly,
-            disableComponentMerging = disableComponentMerging,
-            enableExperimentalAnvilApis = enableExperimentalAnvilApis,
-            codeGenerators = codeGenerators,
-        )
-        .compile(*sources)
-        .also(block)
 }

--- a/codegen-compiler/src/testFixtures/kotlin/com/freeletics/khonshu/codegen/KhonshuCompilation.kt
+++ b/codegen-compiler/src/testFixtures/kotlin/com/freeletics/khonshu/codegen/KhonshuCompilation.kt
@@ -1,0 +1,112 @@
+package com.freeletics.khonshu.codegen
+
+import com.squareup.anvil.compiler.api.CodeGenerator
+import com.squareup.anvil.compiler.internal.reference.ClassReference
+import com.squareup.anvil.compiler.internal.testing.simpleCodeGenerator as anvilSimpleCodeGenerator
+import com.tschuchort.compiletesting.JvmCompilationResult
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import java.io.File
+import java.nio.file.Files
+import org.intellij.lang.annotations.Language
+import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
+
+interface KhonshuCompilation {
+    fun compile(block: KhonshuCompilation.(JvmCompilationResult) -> Unit)
+    fun generatedFileFor(name: String): String
+
+    companion object {
+        fun simpleCompilation(
+            sources: List<Pair<String, String>>,
+            compilerPlugins: List<CompilerPluginRegistrar> = emptyList(),
+        ): KhonshuCompilation {
+            return SimpleKhonshuCompilation(
+                sources = sources,
+                compilerPlugins = compilerPlugins,
+            )
+        }
+
+        fun anvilCompilation(
+            @Language("kotlin") source: String,
+            fileName: String = "Test.kt",
+            compilerPlugins: List<CompilerPluginRegistrar> = emptyList(),
+            codeGenerators: List<CodeGenerator> = emptyList(),
+        ): KhonshuCompilation {
+            return AnvilKhonshuCompilation(
+                sources = listOf(fileName to source),
+                compilerPlugins = compilerPlugins,
+                codeGenerators = codeGenerators,
+            )
+        }
+    }
+}
+
+private class SimpleKhonshuCompilation(
+    sources: List<Pair<String, String>>,
+    compilerPlugins: List<CompilerPluginRegistrar>,
+) : KhonshuCompilation {
+    val compilation = KotlinCompilation().apply {
+        configure(sources, compilerPlugins)
+    }
+
+    override fun compile(block: KhonshuCompilation.(JvmCompilationResult) -> Unit) {
+        return block(compilation.compile())
+    }
+
+    override fun generatedFileFor(name: String): String {
+        throw UnsupportedOperationException("Simple compilation does not support generating files")
+    }
+}
+
+private class AnvilKhonshuCompilation(
+    sources: List<Pair<String, String>>,
+    compilerPlugins: List<CompilerPluginRegistrar>,
+    codeGenerators: List<CodeGenerator>,
+) : KhonshuCompilation {
+    val compilation = AnvilCompilation().apply {
+        configureAnvil(codeGenerators = codeGenerators)
+        kotlinCompilation.configure(sources, compilerPlugins)
+    }
+
+    override fun compile(block: KhonshuCompilation.(JvmCompilationResult) -> Unit) {
+        return block(compilation.kotlinCompilation.compile())
+    }
+
+    override fun generatedFileFor(name: String): String {
+        val path = "${compilation.kotlinCompilation.workingDir.absolutePath}/build/anvil/${name.testFileName()}"
+        return File(path).readText()
+    }
+}
+
+private fun KotlinCompilation.configure(
+    sourceFiles: List<Pair<String, String>>,
+    compilerPlugins: List<CompilerPluginRegistrar>,
+) {
+    compilerPluginRegistrars += compilerPlugins
+    jvmTarget = "11"
+    inheritClassPath = true
+    messageOutputStream = System.out // see diagnostics in real time
+    allWarningsAsErrors = true
+    sources = sourceFiles.map { (fileName, source) ->
+        sourceFile(fileName, source)
+    }
+}
+
+private fun KotlinCompilation.sourceFile(name: String, content: String): SourceFile {
+    val path = "${workingDir.absolutePath}/sources/src/main/kotlin/$name"
+    Files.createDirectories(File(path).parentFile!!.toPath())
+    return SourceFile.kotlin(path, content)
+}
+
+public fun String.testFileName(): String {
+    val path = substringBeforeLast("/")
+    val name = substringAfterLast("/")
+    return "$path/Khonshu$name"
+}
+
+public fun simpleCodeGenerator(block: (ClassReference) -> Unit): CodeGenerator {
+    return anvilSimpleCodeGenerator {
+        block(it)
+        null
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ anvil = "2.4.7"
 renderer = "0.13.0"
 kotlinpoet = "1.14.2"
 auto-service = "1.1.1"
+auto-value = "1.10.2"
 
 junit = "4.13.2"
 truth = "1.1.5"
@@ -96,6 +97,7 @@ renderer-connect = { module = "com.gabrielittner.renderer:connect", version.ref 
 kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinpoet" }
 auto-service-annotations = { module = "com.google.auto.service:auto-service-annotations", version.ref = "auto-service" }
 auto-service-compiler = { module = "com.google.auto.service:auto-service", version.ref = "auto-service" }
+auto-value = { module = "com.google.auto.value:auto-value", version.ref = "auto-value" }
 flowredux = { module = "com.freeletics.flowredux:flowredux", version = "1.2.0" }
 
 junit = { module = "junit:junit", version.ref = "junit" }


### PR DESCRIPTION
Creates a `KhonshuCompilation` abstraction that currently has 2 modes
- just compile the given code without any compiler plugins
- compile with anvil running

This basically matches the 2 tests we do in `TestHelper`. Now this is used also for the `AllSuperTypesTest`. This can be easily extended to add a ksp mode afterwards. 