### PR TITLE
rename @ComposeDestination annotation

### DIFF
--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestCompose.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestCompose.kt
@@ -52,12 +52,12 @@ internal class FileGeneratorTestCompose {
             package com.test
 
             import androidx.compose.runtime.Composable
-            import com.freeletics.khonshu.codegen.compose.ComposeDestination
+            import com.freeletics.khonshu.codegen.compose.NavDestination
             import com.freeletics.khonshu.codegen.compose.DestinationType
             import com.test.destination.TestDestinationScope
             import com.test.parent.TestParentRoute
 
-            @ComposeDestination(
+            @NavDestination(
               route = TestRoute::class,
               parentScope = TestParentRoute::class,
               stateMachine = TestStateMachine::class,
@@ -229,10 +229,10 @@ internal class FileGeneratorTestCompose {
             package com.test
 
             import androidx.compose.runtime.Composable
-            import com.freeletics.khonshu.codegen.compose.ComposeDestination
+            import com.freeletics.khonshu.codegen.compose.NavDestination
             import com.freeletics.khonshu.codegen.compose.DestinationType
 
-            @ComposeDestination(
+            @NavDestination(
               route = TestRoute::class,
               stateMachine = TestStateMachine::class,
               destinationType = DestinationType.SCREEN,
@@ -413,13 +413,13 @@ internal class FileGeneratorTestCompose {
             package com.test
 
             import androidx.compose.runtime.Composable
-            import com.freeletics.khonshu.codegen.compose.ComposeDestination
+            import com.freeletics.khonshu.codegen.compose.NavDestination
             import com.freeletics.khonshu.codegen.compose.DestinationType
             import com.test.destination.TestDestinationScope
             import com.test.other.TestClass2
             import com.test.parent.TestParentRoute
 
-            @ComposeDestination(
+            @NavDestination(
               route = TestRoute::class,
               parentScope = TestParentRoute::class,
               stateMachine = TestStateMachine::class,
@@ -609,12 +609,12 @@ internal class FileGeneratorTestCompose {
             package com.test
 
             import androidx.compose.runtime.Composable
-            import com.freeletics.khonshu.codegen.compose.ComposeDestination
+            import com.freeletics.khonshu.codegen.compose.NavDestination
             import com.freeletics.khonshu.codegen.compose.DestinationType
             import com.test.destination.TestDestinationScope
             import com.test.parent.TestParentRoute
 
-            @ComposeDestination(
+            @NavDestination(
               route = TestRoute::class,
               parentScope = TestParentRoute::class,
               stateMachine = TestStateMachine::class,
@@ -775,12 +775,12 @@ internal class FileGeneratorTestCompose {
             package com.test
 
             import androidx.compose.runtime.Composable
-            import com.freeletics.khonshu.codegen.compose.ComposeDestination
+            import com.freeletics.khonshu.codegen.compose.NavDestination
             import com.freeletics.khonshu.codegen.compose.DestinationType
             import com.test.destination.TestDestinationScope
             import com.test.parent.TestParentRoute
 
-            @ComposeDestination(
+            @NavDestination(
               route = TestRoute::class,
               parentScope = TestParentRoute::class,
               stateMachine = TestStateMachine::class,

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestComposeFragment.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestComposeFragment.kt
@@ -53,12 +53,12 @@ internal class FileGeneratorTestComposeFragment {
             package com.test
 
             import androidx.compose.runtime.Composable
-            import com.freeletics.khonshu.codegen.fragment.ComposeDestination
+            import com.freeletics.khonshu.codegen.fragment.ComposeFragmentDestination
             import com.freeletics.khonshu.codegen.fragment.DestinationType
             import com.test.destination.TestDestinationScope
             import com.test.parent.TestParentRoute
 
-            @ComposeDestination(
+            @ComposeFragmentDestination(
               route = TestRoute::class,
               parentScope = TestParentRoute::class,
               stateMachine = TestStateMachine::class,
@@ -251,10 +251,10 @@ internal class FileGeneratorTestComposeFragment {
             package com.test
 
             import androidx.compose.runtime.Composable
-            import com.freeletics.khonshu.codegen.fragment.ComposeDestination
+            import com.freeletics.khonshu.codegen.fragment.ComposeFragmentDestination
             import com.freeletics.khonshu.codegen.fragment.DestinationType
 
-            @ComposeDestination(
+            @ComposeFragmentDestination(
               route = TestRoute::class,
               stateMachine = TestStateMachine::class,
             )
@@ -442,12 +442,12 @@ internal class FileGeneratorTestComposeFragment {
 
             import androidx.compose.runtime.Composable
             import androidx.fragment.app.DialogFragment
-            import com.freeletics.khonshu.codegen.fragment.ComposeDestination
+            import com.freeletics.khonshu.codegen.fragment.ComposeFragmentDestination
             import com.freeletics.khonshu.codegen.fragment.DestinationType
             import com.test.destination.TestDestinationScope
             import com.test.parent.TestParentRoute
 
-            @ComposeDestination(
+            @ComposeFragmentDestination(
               route = TestRoute::class,
               parentScope = TestParentRoute::class,
               stateMachine = TestStateMachine::class,
@@ -653,13 +653,13 @@ internal class FileGeneratorTestComposeFragment {
             package com.test
 
             import androidx.compose.runtime.Composable
-            import com.freeletics.khonshu.codegen.fragment.ComposeDestination
+            import com.freeletics.khonshu.codegen.fragment.ComposeFragmentDestination
             import com.freeletics.khonshu.codegen.fragment.DestinationType
             import com.test.destination.TestDestinationScope
             import com.test.other.TestClass2
             import com.test.parent.TestParentRoute
 
-            @ComposeDestination(
+            @ComposeFragmentDestination(
               route = TestRoute::class,
               parentScope = TestParentRoute::class,
               stateMachine = TestStateMachine::class,
@@ -870,12 +870,12 @@ internal class FileGeneratorTestComposeFragment {
             package com.test
 
             import androidx.compose.runtime.Composable
-            import com.freeletics.khonshu.codegen.fragment.ComposeDestination
+            import com.freeletics.khonshu.codegen.fragment.ComposeFragmentDestination
             import com.freeletics.khonshu.codegen.fragment.DestinationType
             import com.test.destination.TestDestinationScope
             import com.test.parent.TestParentRoute
 
-            @ComposeDestination(
+            @ComposeFragmentDestination(
               route = TestRoute::class,
               parentScope = TestParentRoute::class,
               stateMachine = TestStateMachine::class,
@@ -1057,12 +1057,12 @@ internal class FileGeneratorTestComposeFragment {
             package com.test
 
             import androidx.compose.runtime.Composable
-            import com.freeletics.khonshu.codegen.fragment.ComposeDestination
+            import com.freeletics.khonshu.codegen.fragment.ComposeFragmentDestination
             import com.freeletics.khonshu.codegen.fragment.DestinationType
             import com.test.destination.TestDestinationScope
             import com.test.parent.TestParentRoute
 
-            @ComposeDestination(
+            @ComposeFragmentDestination(
               route = TestRoute::class,
               parentScope = TestParentRoute::class,
               stateMachine = TestStateMachine::class,

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/KhonshuSymbolProcessor.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/KhonshuSymbolProcessor.kt
@@ -1,9 +1,9 @@
 package com.freeletics.khonshu.codegen
 
 import com.freeletics.khonshu.codegen.codegen.FileGenerator
-import com.freeletics.khonshu.codegen.compose.ComposeDestination
+import com.freeletics.khonshu.codegen.compose.NavDestination
 import com.freeletics.khonshu.codegen.compose.NavHostActivity
-import com.freeletics.khonshu.codegen.fragment.ComposeDestination as ComposeFragmentDestination
+import com.freeletics.khonshu.codegen.fragment.ComposeFragmentDestination as ComposeFragmentDestination
 import com.freeletics.khonshu.codegen.fragment.RendererDestination
 import com.freeletics.khonshu.codegen.parser.ksp.toComposeFragmentDestinationData
 import com.freeletics.khonshu.codegen.parser.ksp.toComposeScreenDestinationData
@@ -38,7 +38,7 @@ public class KhonshuSymbolProcessor(
     private val fileGenerator = FileGenerator()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
-        resolver.generateCodeForAnnotation<KSFunctionDeclaration, ComposeDestination> {
+        resolver.generateCodeForAnnotation<KSFunctionDeclaration, NavDestination> {
             toComposeScreenDestinationData(it, resolver, logger)
         }
         resolver.generateCodeForAnnotation<KSClassDeclaration, RendererDestination> {

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/util/External.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/util/External.kt
@@ -11,7 +11,8 @@ import org.jetbrains.kotlin.name.FqName
 // Codegen Public API
 internal val rendererFragmentDestination = ClassName("com.freeletics.khonshu.codegen.fragment", "RendererDestination")
 internal val rendererFragmentDestinationFqName = FqName(rendererFragmentDestination.canonicalName)
-internal val composeFragmentDestination = ClassName("com.freeletics.khonshu.codegen.fragment", "ComposeFragmentDestination")
+internal val composeFragmentDestination =
+    ClassName("com.freeletics.khonshu.codegen.fragment", "ComposeFragmentDestination")
 internal val composeFragmentDestinationFqName = FqName(composeFragmentDestination.canonicalName)
 internal val navDestination = ClassName("com.freeletics.khonshu.codegen.compose", "NavDestination")
 internal val navDestinationFqName = FqName(navDestination.canonicalName)

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/util/External.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/util/External.kt
@@ -11,10 +11,10 @@ import org.jetbrains.kotlin.name.FqName
 // Codegen Public API
 internal val rendererFragmentDestination = ClassName("com.freeletics.khonshu.codegen.fragment", "RendererDestination")
 internal val rendererFragmentDestinationFqName = FqName(rendererFragmentDestination.canonicalName)
-internal val composeFragmentDestination = ClassName("com.freeletics.khonshu.codegen.fragment", "ComposeDestination")
+internal val composeFragmentDestination = ClassName("com.freeletics.khonshu.codegen.fragment", "ComposeFragmentDestination")
 internal val composeFragmentDestinationFqName = FqName(composeFragmentDestination.canonicalName)
-internal val codegenComposeDestination = ClassName("com.freeletics.khonshu.codegen.compose", "ComposeDestination")
-internal val codegenComposeDestinationFqName = FqName(codegenComposeDestination.canonicalName)
+internal val navDestination = ClassName("com.freeletics.khonshu.codegen.compose", "NavDestination")
+internal val navDestinationFqName = FqName(navDestination.canonicalName)
 internal val navHostActivity = ClassName("com.freeletics.khonshu.codegen.compose", "NavHostActivity")
 internal val navHostActivityFqName = FqName(navHostActivity.canonicalName)
 internal val appScope = ClassName("com.freeletics.khonshu.codegen", "AppScope")

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/anvil/ComposeParser.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/anvil/ComposeParser.kt
@@ -3,14 +3,14 @@ package com.freeletics.khonshu.codegen.parser.anvil
 import com.freeletics.khonshu.codegen.ComposeScreenData
 import com.freeletics.khonshu.codegen.NavHostActivityData
 import com.freeletics.khonshu.codegen.Navigation
-import com.freeletics.khonshu.codegen.codegen.util.codegenComposeDestinationFqName
+import com.freeletics.khonshu.codegen.codegen.util.navDestinationFqName
 import com.freeletics.khonshu.codegen.codegen.util.navHostActivityFqName
 import com.freeletics.khonshu.codegen.compose.DestinationType
 import com.squareup.anvil.compiler.internal.reference.TopLevelFunctionReference
 import com.squareup.anvil.compiler.internal.reference.asClassName
 
 internal fun TopLevelFunctionReference.toComposeScreenDestinationData(): ComposeScreenData? {
-    val annotation = findAnnotation(codegenComposeDestinationFqName) ?: return null
+    val annotation = findAnnotation(navDestinationFqName) ?: return null
 
     val stateMachine = annotation.stateMachineReference
     val (stateParameter, actionParameter) = stateMachine.stateMachineParameters()

--- a/codegen/api/android/codegen.api
+++ b/codegen/api/android/codegen.api
@@ -4,20 +4,20 @@ public abstract interface class com/freeletics/khonshu/codegen/ActivityScope {
 public abstract interface class com/freeletics/khonshu/codegen/AppScope {
 }
 
-public abstract interface annotation class com/freeletics/khonshu/codegen/compose/ComposeDestination : java/lang/annotation/Annotation {
-	public abstract fun destinationScope ()Ljava/lang/Class;
-	public abstract fun destinationType ()Lcom/freeletics/khonshu/codegen/compose/DestinationType;
-	public abstract fun parentScope ()Ljava/lang/Class;
-	public abstract fun route ()Ljava/lang/Class;
-	public abstract fun stateMachine ()Ljava/lang/Class;
-}
-
 public final class com/freeletics/khonshu/codegen/compose/DestinationType : java/lang/Enum {
 	public static final field OVERLAY Lcom/freeletics/khonshu/codegen/compose/DestinationType;
 	public static final field SCREEN Lcom/freeletics/khonshu/codegen/compose/DestinationType;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/freeletics/khonshu/codegen/compose/DestinationType;
 	public static fun values ()[Lcom/freeletics/khonshu/codegen/compose/DestinationType;
+}
+
+public abstract interface annotation class com/freeletics/khonshu/codegen/compose/NavDestination : java/lang/annotation/Annotation {
+	public abstract fun destinationScope ()Ljava/lang/Class;
+	public abstract fun destinationType ()Lcom/freeletics/khonshu/codegen/compose/DestinationType;
+	public abstract fun parentScope ()Ljava/lang/Class;
+	public abstract fun route ()Ljava/lang/Class;
+	public abstract fun stateMachine ()Ljava/lang/Class;
 }
 
 public abstract interface annotation class com/freeletics/khonshu/codegen/compose/NavHostActivity : java/lang/annotation/Annotation {
@@ -27,7 +27,7 @@ public abstract interface annotation class com/freeletics/khonshu/codegen/compos
 	public abstract fun stateMachine ()Ljava/lang/Class;
 }
 
-public abstract interface annotation class com/freeletics/khonshu/codegen/fragment/ComposeDestination : java/lang/annotation/Annotation {
+public abstract interface annotation class com/freeletics/khonshu/codegen/fragment/ComposeFragmentDestination : java/lang/annotation/Annotation {
 	public abstract fun destinationScope ()Ljava/lang/Class;
 	public abstract fun destinationType ()Lcom/freeletics/khonshu/codegen/fragment/DestinationType;
 	public abstract fun fragmentBaseClass ()Ljava/lang/Class;

--- a/codegen/api/jvm/codegen.api
+++ b/codegen/api/jvm/codegen.api
@@ -4,20 +4,20 @@ public abstract interface class com/freeletics/khonshu/codegen/ActivityScope {
 public abstract interface class com/freeletics/khonshu/codegen/AppScope {
 }
 
-public abstract interface annotation class com/freeletics/khonshu/codegen/compose/ComposeDestination : java/lang/annotation/Annotation {
-	public abstract fun destinationScope ()Ljava/lang/Class;
-	public abstract fun destinationType ()Lcom/freeletics/khonshu/codegen/compose/DestinationType;
-	public abstract fun parentScope ()Ljava/lang/Class;
-	public abstract fun route ()Ljava/lang/Class;
-	public abstract fun stateMachine ()Ljava/lang/Class;
-}
-
 public final class com/freeletics/khonshu/codegen/compose/DestinationType : java/lang/Enum {
 	public static final field OVERLAY Lcom/freeletics/khonshu/codegen/compose/DestinationType;
 	public static final field SCREEN Lcom/freeletics/khonshu/codegen/compose/DestinationType;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/freeletics/khonshu/codegen/compose/DestinationType;
 	public static fun values ()[Lcom/freeletics/khonshu/codegen/compose/DestinationType;
+}
+
+public abstract interface annotation class com/freeletics/khonshu/codegen/compose/NavDestination : java/lang/annotation/Annotation {
+	public abstract fun destinationScope ()Ljava/lang/Class;
+	public abstract fun destinationType ()Lcom/freeletics/khonshu/codegen/compose/DestinationType;
+	public abstract fun parentScope ()Ljava/lang/Class;
+	public abstract fun route ()Ljava/lang/Class;
+	public abstract fun stateMachine ()Ljava/lang/Class;
 }
 
 public abstract interface annotation class com/freeletics/khonshu/codegen/compose/NavHostActivity : java/lang/annotation/Annotation {
@@ -27,7 +27,7 @@ public abstract interface annotation class com/freeletics/khonshu/codegen/compos
 	public abstract fun stateMachine ()Ljava/lang/Class;
 }
 
-public abstract interface annotation class com/freeletics/khonshu/codegen/fragment/ComposeDestination : java/lang/annotation/Annotation {
+public abstract interface annotation class com/freeletics/khonshu/codegen/fragment/ComposeFragmentDestination : java/lang/annotation/Annotation {
 	public abstract fun destinationScope ()Ljava/lang/Class;
 	public abstract fun destinationType ()Lcom/freeletics/khonshu/codegen/fragment/DestinationType;
 	public abstract fun fragmentBaseClass ()Ljava/lang/Class;

--- a/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/compose/NavDestination.kt
+++ b/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/compose/NavDestination.kt
@@ -18,7 +18,7 @@ import kotlin.reflect.KClass
  */
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
-public annotation class ComposeDestination(
+public annotation class NavDestination(
     val route: KClass<out BaseRoute>,
     val parentScope: KClass<*> = AppScope::class,
     val stateMachine: KClass<out StateMachine<*, *>>,

--- a/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/fragment/ComposeFragmentDestination.kt
+++ b/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/fragment/ComposeFragmentDestination.kt
@@ -19,7 +19,7 @@ import kotlin.reflect.KClass
  */
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
-public annotation class ComposeDestination(
+public annotation class ComposeFragmentDestination(
     val route: KClass<out BaseRoute>,
     val parentScope: KClass<*> = AppScope::class,
     val stateMachine: KClass<out StateMachine<*, *>>,


### PR DESCRIPTION
If we want to use them in parallel having the same name is inconvenient and also makes it hard to talk about them. This renames the compose only annotation to `@NavDestination` (matches `@NavHostActivity` and once fragment support is gone these will be the only annotations codegen has) and the fragment one is `@ComposeFragmentDestination`.