### PR TITLE
generate Activity for NavHostActivityData

### DIFF
--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestNavHostActivity.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestNavHostActivity.kt
@@ -25,6 +25,7 @@ internal class FileGeneratorTestNavHostActivity {
         scope = ClassName("com.test", "TestScreen"),
         parentScope = ClassName("com.test.parent", "TestParentScope"),
         stateMachine = ClassName("com.test", "TestStateMachine"),
+        activityBaseClass = ClassName("androidx.activity", "ComponentActivity"),
         stateParameter = ComposableParameter("state", ClassName("com.test", "TestState")),
         sendActionParameter = ComposableParameter(
             "sendAction",
@@ -71,6 +72,8 @@ internal class FileGeneratorTestNavHostActivity {
             package com.test
 
             import android.os.Bundle
+            import androidx.activity.ComponentActivity
+            import androidx.activity.compose.setContent
             import androidx.compose.runtime.Composable
             import androidx.compose.runtime.remember
             import androidx.compose.runtime.rememberCoroutineScope
@@ -79,6 +82,7 @@ internal class FileGeneratorTestNavHostActivity {
             import com.freeletics.khonshu.codegen.ScopeTo
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
             import com.freeletics.khonshu.codegen.`internal`.asComposeState
+            import com.freeletics.khonshu.codegen.`internal`.component
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
             import com.test.parent.TestParentScope
@@ -127,6 +131,25 @@ internal class FileGeneratorTestNavHostActivity {
               @Multibinds
               @ForScope(TestScreen::class)
               public fun bindCloseables(): Set<Closeable>
+            }
+
+            @OptIn(InternalCodegenApi::class)
+            public class KhonshuTestActivity : ComponentActivity() {
+              private lateinit var khonshuTestComponent: KhonshuTestComponent
+
+              override fun onCreate(savedInstanceState: Bundle?) {
+                super.onCreate(savedInstanceState)
+                if (!::khonshuTestComponent.isInitialized) {
+                  khonshuTestComponent = component(this, this, TestParentScope::class, intent.extras) {
+                      parentComponent: KhonshuTestComponent.ParentComponent, savedStateHandle, extras ->
+                    parentComponent.khonshuTestComponentFactory().create(savedStateHandle, extras)
+                  }
+                }
+
+                setContent {
+                  KhonshuTest(khonshuTestComponent)
+                }
+              }
             }
 
             @Composable
@@ -186,6 +209,8 @@ internal class FileGeneratorTestNavHostActivity {
             package com.test
 
             import android.os.Bundle
+            import androidx.activity.ComponentActivity
+            import androidx.activity.compose.setContent
             import androidx.compose.runtime.Composable
             import androidx.compose.runtime.remember
             import androidx.compose.runtime.rememberCoroutineScope
@@ -196,6 +221,7 @@ internal class FileGeneratorTestNavHostActivity {
             import com.freeletics.khonshu.codegen.ScopeTo
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
             import com.freeletics.khonshu.codegen.`internal`.asComposeState
+            import com.freeletics.khonshu.codegen.`internal`.component
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
             import dagger.BindsInstance
@@ -243,6 +269,25 @@ internal class FileGeneratorTestNavHostActivity {
               @Multibinds
               @ForScope(ActivityScope::class)
               public fun bindCloseables(): Set<Closeable>
+            }
+
+            @OptIn(InternalCodegenApi::class)
+            public class KhonshuTestActivity : ComponentActivity() {
+              private lateinit var khonshuTestComponent: KhonshuTestComponent
+
+              override fun onCreate(savedInstanceState: Bundle?) {
+                super.onCreate(savedInstanceState)
+                if (!::khonshuTestComponent.isInitialized) {
+                  khonshuTestComponent = component(this, this, AppScope::class, intent.extras) {
+                      parentComponent: KhonshuTestComponent.ParentComponent, savedStateHandle, extras ->
+                    parentComponent.khonshuTestComponentFactory().create(savedStateHandle, extras)
+                  }
+                }
+
+                setContent {
+                  KhonshuTest(khonshuTestComponent)
+                }
+              }
             }
 
             @Composable
@@ -327,6 +372,8 @@ internal class FileGeneratorTestNavHostActivity {
             package com.test
 
             import android.os.Bundle
+            import androidx.activity.ComponentActivity
+            import androidx.activity.compose.setContent
             import androidx.compose.runtime.Composable
             import androidx.compose.runtime.remember
             import androidx.compose.runtime.rememberCoroutineScope
@@ -335,6 +382,7 @@ internal class FileGeneratorTestNavHostActivity {
             import com.freeletics.khonshu.codegen.ScopeTo
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
             import com.freeletics.khonshu.codegen.`internal`.asComposeState
+            import com.freeletics.khonshu.codegen.`internal`.component
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
             import com.test.other.TestClass2
@@ -395,6 +443,25 @@ internal class FileGeneratorTestNavHostActivity {
               @Multibinds
               @ForScope(TestScreen::class)
               public fun bindCloseables(): Set<Closeable>
+            }
+
+            @OptIn(InternalCodegenApi::class)
+            public class KhonshuTest2Activity : ComponentActivity() {
+              private lateinit var khonshuTest2Component: KhonshuTest2Component
+
+              override fun onCreate(savedInstanceState: Bundle?) {
+                super.onCreate(savedInstanceState)
+                if (!::khonshuTest2Component.isInitialized) {
+                  khonshuTest2Component = component(this, this, TestParentScope::class, intent.extras) {
+                      parentComponent: KhonshuTest2Component.ParentComponent, savedStateHandle, extras ->
+                    parentComponent.khonshuTest2ComponentFactory().create(savedStateHandle, extras)
+                  }
+                }
+
+                setContent {
+                  KhonshuTest2(khonshuTest2Component)
+                }
+              }
             }
 
             @Composable
@@ -463,6 +530,8 @@ internal class FileGeneratorTestNavHostActivity {
             package com.test
 
             import android.os.Bundle
+            import androidx.activity.ComponentActivity
+            import androidx.activity.compose.setContent
             import androidx.compose.runtime.Composable
             import androidx.compose.runtime.remember
             import androidx.lifecycle.SavedStateHandle
@@ -470,6 +539,7 @@ internal class FileGeneratorTestNavHostActivity {
             import com.freeletics.khonshu.codegen.ScopeTo
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
             import com.freeletics.khonshu.codegen.`internal`.asComposeState
+            import com.freeletics.khonshu.codegen.`internal`.component
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
             import com.test.parent.TestParentScope
@@ -517,6 +587,25 @@ internal class FileGeneratorTestNavHostActivity {
               @Multibinds
               @ForScope(TestScreen::class)
               public fun bindCloseables(): Set<Closeable>
+            }
+
+            @OptIn(InternalCodegenApi::class)
+            public class KhonshuTestActivity : ComponentActivity() {
+              private lateinit var khonshuTestComponent: KhonshuTestComponent
+
+              override fun onCreate(savedInstanceState: Bundle?) {
+                super.onCreate(savedInstanceState)
+                if (!::khonshuTestComponent.isInitialized) {
+                  khonshuTestComponent = component(this, this, TestParentScope::class, intent.extras) {
+                      parentComponent: KhonshuTestComponent.ParentComponent, savedStateHandle, extras ->
+                    parentComponent.khonshuTestComponentFactory().create(savedStateHandle, extras)
+                  }
+                }
+
+                setContent {
+                  KhonshuTest(khonshuTestComponent)
+                }
+              }
             }
 
             @Composable
@@ -575,6 +664,8 @@ internal class FileGeneratorTestNavHostActivity {
             package com.test
 
             import android.os.Bundle
+            import androidx.activity.ComponentActivity
+            import androidx.activity.compose.setContent
             import androidx.compose.runtime.Composable
             import androidx.compose.runtime.remember
             import androidx.compose.runtime.rememberCoroutineScope
@@ -583,6 +674,7 @@ internal class FileGeneratorTestNavHostActivity {
             import com.freeletics.khonshu.codegen.ScopeTo
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
             import com.freeletics.khonshu.codegen.`internal`.asComposeState
+            import com.freeletics.khonshu.codegen.`internal`.component
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
             import com.test.parent.TestParentScope
@@ -631,6 +723,25 @@ internal class FileGeneratorTestNavHostActivity {
               @Multibinds
               @ForScope(TestScreen::class)
               public fun bindCloseables(): Set<Closeable>
+            }
+
+            @OptIn(InternalCodegenApi::class)
+            public class KhonshuTestActivity : ComponentActivity() {
+              private lateinit var khonshuTestComponent: KhonshuTestComponent
+
+              override fun onCreate(savedInstanceState: Bundle?) {
+                super.onCreate(savedInstanceState)
+                if (!::khonshuTestComponent.isInitialized) {
+                  khonshuTestComponent = component(this, this, TestParentScope::class, intent.extras) {
+                      parentComponent: KhonshuTestComponent.ParentComponent, savedStateHandle, extras ->
+                    parentComponent.khonshuTestComponentFactory().create(savedStateHandle, extras)
+                  }
+                }
+
+                setContent {
+                  KhonshuTest(khonshuTestComponent)
+                }
+              }
             }
 
             @Composable

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/Data.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/Data.kt
@@ -60,6 +60,8 @@ public data class NavHostActivityData(
 
     override val stateMachine: ClassName,
 
+    public val activityBaseClass: ClassName,
+
     override val stateParameter: ComposableParameter?,
     override val sendActionParameter: ComposableParameter?,
     override val composableParameter: List<ComposableParameter>,

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/FileGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/FileGenerator.kt
@@ -10,6 +10,7 @@ import com.freeletics.khonshu.codegen.codegen.common.ComponentProviderGenerator
 import com.freeletics.khonshu.codegen.codegen.common.InnerComposableGenerator
 import com.freeletics.khonshu.codegen.codegen.common.ModuleGenerator
 import com.freeletics.khonshu.codegen.codegen.common.NavDestinationModuleGenerator
+import com.freeletics.khonshu.codegen.codegen.compose.ActivityGenerator
 import com.freeletics.khonshu.codegen.codegen.compose.OuterComposableGenerator
 import com.freeletics.khonshu.codegen.codegen.fragment.ComposeFragmentGenerator
 import com.freeletics.khonshu.codegen.codegen.fragment.RendererFragmentGenerator
@@ -45,11 +46,13 @@ public class FileGenerator {
     public fun generate(data: NavHostActivityData): FileSpec {
         val component = ComponentGenerator(data)
         val module = ModuleGenerator(data)
+        val activity = ActivityGenerator(data)
         val innerComposable = InnerComposableGenerator(data)
 
         return FileSpec.builder(data.packageName, "Khonshu${data.baseName}")
             .addType(component.generate())
             .addType(module.generate())
+            .addType(activity.generate())
             .addFunction(innerComposable.generate())
             .build()
     }

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/compose/ActivityGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/compose/ActivityGenerator.kt
@@ -1,0 +1,64 @@
+package com.freeletics.khonshu.codegen.codegen.compose
+
+import com.freeletics.khonshu.codegen.BaseData
+import com.freeletics.khonshu.codegen.NavHostActivityData
+import com.freeletics.khonshu.codegen.codegen.Generator
+import com.freeletics.khonshu.codegen.codegen.common.composableName
+import com.freeletics.khonshu.codegen.codegen.common.retainedComponentClassName
+import com.freeletics.khonshu.codegen.codegen.common.retainedComponentFactoryCreateName
+import com.freeletics.khonshu.codegen.codegen.common.retainedParentComponentClassName
+import com.freeletics.khonshu.codegen.codegen.common.retainedParentComponentGetterName
+import com.freeletics.khonshu.codegen.codegen.util.bundle
+import com.freeletics.khonshu.codegen.codegen.util.getComponent
+import com.freeletics.khonshu.codegen.codegen.util.lateinitPropertySpec
+import com.freeletics.khonshu.codegen.codegen.util.optInAnnotation
+import com.freeletics.khonshu.codegen.codegen.util.propertyName
+import com.freeletics.khonshu.codegen.codegen.util.setContent
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier.OVERRIDE
+import com.squareup.kotlinpoet.TypeSpec
+
+internal val Generator<out BaseData>.fragmentName
+    get() = "Khonshu${data.baseName}Activity"
+
+internal class ActivityGenerator(
+    override val data: NavHostActivityData,
+) : Generator<NavHostActivityData>() {
+
+    internal fun generate(): TypeSpec {
+        return TypeSpec.classBuilder(fragmentName)
+            .addAnnotation(optInAnnotation())
+            .superclass(data.activityBaseClass)
+            .addProperty(lateinitPropertySpec(retainedComponentClassName))
+            .addFunction(onCreateFun())
+            .build()
+    }
+
+    private fun onCreateFun(): FunSpec {
+        return FunSpec.builder("onCreate")
+            .addModifiers(OVERRIDE)
+            .addParameter("savedInstanceState", bundle.copy(nullable = true))
+            .addStatement("super.onCreate(savedInstanceState)")
+            .beginControlFlow("if (!::%L.isInitialized)", retainedComponentClassName.propertyName)
+            .beginControlFlow(
+                "%L = %M(this, this, %T::class, intent.extras) { " +
+                    "parentComponent: %T, savedStateHandle, extras ->",
+                retainedComponentClassName.propertyName,
+                getComponent,
+                data.parentScope,
+                retainedParentComponentClassName,
+            )
+            .addStatement(
+                "parentComponent.%L().%L(savedStateHandle, extras)",
+                retainedParentComponentGetterName,
+                retainedComponentFactoryCreateName,
+            )
+            .endControlFlow()
+            .endControlFlow()
+            .addStatement("")
+            .beginControlFlow("%M", setContent)
+            .addStatement("%L(%L)", composableName, retainedComponentClassName.propertyName)
+            .endControlFlow()
+            .build()
+    }
+}

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/compose/ActivityGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/compose/ActivityGenerator.kt
@@ -18,7 +18,7 @@ import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier.OVERRIDE
 import com.squareup.kotlinpoet.TypeSpec
 
-internal val Generator<out BaseData>.fragmentName
+internal val Generator<out BaseData>.activityName
     get() = "Khonshu${data.baseName}Activity"
 
 internal class ActivityGenerator(
@@ -26,7 +26,7 @@ internal class ActivityGenerator(
 ) : Generator<NavHostActivityData>() {
 
     internal fun generate(): TypeSpec {
-        return TypeSpec.classBuilder(fragmentName)
+        return TypeSpec.classBuilder(activityName)
             .addAnnotation(optInAnnotation())
             .superclass(data.activityBaseClass)
             .addProperty(lateinitPropertySpec(retainedComponentClassName))

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/util/External.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/util/External.kt
@@ -73,6 +73,7 @@ internal val module = ClassName("dagger", "Module")
 
 // AndroidX
 internal val fragment = ClassName("androidx.fragment.app", "Fragment")
+internal val setContent = MemberName("androidx.activity.compose", "setContent")
 internal val savedStateHandle = ClassName("androidx.lifecycle", "SavedStateHandle")
 internal val localViewModelStoreOwner = ClassName("androidx.lifecycle.viewmodel.compose", "LocalViewModelStoreOwner")
 

--- a/codegen/src/androidMain/kotlin/com/freeletics/khonshu/codegen/internal/ComponentProvider.kt
+++ b/codegen/src/androidMain/kotlin/com/freeletics/khonshu/codegen/internal/ComponentProvider.kt
@@ -19,14 +19,14 @@ public inline fun <reified C : Any, P : Any> component(
     viewModelStoreOwner: ViewModelStoreOwner,
     context: Context,
     parentScope: KClass<*>,
-    arguments: Bundle,
+    arguments: Bundle?,
     crossinline factory: @DisallowComposableCalls (P, SavedStateHandle, Bundle) -> C,
 ): C {
     val store = ViewModelProvider(viewModelStoreOwner, SavedStateViewModelFactory())[StoreViewModel::class.java]
     return store.getOrCreate(C::class) {
         val parentComponent = context.findComponentByScope<P>(parentScope)
         val savedStateHandle = store.savedStateHandle
-        factory(parentComponent, savedStateHandle, arguments)
+        factory(parentComponent, savedStateHandle, arguments ?: Bundle.EMPTY)
     }
 }
 


### PR DESCRIPTION
First new part of the NavHostActivity codegen. This generates the `Activity` subclass which will obtain the component and then call the already generated wrapper composable from `setContent`. `NavHostActivityData` gets a property for the activity base class (there already is a parameter for this on the annotation).