### PR TITLE
use DestinationType in compiler

### DIFF
--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestCompose.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestCompose.kt
@@ -6,6 +6,7 @@ import com.freeletics.khonshu.codegen.AppScope
 import com.freeletics.khonshu.codegen.ComposableParameter
 import com.freeletics.khonshu.codegen.ComposeScreenData
 import com.freeletics.khonshu.codegen.Navigation
+import com.freeletics.khonshu.codegen.compose.DestinationType
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.INT
 import com.squareup.kotlinpoet.MAP
@@ -22,7 +23,7 @@ internal class FileGeneratorTestCompose {
     private val navigation = Navigation.Compose(
         route = ClassName("com.test", "TestRoute"),
         parentScopeIsRoute = true,
-        destinationType = "SCREEN",
+        destinationType = DestinationType.SCREEN,
         destinationScope = ClassName("com.test.destination", "TestDestinationScope"),
     )
 

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestComposeFragment.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestComposeFragment.kt
@@ -6,6 +6,7 @@ import com.freeletics.khonshu.codegen.AppScope
 import com.freeletics.khonshu.codegen.ComposableParameter
 import com.freeletics.khonshu.codegen.ComposeFragmentData
 import com.freeletics.khonshu.codegen.Navigation
+import com.freeletics.khonshu.codegen.fragment.DestinationType
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.INT
 import com.squareup.kotlinpoet.MAP
@@ -22,7 +23,7 @@ internal class FileGeneratorTestComposeFragment {
     private val navigation = Navigation.Fragment(
         route = ClassName("com.test", "TestRoute"),
         parentScopeIsRoute = true,
-        destinationType = "SCREEN",
+        destinationType = DestinationType.SCREEN,
         destinationScope = ClassName("com.test.destination", "TestDestinationScope"),
     )
 

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestRendererFragment.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestRendererFragment.kt
@@ -5,6 +5,7 @@ package com.freeletics.khonshu.codegen.codegen
 import com.freeletics.khonshu.codegen.AppScope
 import com.freeletics.khonshu.codegen.Navigation
 import com.freeletics.khonshu.codegen.RendererFragmentData
+import com.freeletics.khonshu.codegen.fragment.DestinationType
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.asClassName
 import org.intellij.lang.annotations.Language
@@ -15,7 +16,7 @@ internal class FileGeneratorTestRendererFragment {
     private val navigation = Navigation.Fragment(
         route = ClassName("com.test", "TestRoute"),
         parentScopeIsRoute = true,
-        destinationType = "SCREEN",
+        destinationType = DestinationType.SCREEN,
         destinationScope = ClassName("com.test.destination", "TestDestinationScope"),
     )
 

--- a/codegen-compiler/codegen-compiler.gradle.kts
+++ b/codegen-compiler/codegen-compiler.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     api(libs.kotlin.compiler)
     api(libs.anvil.compiler.api)
     api(libs.kotlinpoet)
+    api(projects.codegen)
     implementation(libs.anvil.annotations)
     implementation(libs.anvil.compiler.utils)
 

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/Data.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/Data.kt
@@ -6,6 +6,8 @@ import com.freeletics.khonshu.codegen.codegen.util.composeScreenDestination
 import com.freeletics.khonshu.codegen.codegen.util.fragmentDestination
 import com.freeletics.khonshu.codegen.codegen.util.fragmentDialogDestination
 import com.freeletics.khonshu.codegen.codegen.util.fragmentScreenDestination
+import com.freeletics.khonshu.codegen.compose.DestinationType
+import com.freeletics.khonshu.codegen.fragment.DestinationType as FragmentDestinationType
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.TypeName
@@ -95,30 +97,28 @@ public sealed interface Navigation {
     public data class Compose(
         override val route: ClassName,
         override val parentScopeIsRoute: Boolean,
-        private val destinationType: String,
+        private val destinationType: DestinationType,
         override val destinationScope: ClassName,
     ) : Navigation {
         override val destinationClass: ClassName = composeDestination
 
         override val destinationMethod: MemberName = when (destinationType) {
-            "SCREEN" -> composeScreenDestination
-            "OVERLAY" -> composeOverlayDestination
-            else -> throw IllegalArgumentException("Unknown destinationType $destinationType")
+            DestinationType.SCREEN -> composeScreenDestination
+            DestinationType.OVERLAY -> composeOverlayDestination
         }
     }
 
     public data class Fragment(
         override val route: ClassName,
         override val parentScopeIsRoute: Boolean,
-        private val destinationType: String,
+        private val destinationType: FragmentDestinationType,
         override val destinationScope: ClassName,
     ) : Navigation {
         override val destinationClass: ClassName = fragmentDestination
 
         override val destinationMethod: MemberName = when (destinationType) {
-            "SCREEN" -> fragmentScreenDestination
-            "DIALOG" -> fragmentDialogDestination
-            else -> throw IllegalArgumentException("Unknown destinationType $destinationType")
+            FragmentDestinationType.SCREEN -> fragmentScreenDestination
+            FragmentDestinationType.DIALOG -> fragmentDialogDestination
         }
     }
 }

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/anvil/ComposeParser.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/anvil/ComposeParser.kt
@@ -4,6 +4,7 @@ import com.freeletics.khonshu.codegen.ComposeScreenData
 import com.freeletics.khonshu.codegen.Navigation
 import com.freeletics.khonshu.codegen.codegen.util.codegenComposeDestinationFqName
 import com.freeletics.khonshu.codegen.codegen.util.composeFqName
+import com.freeletics.khonshu.codegen.compose.DestinationType
 import com.squareup.anvil.compiler.internal.reference.TopLevelFunctionReference
 import com.squareup.anvil.compiler.internal.reference.asClassName
 
@@ -35,7 +36,7 @@ internal fun TopLevelFunctionReference.toComposeScreenDestinationData(): Compose
     val navigation = Navigation.Compose(
         route = annotation.route,
         parentScopeIsRoute = annotation.parentScopeReference.extendsBaseRoute(),
-        destinationType = annotation.destinationType,
+        destinationType = DestinationType.valueOf(annotation.destinationType),
         destinationScope = annotation.destinationScope,
     )
 

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/anvil/FragmentParser.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/anvil/FragmentParser.kt
@@ -7,6 +7,7 @@ import com.freeletics.khonshu.codegen.codegen.util.composeFragmentDestinationFqN
 import com.freeletics.khonshu.codegen.codegen.util.composeFragmentFqName
 import com.freeletics.khonshu.codegen.codegen.util.rendererFragmentDestinationFqName
 import com.freeletics.khonshu.codegen.codegen.util.rendererFragmentFqName
+import com.freeletics.khonshu.codegen.fragment.DestinationType
 import com.squareup.anvil.compiler.internal.reference.ClassReference
 import com.squareup.anvil.compiler.internal.reference.TopLevelFunctionReference
 import com.squareup.anvil.compiler.internal.reference.asClassName
@@ -32,7 +33,7 @@ internal fun ClassReference.toRendererFragmentDestinationData(): RendererFragmen
     val navigation = Navigation.Fragment(
         route = annotation.route,
         parentScopeIsRoute = annotation.parentScopeReference.extendsBaseRoute(),
-        destinationType = annotation.destinationType,
+        destinationType = DestinationType.valueOf(annotation.destinationType),
         destinationScope = annotation.destinationScope,
     )
 
@@ -77,7 +78,7 @@ internal fun TopLevelFunctionReference.toComposeFragmentDestinationData(): Compo
     val navigation = Navigation.Fragment(
         route = annotation.route,
         parentScopeIsRoute = annotation.parentScopeReference.extendsBaseRoute(),
-        destinationType = annotation.destinationType,
+        destinationType = DestinationType.valueOf(annotation.destinationType),
         destinationScope = annotation.destinationScope,
     )
 


### PR DESCRIPTION
Now that the compiler can depend on the runtime we can directly use the `DestinationType` enum.