### PR TITLE
add NavHostActivityData and basic codegen

### DIFF
--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestNavHostActivity.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestNavHostActivity.kt
@@ -1,0 +1,654 @@
+@file:Suppress("RedundantVisibilityModifier", "TestFunctionName")
+
+package com.freeletics.khonshu.codegen.codegen
+
+import com.freeletics.khonshu.codegen.ActivityScope
+import com.freeletics.khonshu.codegen.AppScope
+import com.freeletics.khonshu.codegen.ComposableParameter
+import com.freeletics.khonshu.codegen.NavHostActivityData
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.INT
+import com.squareup.kotlinpoet.MAP
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.SET
+import com.squareup.kotlinpoet.STRING
+import com.squareup.kotlinpoet.UNIT
+import com.squareup.kotlinpoet.asClassName
+import org.intellij.lang.annotations.Language
+import org.junit.Test
+
+internal class FileGeneratorTestNavHostActivity {
+
+    private val data = NavHostActivityData(
+        baseName = "Test",
+        packageName = "com.test",
+        scope = ClassName("com.test", "TestScreen"),
+        parentScope = ClassName("com.test.parent", "TestParentScope"),
+        stateMachine = ClassName("com.test", "TestStateMachine"),
+        stateParameter = ComposableParameter("state", ClassName("com.test", "TestState")),
+        sendActionParameter = ComposableParameter(
+            "sendAction",
+            Function1::class.asClassName().parameterizedBy(
+                ClassName("com.test", "TestAction"),
+                UNIT,
+            ),
+        ),
+        composableParameter = emptyList(),
+    )
+
+    @Test
+    fun `generates code for NavHostActivityData`() {
+        @Language("kotlin")
+        val source = """
+            package com.test
+
+            import androidx.activity.ComponentActivity
+            import androidx.compose.runtime.Composable
+            import com.freeletics.khonshu.codegen.compose.NavHostActivity
+            import com.freeletics.khonshu.navigation.BaseRoute
+            import com.freeletics.khonshu.navigation.DeepLinkHandler
+            import com.freeletics.khonshu.navigation.NavRoot
+            import com.freeletics.khonshu.navigation.compose.NavDestination
+            import com.test.parent.TestParentScope
+
+            @NavHostActivity(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+              stateMachine = TestStateMachine::class,
+              activityBaseClass = ComponentActivity::class,
+            )
+            @Composable
+            @Suppress("unused_parameter")
+            public fun Test(
+              state: TestState,
+              sendAction: (TestAction) -> Unit,
+            ) {
+            }
+        """.trimIndent()
+
+        @Language("kotlin")
+        val expected = """
+            package com.test
+
+            import android.os.Bundle
+            import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.remember
+            import androidx.compose.runtime.rememberCoroutineScope
+            import androidx.lifecycle.SavedStateHandle
+            import com.freeletics.khonshu.codegen.ForScope
+            import com.freeletics.khonshu.codegen.ScopeTo
+            import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
+            import com.freeletics.khonshu.codegen.`internal`.asComposeState
+            import com.squareup.anvil.annotations.ContributesSubcomponent
+            import com.squareup.anvil.annotations.ContributesTo
+            import com.test.parent.TestParentScope
+            import dagger.BindsInstance
+            import dagger.Module
+            import dagger.multibindings.Multibinds
+            import java.io.Closeable
+            import kotlin.OptIn
+            import kotlin.collections.Set
+            import kotlinx.coroutines.launch
+
+            @OptIn(InternalCodegenApi::class)
+            @ScopeTo(TestScreen::class)
+            @ContributesSubcomponent(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+            )
+            public interface KhonshuTestComponent : Closeable {
+              public val testStateMachine: TestStateMachine
+
+              @get:ForScope(TestScreen::class)
+              public val closeables: Set<Closeable>
+
+              override fun close() {
+                closeables.forEach {
+                  it.close()
+                }
+              }
+
+              @ContributesSubcomponent.Factory
+              public interface Factory {
+                public fun create(@BindsInstance @ForScope(TestScreen::class)
+                    savedStateHandle: SavedStateHandle, @BindsInstance @ForScope(TestScreen::class)
+                    arguments: Bundle): KhonshuTestComponent
+              }
+
+              @ContributesTo(TestParentScope::class)
+              public interface ParentComponent {
+                public fun khonshuTestComponentFactory(): Factory
+              }
+            }
+
+            @Module
+            @ContributesTo(TestScreen::class)
+            public interface KhonshuTestModule {
+              @Multibinds
+              @ForScope(TestScreen::class)
+              public fun bindCloseables(): Set<Closeable>
+            }
+
+            @Composable
+            @OptIn(InternalCodegenApi::class)
+            private fun KhonshuTest(component: KhonshuTestComponent) {
+              val stateMachine = remember { component.testStateMachine }
+              val state = stateMachine.asComposeState()
+              val currentState = state.value
+              if (currentState != null) {
+                val scope = rememberCoroutineScope()
+                Test(
+                  state = currentState,
+                  sendAction = { scope.launch { stateMachine.dispatch(it) } },
+                )
+              }
+            }
+
+        """.trimIndent()
+
+        test(data, "com/test/Test.kt", source, expected)
+    }
+
+    @Test
+    fun `generates code for NavHostActivityData with default values`() {
+        val withDefaultValues = data.copy(
+            scope = ActivityScope::class.asClassName(),
+            parentScope = AppScope::class.asClassName(),
+        )
+
+        @Language("kotlin")
+        val source = """
+            package com.test
+
+            import androidx.activity.ComponentActivity
+            import androidx.compose.runtime.Composable
+            import com.freeletics.khonshu.codegen.ActivityScope
+            import com.freeletics.khonshu.codegen.compose.NavHostActivity
+            import com.freeletics.khonshu.navigation.BaseRoute
+            import com.freeletics.khonshu.navigation.DeepLinkHandler
+            import com.freeletics.khonshu.navigation.NavRoot
+
+            @NavHostActivity(
+              stateMachine = TestStateMachine::class,
+              activityBaseClass = ComponentActivity::class,
+            )
+            @Composable
+            @Suppress("unused_parameter")
+            public fun Test(
+              state: TestState,
+              sendAction: (TestAction) -> Unit,
+            ) {
+            }
+        """.trimIndent()
+
+        @Language("kotlin")
+        val expected = """
+            package com.test
+
+            import android.os.Bundle
+            import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.remember
+            import androidx.compose.runtime.rememberCoroutineScope
+            import androidx.lifecycle.SavedStateHandle
+            import com.freeletics.khonshu.codegen.ActivityScope
+            import com.freeletics.khonshu.codegen.AppScope
+            import com.freeletics.khonshu.codegen.ForScope
+            import com.freeletics.khonshu.codegen.ScopeTo
+            import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
+            import com.freeletics.khonshu.codegen.`internal`.asComposeState
+            import com.squareup.anvil.annotations.ContributesSubcomponent
+            import com.squareup.anvil.annotations.ContributesTo
+            import dagger.BindsInstance
+            import dagger.Module
+            import dagger.multibindings.Multibinds
+            import java.io.Closeable
+            import kotlin.OptIn
+            import kotlin.collections.Set
+            import kotlinx.coroutines.launch
+
+            @OptIn(InternalCodegenApi::class)
+            @ScopeTo(ActivityScope::class)
+            @ContributesSubcomponent(
+              scope = ActivityScope::class,
+              parentScope = AppScope::class,
+            )
+            public interface KhonshuTestComponent : Closeable {
+              public val testStateMachine: TestStateMachine
+
+              @get:ForScope(ActivityScope::class)
+              public val closeables: Set<Closeable>
+
+              override fun close() {
+                closeables.forEach {
+                  it.close()
+                }
+              }
+
+              @ContributesSubcomponent.Factory
+              public interface Factory {
+                public fun create(@BindsInstance @ForScope(ActivityScope::class)
+                    savedStateHandle: SavedStateHandle, @BindsInstance @ForScope(ActivityScope::class)
+                    arguments: Bundle): KhonshuTestComponent
+              }
+
+              @ContributesTo(AppScope::class)
+              public interface ParentComponent {
+                public fun khonshuTestComponentFactory(): Factory
+              }
+            }
+
+            @Module
+            @ContributesTo(ActivityScope::class)
+            public interface KhonshuTestModule {
+              @Multibinds
+              @ForScope(ActivityScope::class)
+              public fun bindCloseables(): Set<Closeable>
+            }
+
+            @Composable
+            @OptIn(InternalCodegenApi::class)
+            private fun KhonshuTest(component: KhonshuTestComponent) {
+              val stateMachine = remember { component.testStateMachine }
+              val state = stateMachine.asComposeState()
+              val currentState = state.value
+              if (currentState != null) {
+                val scope = rememberCoroutineScope()
+                Test(
+                  state = currentState,
+                  sendAction = { scope.launch { stateMachine.dispatch(it) } },
+                )
+              }
+            }
+
+        """.trimIndent()
+
+        test(withDefaultValues, "com/test/Test.kt", source, expected)
+    }
+
+    @Test
+    fun `generates code for NavHostActivityData with Composable Dependencies`() {
+        val withInjectedParameters = data.copy(
+            baseName = "Test2",
+            composableParameter = listOf(
+                ComposableParameter(
+                    name = "testClass",
+                    typeName = ClassName("com.test", "TestClass"),
+                ),
+                ComposableParameter(
+                    name = "test",
+                    typeName = ClassName("com.test.other", "TestClass2"),
+                ),
+                ComposableParameter(
+                    name = "testSet",
+                    typeName = SET.parameterizedBy(STRING),
+                ),
+                ComposableParameter(
+                    name = "testMap",
+                    typeName = MAP.parameterizedBy(STRING, INT),
+                ),
+            ),
+        )
+
+        @Language("kotlin")
+        val source = """
+            package com.test
+
+            import androidx.activity.ComponentActivity
+            import androidx.compose.runtime.Composable
+            import com.freeletics.khonshu.codegen.compose.NavHostActivity
+            import com.freeletics.khonshu.navigation.BaseRoute
+            import com.freeletics.khonshu.navigation.DeepLinkHandler
+            import com.freeletics.khonshu.navigation.NavRoot
+            import com.freeletics.khonshu.navigation.compose.NavDestination
+            import com.test.other.TestClass2
+            import com.test.parent.TestParentScope
+
+            @NavHostActivity(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+              stateMachine = TestStateMachine::class,
+              activityBaseClass = ComponentActivity::class,
+            )
+            @Composable
+            @Suppress("unused_parameter")
+            public fun Test2(
+                state: TestState,
+                sendAction: (TestAction) -> Unit,
+                testClass: TestClass,
+                test: TestClass2,
+                testSet: Set<String>,
+                testMap: Map<String, Int>,
+            ) {
+            }
+        """.trimIndent()
+
+        @Language("kotlin")
+        val expected = """
+            package com.test
+
+            import android.os.Bundle
+            import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.remember
+            import androidx.compose.runtime.rememberCoroutineScope
+            import androidx.lifecycle.SavedStateHandle
+            import com.freeletics.khonshu.codegen.ForScope
+            import com.freeletics.khonshu.codegen.ScopeTo
+            import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
+            import com.freeletics.khonshu.codegen.`internal`.asComposeState
+            import com.squareup.anvil.annotations.ContributesSubcomponent
+            import com.squareup.anvil.annotations.ContributesTo
+            import com.test.other.TestClass2
+            import com.test.parent.TestParentScope
+            import dagger.BindsInstance
+            import dagger.Module
+            import dagger.multibindings.Multibinds
+            import java.io.Closeable
+            import kotlin.Int
+            import kotlin.OptIn
+            import kotlin.String
+            import kotlin.collections.Map
+            import kotlin.collections.Set
+            import kotlinx.coroutines.launch
+
+            @OptIn(InternalCodegenApi::class)
+            @ScopeTo(TestScreen::class)
+            @ContributesSubcomponent(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+            )
+            public interface KhonshuTest2Component : Closeable {
+              public val testStateMachine: TestStateMachine
+
+              public val testClass: TestClass
+
+              public val test: TestClass2
+
+              public val testSet: Set<String>
+
+              public val testMap: Map<String, Int>
+
+              @get:ForScope(TestScreen::class)
+              public val closeables: Set<Closeable>
+
+              override fun close() {
+                closeables.forEach {
+                  it.close()
+                }
+              }
+
+              @ContributesSubcomponent.Factory
+              public interface Factory {
+                public fun create(@BindsInstance @ForScope(TestScreen::class)
+                    savedStateHandle: SavedStateHandle, @BindsInstance @ForScope(TestScreen::class)
+                    arguments: Bundle): KhonshuTest2Component
+              }
+
+              @ContributesTo(TestParentScope::class)
+              public interface ParentComponent {
+                public fun khonshuTest2ComponentFactory(): Factory
+              }
+            }
+
+            @Module
+            @ContributesTo(TestScreen::class)
+            public interface KhonshuTest2Module {
+              @Multibinds
+              @ForScope(TestScreen::class)
+              public fun bindCloseables(): Set<Closeable>
+            }
+
+            @Composable
+            @OptIn(InternalCodegenApi::class)
+            private fun KhonshuTest2(component: KhonshuTest2Component) {
+              val testClass = remember { component.testClass }
+              val test = remember { component.test }
+              val testSet = remember { component.testSet }
+              val testMap = remember { component.testMap }
+              val stateMachine = remember { component.testStateMachine }
+              val state = stateMachine.asComposeState()
+              val currentState = state.value
+              if (currentState != null) {
+                val scope = rememberCoroutineScope()
+                Test2(
+                  testClass = testClass,
+                  test = test,
+                  testSet = testSet,
+                  testMap = testMap,
+                  state = currentState,
+                  sendAction = { scope.launch { stateMachine.dispatch(it) } },
+                )
+              }
+            }
+
+        """.trimIndent()
+
+        test(withInjectedParameters, "com/test/Test2.kt", source, expected)
+    }
+
+    @Test
+    fun `generates code for NavHostActivityData without sendAction`() {
+        val withoutSendAction = data.copy(
+            sendActionParameter = null,
+        )
+
+        @Language("kotlin")
+        val source = """
+            package com.test
+
+            import androidx.activity.ComponentActivity
+            import androidx.compose.runtime.Composable
+            import com.freeletics.khonshu.codegen.compose.NavHostActivity
+            import com.freeletics.khonshu.navigation.BaseRoute
+            import com.freeletics.khonshu.navigation.DeepLinkHandler
+            import com.freeletics.khonshu.navigation.NavRoot
+            import com.freeletics.khonshu.navigation.compose.NavDestination
+            import com.test.parent.TestParentScope
+
+            @NavHostActivity(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+              stateMachine = TestStateMachine::class,
+              activityBaseClass = ComponentActivity::class,
+            )
+            @Composable
+            @Suppress("unused_parameter")
+            public fun Test(
+              state: TestState,
+            ) {
+            }
+        """.trimIndent()
+
+        @Language("kotlin")
+        val expected = """
+            package com.test
+
+            import android.os.Bundle
+            import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.remember
+            import androidx.lifecycle.SavedStateHandle
+            import com.freeletics.khonshu.codegen.ForScope
+            import com.freeletics.khonshu.codegen.ScopeTo
+            import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
+            import com.freeletics.khonshu.codegen.`internal`.asComposeState
+            import com.squareup.anvil.annotations.ContributesSubcomponent
+            import com.squareup.anvil.annotations.ContributesTo
+            import com.test.parent.TestParentScope
+            import dagger.BindsInstance
+            import dagger.Module
+            import dagger.multibindings.Multibinds
+            import java.io.Closeable
+            import kotlin.OptIn
+            import kotlin.collections.Set
+
+            @OptIn(InternalCodegenApi::class)
+            @ScopeTo(TestScreen::class)
+            @ContributesSubcomponent(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+            )
+            public interface KhonshuTestComponent : Closeable {
+              public val testStateMachine: TestStateMachine
+
+              @get:ForScope(TestScreen::class)
+              public val closeables: Set<Closeable>
+
+              override fun close() {
+                closeables.forEach {
+                  it.close()
+                }
+              }
+
+              @ContributesSubcomponent.Factory
+              public interface Factory {
+                public fun create(@BindsInstance @ForScope(TestScreen::class)
+                    savedStateHandle: SavedStateHandle, @BindsInstance @ForScope(TestScreen::class)
+                    arguments: Bundle): KhonshuTestComponent
+              }
+
+              @ContributesTo(TestParentScope::class)
+              public interface ParentComponent {
+                public fun khonshuTestComponentFactory(): Factory
+              }
+            }
+
+            @Module
+            @ContributesTo(TestScreen::class)
+            public interface KhonshuTestModule {
+              @Multibinds
+              @ForScope(TestScreen::class)
+              public fun bindCloseables(): Set<Closeable>
+            }
+
+            @Composable
+            @OptIn(InternalCodegenApi::class)
+            private fun KhonshuTest(component: KhonshuTestComponent) {
+              val stateMachine = remember { component.testStateMachine }
+              val state = stateMachine.asComposeState()
+              val currentState = state.value
+              if (currentState != null) {
+                Test(
+                  state = currentState,
+                )
+              }
+            }
+
+        """.trimIndent()
+
+        test(withoutSendAction, "com/test/Test.kt", source, expected)
+    }
+
+    @Test
+    fun `generates code for NavHostActivityData without state`() {
+        val withoutSendAction = data.copy(
+            stateParameter = null,
+        )
+
+        @Language("kotlin")
+        val source = """
+            package com.test
+
+            import androidx.activity.ComponentActivity
+            import androidx.compose.runtime.Composable
+            import com.freeletics.khonshu.codegen.compose.NavHostActivity
+            import com.freeletics.khonshu.navigation.BaseRoute
+            import com.freeletics.khonshu.navigation.DeepLinkHandler
+            import com.freeletics.khonshu.navigation.NavRoot
+            import com.freeletics.khonshu.navigation.compose.NavDestination
+            import com.test.parent.TestParentScope
+
+            @NavHostActivity(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+              stateMachine = TestStateMachine::class,
+              activityBaseClass = ComponentActivity::class,
+            )
+            @Composable
+            @Suppress("unused_parameter")
+            public fun Test(
+              sendAction: (TestAction) -> Unit,
+            ) {
+            }
+        """.trimIndent()
+
+        @Language("kotlin")
+        val expected = """
+            package com.test
+
+            import android.os.Bundle
+            import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.remember
+            import androidx.compose.runtime.rememberCoroutineScope
+            import androidx.lifecycle.SavedStateHandle
+            import com.freeletics.khonshu.codegen.ForScope
+            import com.freeletics.khonshu.codegen.ScopeTo
+            import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
+            import com.freeletics.khonshu.codegen.`internal`.asComposeState
+            import com.squareup.anvil.annotations.ContributesSubcomponent
+            import com.squareup.anvil.annotations.ContributesTo
+            import com.test.parent.TestParentScope
+            import dagger.BindsInstance
+            import dagger.Module
+            import dagger.multibindings.Multibinds
+            import java.io.Closeable
+            import kotlin.OptIn
+            import kotlin.collections.Set
+            import kotlinx.coroutines.launch
+
+            @OptIn(InternalCodegenApi::class)
+            @ScopeTo(TestScreen::class)
+            @ContributesSubcomponent(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+            )
+            public interface KhonshuTestComponent : Closeable {
+              public val testStateMachine: TestStateMachine
+
+              @get:ForScope(TestScreen::class)
+              public val closeables: Set<Closeable>
+
+              override fun close() {
+                closeables.forEach {
+                  it.close()
+                }
+              }
+
+              @ContributesSubcomponent.Factory
+              public interface Factory {
+                public fun create(@BindsInstance @ForScope(TestScreen::class)
+                    savedStateHandle: SavedStateHandle, @BindsInstance @ForScope(TestScreen::class)
+                    arguments: Bundle): KhonshuTestComponent
+              }
+
+              @ContributesTo(TestParentScope::class)
+              public interface ParentComponent {
+                public fun khonshuTestComponentFactory(): Factory
+              }
+            }
+
+            @Module
+            @ContributesTo(TestScreen::class)
+            public interface KhonshuTestModule {
+              @Multibinds
+              @ForScope(TestScreen::class)
+              public fun bindCloseables(): Set<Closeable>
+            }
+
+            @Composable
+            @OptIn(InternalCodegenApi::class)
+            private fun KhonshuTest(component: KhonshuTestComponent) {
+              val stateMachine = remember { component.testStateMachine }
+              val state = stateMachine.asComposeState()
+              val currentState = state.value
+              if (currentState != null) {
+                val scope = rememberCoroutineScope()
+                Test(
+                  sendAction = { scope.launch { stateMachine.dispatch(it) } },
+                )
+              }
+            }
+
+        """.trimIndent()
+
+        test(withoutSendAction, "com/test/Test.kt", source, expected)
+    }
+}

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/TestHelper.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/TestHelper.kt
@@ -6,14 +6,17 @@ import com.freeletics.khonshu.codegen.KhonshuCompilation.Companion.anvilCompilat
 import com.freeletics.khonshu.codegen.KhonshuCompilation.Companion.kspCompilation
 import com.freeletics.khonshu.codegen.KhonshuCompilation.Companion.simpleCompilation
 import com.freeletics.khonshu.codegen.KhonshuSymbolProcessor.KhonshuSymbolProcessorProvider
+import com.freeletics.khonshu.codegen.NavHostActivityData
 import com.freeletics.khonshu.codegen.testFileName
 import com.google.common.truth.Truth.assertThat
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
 
 internal fun test(data: BaseData, fileName: String, source: String, expectedCode: String) {
     compile(fileName = fileName, source = source, data = data, expectedCode = expectedCode)
-    compileWithAnvil(fileName = fileName, source = source, expectedCode = expectedCode)
-    compileWithKsp(fileName = fileName, source = source, expectedCode = expectedCode)
+    if (data !is NavHostActivityData) {
+        compileWithAnvil(fileName = fileName, source = source, expectedCode = expectedCode)
+        compileWithKsp(fileName = fileName, source = source, expectedCode = expectedCode)
+    }
 }
 
 private fun compile(fileName: String, source: String, data: BaseData, expectedCode: String) {

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/Data.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/Data.kt
@@ -51,6 +51,22 @@ public data class ComposeScreenData(
     override val composableParameter: List<ComposableParameter>,
 ) : ComposeData
 
+public data class NavHostActivityData(
+    override val baseName: String,
+    override val packageName: String,
+
+    override val scope: ClassName,
+    override val parentScope: ClassName,
+
+    override val stateMachine: ClassName,
+
+    override val stateParameter: ComposableParameter?,
+    override val sendActionParameter: ComposableParameter?,
+    override val composableParameter: List<ComposableParameter>,
+) : ComposeData {
+    override val navigation: Navigation? = null
+}
+
 public sealed interface FragmentData : BaseData {
     public val fragmentBaseClass: ClassName
     override val navigation: Navigation.Fragment?

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/FileGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/FileGenerator.kt
@@ -3,6 +3,7 @@ package com.freeletics.khonshu.codegen.codegen
 import com.freeletics.khonshu.codegen.BaseData
 import com.freeletics.khonshu.codegen.ComposeFragmentData
 import com.freeletics.khonshu.codegen.ComposeScreenData
+import com.freeletics.khonshu.codegen.NavHostActivityData
 import com.freeletics.khonshu.codegen.RendererFragmentData
 import com.freeletics.khonshu.codegen.codegen.common.ComponentGenerator
 import com.freeletics.khonshu.codegen.codegen.common.ComponentProviderGenerator
@@ -21,6 +22,7 @@ public class FileGenerator {
             is ComposeFragmentData -> generate(data)
             is ComposeScreenData -> generate(data)
             is RendererFragmentData -> generate(data)
+            is NavHostActivityData -> generate(data)
         }
     }
 
@@ -37,6 +39,18 @@ public class FileGenerator {
             .addFunction(outerComposable.generate())
             .addFunction(innerComposable.generate())
             .addNavDestinationTypes(data)
+            .build()
+    }
+
+    public fun generate(data: NavHostActivityData): FileSpec {
+        val component = ComponentGenerator(data)
+        val module = ModuleGenerator(data)
+        val innerComposable = InnerComposableGenerator(data)
+
+        return FileSpec.builder(data.packageName, "Khonshu${data.baseName}")
+            .addType(component.generate())
+            .addType(module.generate())
+            .addFunction(innerComposable.generate())
             .build()
     }
 

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/common/ComponentGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/common/ComponentGenerator.kt
@@ -1,8 +1,7 @@
 package com.freeletics.khonshu.codegen.codegen.common
 
 import com.freeletics.khonshu.codegen.BaseData
-import com.freeletics.khonshu.codegen.ComposeFragmentData
-import com.freeletics.khonshu.codegen.ComposeScreenData
+import com.freeletics.khonshu.codegen.ComposeData
 import com.freeletics.khonshu.codegen.RendererFragmentData
 import com.freeletics.khonshu.codegen.codegen.Generator
 import com.freeletics.khonshu.codegen.codegen.util.asParameter
@@ -72,12 +71,7 @@ internal class ComponentGenerator(
                 .build()
         }
         when (data) {
-            is ComposeFragmentData -> {
-                properties += data.composableParameter.map {
-                    PropertySpec.builder(it.name, it.typeName).build()
-                }
-            }
-            is ComposeScreenData -> {
+            is ComposeData -> {
                 properties += data.composableParameter.map {
                     PropertySpec.builder(it.name, it.typeName).build()
                 }

--- a/codegen/api/android/codegen.api
+++ b/codegen/api/android/codegen.api
@@ -1,3 +1,6 @@
+public abstract interface class com/freeletics/khonshu/codegen/ActivityScope {
+}
+
 public abstract interface class com/freeletics/khonshu/codegen/AppScope {
 }
 
@@ -29,6 +32,13 @@ public final class com/freeletics/khonshu/codegen/compose/DestinationType : java
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/freeletics/khonshu/codegen/compose/DestinationType;
 	public static fun values ()[Lcom/freeletics/khonshu/codegen/compose/DestinationType;
+}
+
+public abstract interface annotation class com/freeletics/khonshu/codegen/compose/NavHostActivity : java/lang/annotation/Annotation {
+	public abstract fun activityBaseClass ()Ljava/lang/Class;
+	public abstract fun parentScope ()Ljava/lang/Class;
+	public abstract fun scope ()Ljava/lang/Class;
+	public abstract fun stateMachine ()Ljava/lang/Class;
 }
 
 public abstract interface annotation class com/freeletics/khonshu/codegen/fragment/ComposeDestination : java/lang/annotation/Annotation {

--- a/codegen/api/jvm/codegen.api
+++ b/codegen/api/jvm/codegen.api
@@ -1,3 +1,6 @@
+public abstract interface class com/freeletics/khonshu/codegen/ActivityScope {
+}
+
 public abstract interface class com/freeletics/khonshu/codegen/AppScope {
 }
 
@@ -29,6 +32,13 @@ public final class com/freeletics/khonshu/codegen/compose/DestinationType : java
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/freeletics/khonshu/codegen/compose/DestinationType;
 	public static fun values ()[Lcom/freeletics/khonshu/codegen/compose/DestinationType;
+}
+
+public abstract interface annotation class com/freeletics/khonshu/codegen/compose/NavHostActivity : java/lang/annotation/Annotation {
+	public abstract fun activityBaseClass ()Ljava/lang/Class;
+	public abstract fun parentScope ()Ljava/lang/Class;
+	public abstract fun scope ()Ljava/lang/Class;
+	public abstract fun stateMachine ()Ljava/lang/Class;
 }
 
 public abstract interface annotation class com/freeletics/khonshu/codegen/fragment/ComposeDestination : java/lang/annotation/Annotation {

--- a/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/AppScope.kt
+++ b/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/AppScope.kt
@@ -4,3 +4,8 @@ package com.freeletics.khonshu.codegen
  * A default scope marker that represents an app wide scope
  */
 public sealed interface AppScope
+
+/**
+ * A default scope marker that represents an app wide scope
+ */
+public sealed interface ActivityScope

--- a/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/compose/NavHostActivity.kt
+++ b/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/compose/NavHostActivity.kt
@@ -1,0 +1,18 @@
+package com.freeletics.khonshu.codegen.compose
+
+import com.freeletics.khonshu.codegen.ActivityScope
+import com.freeletics.khonshu.codegen.AppScope
+import com.freeletics.khonshu.statemachine.StateMachine
+import kotlin.reflect.KClass
+
+/**
+ * TODO
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+public annotation class NavHostActivity(
+    val scope: KClass<*> = ActivityScope::class,
+    val parentScope: KClass<*> = AppScope::class,
+    val stateMachine: KClass<out StateMachine<*, *>>,
+    val activityBaseClass: KClass<*>,
+)


### PR DESCRIPTION
This adds `@NavHostActivity` which is meant to be put on composables to generate an `Activity` containing the general navigation and state setup. In the end it would look like this in the sample app https://github.com/freeletics/khonshu/compare/main...sample-activity. Part of this will also be to remove the non navigation annotations from codegen. The only use case we have for them right now is for the composable that is added to the `Activity`. 

Other than the annotation `NavHostActivityData` with just the existing properties is added and the existing generators are called for it. Subsequent prs will adjust the codegen and add new required parts, I'm just adding this now to make actual changes easier to read afterwards. 