### PR TITLE
SystemBackHandling: remove unnecessary distinctUntilChanged

### DIFF
--- a/navigation-experimental/src/main/kotlin/com/freeletics/khonshu/navigation/compose/NavHost.kt
+++ b/navigation-experimental/src/main/kotlin/com/freeletics/khonshu/navigation/compose/NavHost.kt
@@ -118,7 +118,6 @@ private fun SystemBackHandling(executor: MultiStackNavigationExecutor) {
 
     LaunchedEffect(executor, callback) {
         snapshotFlow { executor.canNavigateBack.value }
-            .distinctUntilChanged()
             .collect { callback.isEnabled = it }
     }
 


### PR DESCRIPTION
- Ref: https://developer.android.com/reference/kotlin/androidx/compose/runtime/package-summary#snapshotFlow(kotlin.Function0)
> If the result of [block](https://developer.android.com/reference/kotlin/androidx/compose/runtime/package-summary#snapshotFlow(kotlin.Function0)) is not [equal to](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html) the previous result, the flow will emit that new result. (This behavior is similar to that of [Flow.distinctUntilChanged](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.flow/index.html).)