### PR TITLE
parse annotation parameters indirectly

### DIFF
--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/KhonshuSymbolProcessor.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/KhonshuSymbolProcessor.kt
@@ -15,7 +15,6 @@ import com.freeletics.khonshu.codegen.parser.ksp.toRendererFragmentData
 import com.freeletics.khonshu.codegen.parser.ksp.toRendererFragmentDestinationData
 import com.google.auto.service.AutoService
 import com.google.devtools.ksp.containingFile
-import com.google.devtools.ksp.getAnnotationsByType
 import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/ksp/CommonParser.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/ksp/CommonParser.kt
@@ -41,14 +41,14 @@ internal val KSAnnotation.destinationType: String
     get() = (findArgument("destinationType").value as KSType).declaration.simpleName.asString()
 
 internal val KSAnnotation.destinationScope: ClassName
-    get() =  (findArgument("destinationScope").value as KSType).toClassName()
+    get() = (findArgument("destinationScope").value as KSType).toClassName()
 
 internal val KSAnnotation.fragmentBaseClass: ClassName
     get() = (findArgument("fragmentBaseClass").value as KSType).toClassName()
 
 private fun KSAnnotation.findArgument(name: String): KSValueArgument {
-    return arguments.find { it.name?.asString() == name } ?:
-        defaultArguments.find { it.name?.asString() == name }!!
+    return arguments.find { it.name?.asString() == name }
+        ?: defaultArguments.find { it.name?.asString() == name }!!
 }
 
 internal fun KSFunctionDeclaration.getParameterWithType(expectedType: TypeName): ComposableParameter? {

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/ksp/ComposeParser.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/ksp/ComposeParser.kt
@@ -4,13 +4,15 @@ import com.freeletics.khonshu.codegen.ComposeScreenData
 import com.freeletics.khonshu.codegen.Navigation
 import com.freeletics.khonshu.codegen.compose.ComposeDestination
 import com.freeletics.khonshu.codegen.compose.ComposeScreen
+import com.freeletics.khonshu.codegen.compose.DestinationType
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.squareup.kotlinpoet.asClassName
 
 internal fun KSFunctionDeclaration.toComposeScreenData(
-    annotation: ComposeScreen,
+    annotation: KSAnnotation,
     resolver: Resolver,
     logger: KSPLogger,
 ): ComposeScreenData? {
@@ -20,9 +22,9 @@ internal fun KSFunctionDeclaration.toComposeScreenData(
     return ComposeScreenData(
         baseName = simpleName.asString(),
         packageName = packageName.asString(),
-        scope = annotation.scope.asClassName(),
-        parentScope = annotation.parentScope.asClassName(),
-        stateMachine = annotation.stateMachine.asClassName(),
+        scope = annotation.scope,
+        parentScope = annotation.parentScope,
+        stateMachine = annotation.stateMachine,
         navigation = null,
         composableParameter = getInjectedParameters(stateParameter, actionParameter),
         stateParameter = getParameterWithType(stateParameter),
@@ -31,7 +33,7 @@ internal fun KSFunctionDeclaration.toComposeScreenData(
 }
 
 internal fun KSFunctionDeclaration.toComposeScreenDestinationData(
-    annotation: ComposeDestination,
+    annotation: KSAnnotation,
     resolver: Resolver,
     logger: KSPLogger,
 ): ComposeScreenData? {
@@ -39,18 +41,18 @@ internal fun KSFunctionDeclaration.toComposeScreenDestinationData(
         ?: return null
 
     val navigation = Navigation.Compose(
-        route = annotation.route.asClassName(),
+        route = annotation.route,
         parentScopeIsRoute = annotation.parentScope.extendsBaseRoute(resolver),
-        destinationType = annotation.destinationType,
-        destinationScope = annotation.destinationScope.asClassName(),
+        destinationType = DestinationType.valueOf(annotation.destinationType),
+        destinationScope = annotation.destinationScope,
     )
 
     return ComposeScreenData(
         baseName = simpleName.asString(),
         packageName = packageName.asString(),
-        scope = annotation.route.asClassName(),
-        parentScope = annotation.parentScope.asClassName(),
-        stateMachine = annotation.stateMachine.asClassName(),
+        scope = annotation.route,
+        parentScope = annotation.parentScope,
+        stateMachine = annotation.stateMachine,
         navigation = navigation,
         composableParameter = getInjectedParameters(stateParameter, actionParameter),
         stateParameter = this.getParameterWithType(stateParameter),

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/ksp/ComposeParser.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/ksp/ComposeParser.kt
@@ -2,14 +2,11 @@ package com.freeletics.khonshu.codegen.parser.ksp
 
 import com.freeletics.khonshu.codegen.ComposeScreenData
 import com.freeletics.khonshu.codegen.Navigation
-import com.freeletics.khonshu.codegen.compose.ComposeDestination
-import com.freeletics.khonshu.codegen.compose.ComposeScreen
 import com.freeletics.khonshu.codegen.compose.DestinationType
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
-import com.squareup.kotlinpoet.asClassName
 
 internal fun KSFunctionDeclaration.toComposeScreenData(
     annotation: KSAnnotation,

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/ksp/FragmentParser.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/ksp/FragmentParser.kt
@@ -3,58 +3,55 @@ package com.freeletics.khonshu.codegen.parser.ksp
 import com.freeletics.khonshu.codegen.ComposeFragmentData
 import com.freeletics.khonshu.codegen.Navigation
 import com.freeletics.khonshu.codegen.RendererFragmentData
-import com.freeletics.khonshu.codegen.fragment.ComposeDestination
-import com.freeletics.khonshu.codegen.fragment.ComposeFragment
-import com.freeletics.khonshu.codegen.fragment.RendererDestination
-import com.freeletics.khonshu.codegen.fragment.RendererFragment
+import com.freeletics.khonshu.codegen.fragment.DestinationType
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
-import com.squareup.kotlinpoet.asClassName
 
 internal fun KSClassDeclaration.toRendererFragmentData(
-    annotation: RendererFragment,
+    annotation: KSAnnotation,
     logger: KSPLogger,
 ): RendererFragmentData? {
     return RendererFragmentData(
         baseName = simpleName.asString(),
         packageName = packageName.asString(),
-        scope = annotation.scope.asClassName(),
-        parentScope = annotation.parentScope.asClassName(),
-        stateMachine = annotation.stateMachine.asClassName(),
-        fragmentBaseClass = annotation.fragmentBaseClass.asClassName(),
+        scope = annotation.scope,
+        parentScope = annotation.parentScope,
+        stateMachine = annotation.stateMachine,
+        fragmentBaseClass = annotation.fragmentBaseClass,
         factory = findRendererFactory(logger) ?: return null,
         navigation = null,
     )
 }
 
 internal fun KSClassDeclaration.toRendererFragmentDestinationData(
-    annotation: RendererDestination,
+    annotation: KSAnnotation,
     resolver: Resolver,
     logger: KSPLogger,
 ): RendererFragmentData? {
     val navigation = Navigation.Fragment(
-        route = annotation.route.asClassName(),
+        route = annotation.route,
         parentScopeIsRoute = annotation.parentScope.extendsBaseRoute(resolver),
-        destinationType = annotation.destinationType,
-        destinationScope = annotation.destinationScope.asClassName(),
+        destinationType = DestinationType.valueOf(annotation.destinationType),
+        destinationScope = annotation.destinationScope,
     )
 
     return RendererFragmentData(
         baseName = simpleName.asString(),
         packageName = packageName.asString(),
-        scope = annotation.route.asClassName(),
-        parentScope = annotation.parentScope.asClassName(),
-        stateMachine = annotation.stateMachine.asClassName(),
-        fragmentBaseClass = annotation.fragmentBaseClass.asClassName(),
+        scope = annotation.route,
+        parentScope = annotation.parentScope,
+        stateMachine = annotation.stateMachine,
+        fragmentBaseClass = annotation.fragmentBaseClass,
         factory = findRendererFactory(logger) ?: return null,
         navigation = navigation,
     )
 }
 
 internal fun KSFunctionDeclaration.toComposeFragmentData(
-    annotation: ComposeFragment,
+    annotation: KSAnnotation,
     resolver: Resolver,
     logger: KSPLogger,
 ): ComposeFragmentData? {
@@ -64,10 +61,10 @@ internal fun KSFunctionDeclaration.toComposeFragmentData(
     return ComposeFragmentData(
         baseName = simpleName.asString(),
         packageName = packageName.asString(),
-        scope = annotation.scope.asClassName(),
-        parentScope = annotation.parentScope.asClassName(),
-        stateMachine = annotation.stateMachine.asClassName(),
-        fragmentBaseClass = annotation.fragmentBaseClass.asClassName(),
+        scope = annotation.scope,
+        parentScope = annotation.parentScope,
+        stateMachine = annotation.stateMachine,
+        fragmentBaseClass = annotation.fragmentBaseClass,
         navigation = null,
         composableParameter = getInjectedParameters(stateParameter, actionParameter),
         stateParameter = this.getParameterWithType(stateParameter),
@@ -76,7 +73,7 @@ internal fun KSFunctionDeclaration.toComposeFragmentData(
 }
 
 internal fun KSFunctionDeclaration.toComposeFragmentDestinationData(
-    annotation: ComposeDestination,
+    annotation: KSAnnotation,
     resolver: Resolver,
     logger: KSPLogger,
 ): ComposeFragmentData? {
@@ -84,19 +81,19 @@ internal fun KSFunctionDeclaration.toComposeFragmentDestinationData(
         ?: return null
 
     val navigation = Navigation.Fragment(
-        route = annotation.route.asClassName(),
+        route = annotation.route,
         parentScopeIsRoute = annotation.parentScope.extendsBaseRoute(resolver),
-        destinationType = annotation.destinationType,
-        destinationScope = annotation.destinationScope.asClassName(),
+        destinationType = DestinationType.valueOf(annotation.destinationType),
+        destinationScope = annotation.destinationScope,
     )
 
     return ComposeFragmentData(
         baseName = simpleName.asString(),
         packageName = packageName.asString(),
-        scope = annotation.route.asClassName(),
-        parentScope = annotation.parentScope.asClassName(),
-        stateMachine = annotation.stateMachine.asClassName(),
-        fragmentBaseClass = annotation.fragmentBaseClass.asClassName(),
+        scope = annotation.route,
+        parentScope = annotation.parentScope,
+        stateMachine = annotation.stateMachine,
+        fragmentBaseClass = annotation.fragmentBaseClass,
         navigation = navigation,
         composableParameter = getInjectedParameters(stateParameter, actionParameter),
         stateParameter = this.getParameterWithType(stateParameter),


### PR DESCRIPTION
It turns out that we need to manually parse parameters from `KSAnnotation` instead of using `getAnnotationsByType` to get an instance of the annotation after all. The latter only works for primitive values and for classes that have already been compiled (so classes coming from dependencies). This is why it works in tests because we use an already compile state machine class but it wouldn't work in real projects where the state machine is defined in the same module as the annotated composable/renderer.

Can be tested by setting the Gradle property `fgp.kotlin.khonshuKsp=true` to enable KSP for the sample project, e.g. `./gradlew -p sample/simple/ assemble -Pfgp.kotlin.khonshuKsp=true`