### PR TITLE
support KSP in Fragment codegen

### DIFF
--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/TestHelper.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/TestHelper.kt
@@ -4,7 +4,6 @@ import androidx.compose.compiler.plugins.kotlin.ComposePluginRegistrar
 import com.freeletics.khonshu.codegen.BaseData
 import com.freeletics.khonshu.codegen.ComposeFragmentData
 import com.freeletics.khonshu.codegen.ComposeScreenData
-import com.freeletics.khonshu.codegen.FragmentData
 import com.freeletics.khonshu.codegen.KhonshuCompilation.Companion.anvilCompilation
 import com.freeletics.khonshu.codegen.KhonshuCompilation.Companion.kspCompilation
 import com.freeletics.khonshu.codegen.KhonshuCompilation.Companion.simpleCompilation
@@ -17,9 +16,7 @@ import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
 internal fun test(data: BaseData, fileName: String, source: String, expectedCode: String) {
     compile(fileName = fileName, source = source, data = data, expectedCode = expectedCode)
     compileWithAnvil(fileName = fileName, source = source, expectedCode = expectedCode)
-    if (data !is FragmentData) {
-        compileWithKsp(fileName = fileName, source = source, expectedCode = expectedCode)
-    }
+    compileWithKsp(fileName = fileName, source = source, expectedCode = expectedCode)
 }
 
 private fun compile(fileName: String, source: String, data: BaseData, expectedCode: String) {

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/KhonshuSymbolProcessor.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/KhonshuSymbolProcessor.kt
@@ -3,8 +3,16 @@ package com.freeletics.khonshu.codegen
 import com.freeletics.khonshu.codegen.codegen.FileGenerator
 import com.freeletics.khonshu.codegen.compose.ComposeDestination
 import com.freeletics.khonshu.codegen.compose.ComposeScreen
+import com.freeletics.khonshu.codegen.fragment.ComposeDestination as ComposeFragmentDestination
+import com.freeletics.khonshu.codegen.fragment.ComposeFragment
+import com.freeletics.khonshu.codegen.fragment.RendererDestination
+import com.freeletics.khonshu.codegen.fragment.RendererFragment
+import com.freeletics.khonshu.codegen.parser.ksp.toComposeFragmentData
+import com.freeletics.khonshu.codegen.parser.ksp.toComposeFragmentDestinationData
 import com.freeletics.khonshu.codegen.parser.ksp.toComposeScreenData
 import com.freeletics.khonshu.codegen.parser.ksp.toComposeScreenDestinationData
+import com.freeletics.khonshu.codegen.parser.ksp.toRendererFragmentData
+import com.freeletics.khonshu.codegen.parser.ksp.toRendererFragmentDestinationData
 import com.google.auto.service.AutoService
 import com.google.devtools.ksp.containingFile
 import com.google.devtools.ksp.getAnnotationsByType
@@ -39,6 +47,18 @@ public class KhonshuSymbolProcessor(
         }
         resolver.generateCodeForAnnotation<KSFunctionDeclaration, ComposeDestination> {
             toComposeScreenDestinationData(it, resolver, logger)
+        }
+        resolver.generateCodeForAnnotation<KSClassDeclaration, RendererFragment> {
+            toRendererFragmentData(it, logger)
+        }
+        resolver.generateCodeForAnnotation<KSClassDeclaration, RendererDestination> {
+            toRendererFragmentDestinationData(it, resolver, logger)
+        }
+        resolver.generateCodeForAnnotation<KSFunctionDeclaration, ComposeFragment> {
+            toComposeFragmentData(it, resolver, logger)
+        }
+        resolver.generateCodeForAnnotation<KSFunctionDeclaration, ComposeFragmentDestination> {
+            toComposeFragmentDestinationData(it, resolver, logger)
         }
         return emptyList()
     }

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/ksp/FragmentParser.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/ksp/FragmentParser.kt
@@ -1,0 +1,105 @@
+package com.freeletics.khonshu.codegen.parser.ksp
+
+import com.freeletics.khonshu.codegen.ComposeFragmentData
+import com.freeletics.khonshu.codegen.Navigation
+import com.freeletics.khonshu.codegen.RendererFragmentData
+import com.freeletics.khonshu.codegen.fragment.ComposeDestination
+import com.freeletics.khonshu.codegen.fragment.ComposeFragment
+import com.freeletics.khonshu.codegen.fragment.RendererDestination
+import com.freeletics.khonshu.codegen.fragment.RendererFragment
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.squareup.kotlinpoet.asClassName
+
+internal fun KSClassDeclaration.toRendererFragmentData(
+    annotation: RendererFragment,
+    logger: KSPLogger,
+): RendererFragmentData? {
+    return RendererFragmentData(
+        baseName = simpleName.asString(),
+        packageName = packageName.asString(),
+        scope = annotation.scope.asClassName(),
+        parentScope = annotation.parentScope.asClassName(),
+        stateMachine = annotation.stateMachine.asClassName(),
+        fragmentBaseClass = annotation.fragmentBaseClass.asClassName(),
+        factory = findRendererFactory(logger) ?: return null,
+        navigation = null,
+    )
+}
+
+internal fun KSClassDeclaration.toRendererFragmentDestinationData(
+    annotation: RendererDestination,
+    resolver: Resolver,
+    logger: KSPLogger,
+): RendererFragmentData? {
+    val navigation = Navigation.Fragment(
+        route = annotation.route.asClassName(),
+        parentScopeIsRoute = annotation.parentScope.extendsBaseRoute(resolver),
+        destinationType = annotation.destinationType,
+        destinationScope = annotation.destinationScope.asClassName(),
+    )
+
+    return RendererFragmentData(
+        baseName = simpleName.asString(),
+        packageName = packageName.asString(),
+        scope = annotation.route.asClassName(),
+        parentScope = annotation.parentScope.asClassName(),
+        stateMachine = annotation.stateMachine.asClassName(),
+        fragmentBaseClass = annotation.fragmentBaseClass.asClassName(),
+        factory = findRendererFactory(logger) ?: return null,
+        navigation = navigation,
+    )
+}
+
+internal fun KSFunctionDeclaration.toComposeFragmentData(
+    annotation: ComposeFragment,
+    resolver: Resolver,
+    logger: KSPLogger,
+): ComposeFragmentData? {
+    val (stateParameter, actionParameter) = annotation.stateMachine.stateMachineParameters(resolver, logger)
+        ?: return null
+
+    return ComposeFragmentData(
+        baseName = simpleName.asString(),
+        packageName = packageName.asString(),
+        scope = annotation.scope.asClassName(),
+        parentScope = annotation.parentScope.asClassName(),
+        stateMachine = annotation.stateMachine.asClassName(),
+        fragmentBaseClass = annotation.fragmentBaseClass.asClassName(),
+        navigation = null,
+        composableParameter = getInjectedParameters(stateParameter, actionParameter),
+        stateParameter = this.getParameterWithType(stateParameter),
+        sendActionParameter = this.getParameterWithType(actionParameter),
+    )
+}
+
+internal fun KSFunctionDeclaration.toComposeFragmentDestinationData(
+    annotation: ComposeDestination,
+    resolver: Resolver,
+    logger: KSPLogger,
+): ComposeFragmentData? {
+    val (stateParameter, actionParameter) = annotation.stateMachine.stateMachineParameters(resolver, logger)
+        ?: return null
+
+    val navigation = Navigation.Fragment(
+        route = annotation.route.asClassName(),
+        parentScopeIsRoute = annotation.parentScope.extendsBaseRoute(resolver),
+        destinationType = annotation.destinationType,
+        destinationScope = annotation.destinationScope.asClassName(),
+    )
+
+    return ComposeFragmentData(
+        baseName = simpleName.asString(),
+        packageName = packageName.asString(),
+        scope = annotation.route.asClassName(),
+        parentScope = annotation.parentScope.asClassName(),
+        stateMachine = annotation.stateMachine.asClassName(),
+        fragmentBaseClass = annotation.fragmentBaseClass.asClassName(),
+        navigation = navigation,
+        composableParameter = getInjectedParameters(stateParameter, actionParameter),
+        stateParameter = this.getParameterWithType(stateParameter),
+        sendActionParameter = this.getParameterWithType(actionParameter),
+    )
+}


### PR DESCRIPTION
Adds the parts of codegen to KSP that #504 omitted. With this everything can be generated through KSP.