### PR TITLE
ActivityModule codegen

### DIFF
--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestNavHostActivity.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestNavHostActivity.kt
@@ -159,6 +159,16 @@ internal class FileGeneratorTestNavHostActivity {
               public fun bindCloseables(): Set<Closeable>
             }
 
+            @Module
+            @ContributesTo(TestScreen::class)
+            public interface KhonshuTestActivityModule {
+              @Multibinds
+              public fun bindDeepLinkHandler(): Set<DeepLinkHandler>
+
+              @Multibinds
+              public fun bindDeepLinkPrefix(): Set<DeepLinkHandler.Prefix>
+            }
+
             @OptIn(InternalCodegenApi::class)
             public class KhonshuTestActivity : ComponentActivity() {
               private lateinit var khonshuTestComponent: KhonshuTestComponent
@@ -319,6 +329,16 @@ internal class FileGeneratorTestNavHostActivity {
               @Multibinds
               @ForScope(ActivityScope::class)
               public fun bindCloseables(): Set<Closeable>
+            }
+
+            @Module
+            @ContributesTo(ActivityScope::class)
+            public interface KhonshuTestActivityModule {
+              @Multibinds
+              public fun bindDeepLinkHandler(): Set<DeepLinkHandler>
+
+              @Multibinds
+              public fun bindDeepLinkPrefix(): Set<DeepLinkHandler.Prefix>
             }
 
             @OptIn(InternalCodegenApi::class)
@@ -519,6 +539,16 @@ internal class FileGeneratorTestNavHostActivity {
               public fun bindCloseables(): Set<Closeable>
             }
 
+            @Module
+            @ContributesTo(TestScreen::class)
+            public interface KhonshuTest2ActivityModule {
+              @Multibinds
+              public fun bindDeepLinkHandler(): Set<DeepLinkHandler>
+
+              @Multibinds
+              public fun bindDeepLinkPrefix(): Set<DeepLinkHandler.Prefix>
+            }
+
             @OptIn(InternalCodegenApi::class)
             public class KhonshuTest2Activity : ComponentActivity() {
               private lateinit var khonshuTest2Component: KhonshuTest2Component
@@ -687,6 +717,16 @@ internal class FileGeneratorTestNavHostActivity {
               public fun bindCloseables(): Set<Closeable>
             }
 
+            @Module
+            @ContributesTo(TestScreen::class)
+            public interface KhonshuTestActivityModule {
+              @Multibinds
+              public fun bindDeepLinkHandler(): Set<DeepLinkHandler>
+
+              @Multibinds
+              public fun bindDeepLinkPrefix(): Set<DeepLinkHandler.Prefix>
+            }
+
             @OptIn(InternalCodegenApi::class)
             public class KhonshuTestActivity : ComponentActivity() {
               private lateinit var khonshuTestComponent: KhonshuTestComponent
@@ -845,6 +885,16 @@ internal class FileGeneratorTestNavHostActivity {
               @Multibinds
               @ForScope(TestScreen::class)
               public fun bindCloseables(): Set<Closeable>
+            }
+
+            @Module
+            @ContributesTo(TestScreen::class)
+            public interface KhonshuTestActivityModule {
+              @Multibinds
+              public fun bindDeepLinkHandler(): Set<DeepLinkHandler>
+
+              @Multibinds
+              public fun bindDeepLinkPrefix(): Set<DeepLinkHandler.Prefix>
             }
 
             @OptIn(InternalCodegenApi::class)

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/FileGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/FileGenerator.kt
@@ -11,6 +11,7 @@ import com.freeletics.khonshu.codegen.codegen.common.InnerComposableGenerator
 import com.freeletics.khonshu.codegen.codegen.common.ModuleGenerator
 import com.freeletics.khonshu.codegen.codegen.common.NavDestinationModuleGenerator
 import com.freeletics.khonshu.codegen.codegen.compose.ActivityGenerator
+import com.freeletics.khonshu.codegen.codegen.compose.ActivityModuleGenerator
 import com.freeletics.khonshu.codegen.codegen.compose.OuterComposableGenerator
 import com.freeletics.khonshu.codegen.codegen.fragment.ComposeFragmentGenerator
 import com.freeletics.khonshu.codegen.codegen.fragment.RendererFragmentGenerator
@@ -46,12 +47,14 @@ public class FileGenerator {
     public fun generate(data: NavHostActivityData): FileSpec {
         val component = ComponentGenerator(data)
         val module = ModuleGenerator(data)
+        val activityModule = ActivityModuleGenerator(data)
         val activity = ActivityGenerator(data)
         val innerComposable = InnerComposableGenerator(data)
 
         return FileSpec.builder(data.packageName, "Khonshu${data.baseName}")
             .addType(component.generate())
             .addType(module.generate())
+            .addType(activityModule.generate())
             .addType(activity.generate())
             .addFunction(innerComposable.generate())
             .build()

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/compose/ActivityModuleGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/compose/ActivityModuleGenerator.kt
@@ -1,0 +1,46 @@
+package com.freeletics.khonshu.codegen.codegen.compose
+
+import com.freeletics.khonshu.codegen.BaseData
+import com.freeletics.khonshu.codegen.codegen.Generator
+import com.freeletics.khonshu.codegen.codegen.util.contributesToAnnotation
+import com.freeletics.khonshu.codegen.codegen.util.deepLinkHandler
+import com.freeletics.khonshu.codegen.codegen.util.deepLinkPrefix
+import com.freeletics.khonshu.codegen.codegen.util.module
+import com.freeletics.khonshu.codegen.codegen.util.multibinds
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier.ABSTRACT
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.SET
+import com.squareup.kotlinpoet.TypeSpec
+
+internal class ActivityModuleGenerator(
+    override val data: BaseData,
+) : Generator<BaseData>() {
+
+    private val moduleClassName = ClassName("Khonshu${data.baseName}ActivityModule")
+
+    internal fun generate(): TypeSpec {
+        return TypeSpec.interfaceBuilder(moduleClassName)
+            .addAnnotation(module)
+            .addAnnotation(contributesToAnnotation(data.scope))
+            .addFunction(bindDeepLinkHandlerFunction())
+            .addFunction(bindDeepLinkPrefixFunction())
+            .build()
+    }
+
+    private fun bindDeepLinkHandlerFunction(): FunSpec {
+        return FunSpec.builder("bindDeepLinkHandler")
+            .addModifiers(ABSTRACT)
+            .addAnnotation(multibinds)
+            .returns(SET.parameterizedBy(deepLinkHandler))
+            .build()
+    }
+
+    private fun bindDeepLinkPrefixFunction(): FunSpec {
+        return FunSpec.builder("bindDeepLinkPrefix")
+            .addModifiers(ABSTRACT)
+            .addAnnotation(multibinds)
+            .returns(SET.parameterizedBy(deepLinkPrefix))
+            .build()
+    }
+}


### PR DESCRIPTION
Generates a module that has multi bindings for `DeepLinkHandler` and `DeepLinkHandler.Prefix` for apps that don't have deep links. I didn't add one for `NavDestination` because the app would not work if there are no contributed destinations.