### PR TITLE
use ksp for auto service

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,13 +1,12 @@
 plugins {
     alias(libs.plugins.kotlin.android).apply(false)
     alias(libs.plugins.kotlin.jvm).apply(false)
-    alias(libs.plugins.kotlin.kapt).apply(false)
     alias(libs.plugins.kotlin.parcelize).apply(false)
     alias(libs.plugins.kotlin.multiplatform).apply(false)
     alias(libs.plugins.android.library).apply(false)
     alias(libs.plugins.dokka).apply(false)
     alias(libs.plugins.publish).apply(false)
-    alias(libs.plugins.gr8) apply (false)
+    alias(libs.plugins.gr8).apply(false)
     alias(libs.plugins.dependency.analysis).apply(false)
     alias(libs.plugins.bestpractices).apply(false)
 

--- a/codegen-compiler/codegen-compiler.gradle.kts
+++ b/codegen-compiler/codegen-compiler.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     alias(libs.plugins.fgp.jvm)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.fgp.publish)
     id("java-test-fixtures")
 }
@@ -21,8 +21,8 @@ dependencies {
     implementation(libs.anvil.annotations)
     implementation(libs.anvil.compiler.utils)
 
-    compileOnly(libs.auto.service.annotations)
-    kapt(libs.auto.service.compiler)
+    implementation(libs.auto.service.annotations)
+    ksp(libs.auto.service.compiler)
 
     testImplementation(libs.junit)
     testImplementation(libs.truth)

--- a/codegen-compiler/codegen-compiler.gradle.kts
+++ b/codegen-compiler/codegen-compiler.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     implementation(libs.anvil.annotations)
     implementation(libs.anvil.compiler.utils)
 
-    implementation(libs.auto.service.annotations)
+    compileOnly(libs.auto.service.annotations)
     ksp(libs.auto.service.compiler)
 
     testImplementation(libs.junit)

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,6 @@ org.gradle.parallel=true
 
 android.useAndroidX=true
 
-kapt.include.compile.classpath=false
-
 dependency.analysis.print.build.health=true
 
 fgp.android.namespacePrefix=com.freeletics.khonshu

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,8 +30,10 @@ inject = "1"
 dagger = "2.47"
 anvil = "2.4.7"
 renderer = "0.13.0"
+ksp = "1.9.0-1.0.12"
 kotlinpoet = "1.14.2"
 auto-service = "1.1.1"
+auto-service-ksp = "1.1.0"
 auto-value = "1.10.3"
 
 junit = "4.13.2"
@@ -96,7 +98,7 @@ renderer = { module = "com.gabrielittner.renderer:renderer", version.ref = "rend
 renderer-connect = { module = "com.gabrielittner.renderer:connect", version.ref = "renderer" }
 kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinpoet" }
 auto-service-annotations = { module = "com.google.auto.service:auto-service-annotations", version.ref = "auto-service" }
-auto-service-compiler = { module = "com.google.auto.service:auto-service", version.ref = "auto-service" }
+auto-service-compiler = { module = "dev.zacsweers.autoservice:auto-service-ksp", version.ref = "auto-service-ksp" }
 auto-value = { module = "com.google.auto.value:auto-value", version.ref = "auto-value" }
 flowredux = { module = "com.freeletics.flowredux:flowredux", version = "1.2.0" }
 
@@ -119,8 +121,8 @@ android-library = { id = "com.android.library", version.ref = "android-gradle" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 publish = { id = "com.vanniktech.maven.publish", version.ref = "publish" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 binarycompatibility = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "binarycompatibility" }

--- a/sample/simple/build.gradle.kts
+++ b/sample/simple/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.anvil).apply(false)
     alias(libs.plugins.dependency.analysis).apply(false)
     alias(libs.plugins.kotlin.android).apply(false)
+    alias(libs.plugins.ksp).apply(false)
 
     alias(libs.plugins.fgp.root)
 }

--- a/sample/simple/gradle/libs.versions.toml
+++ b/sample/simple/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ dagger = "2.47"
 dependency-analysis-gradle = "1.21.0"
 fgp = "0.5.0"
 khonshu = "0.16.1"
+ksp = "1.9.0-1.0.13"
 inject = "1"
 java-target = "11"
 java-toolchain = "17"
@@ -64,3 +65,4 @@ fgp-feature = { id = "com.freeletics.gradle.feature", version.ref = "fgp" }
 fgp-nav = { id = "com.freeletics.gradle.nav", version.ref = "fgp" }
 fgp-root = { id = "com.freeletics.gradle.root", version.ref = "fgp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
Instead of using kapt we can use the ksp version of auto service and don't need kapt at all anymore in this project.