### PR TITLE
add extension to allow changing deeplinks.toml location

### DIFF
--- a/deeplinks-plugin/api/deeplinks-plugin.api
+++ b/deeplinks-plugin/api/deeplinks-plugin.api
@@ -69,9 +69,14 @@ public final class com/freeletics/khonshu/deeplinks/plugin/DeepLinkDefinitions$C
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public abstract class com/freeletics/khonshu/deeplinks/plugin/DeepLinksExtension {
+	public fun <init> ()V
+	public abstract fun getDeepLinkDefinitionsFile ()Lorg/gradle/api/file/RegularFileProperty;
+}
+
 public abstract class com/freeletics/khonshu/deeplinks/plugin/DeeplinksManifestConfiguratorTask : org/gradle/api/DefaultTask {
 	public fun <init> ()V
-	public abstract fun getDeeplinksConfigurationFile ()Lorg/gradle/api/file/RegularFileProperty;
+	public abstract fun getDeepLinkDefinitionsFile ()Lorg/gradle/api/file/RegularFileProperty;
 	public abstract fun getMergedManifest ()Lorg/gradle/api/file/RegularFileProperty;
 	public abstract fun getUpdatedManifest ()Lorg/gradle/api/file/RegularFileProperty;
 	public final fun taskAction ()V

--- a/deeplinks-plugin/src/main/kotlin/com/freeletics/khonshu/deeplinks/plugin/DeepLinksExtension.kt
+++ b/deeplinks-plugin/src/main/kotlin/com/freeletics/khonshu/deeplinks/plugin/DeepLinksExtension.kt
@@ -1,0 +1,7 @@
+package com.freeletics.khonshu.deeplinks.plugin
+
+import org.gradle.api.file.RegularFileProperty
+
+public abstract class DeepLinksExtension() {
+    public abstract val deepLinkDefinitionsFile: RegularFileProperty
+}

--- a/deeplinks-plugin/src/main/kotlin/com/freeletics/khonshu/deeplinks/plugin/DeeplinksManifestConfiguratorTask.kt
+++ b/deeplinks-plugin/src/main/kotlin/com/freeletics/khonshu/deeplinks/plugin/DeeplinksManifestConfiguratorTask.kt
@@ -9,7 +9,7 @@ import org.gradle.api.tasks.TaskAction
 public abstract class DeeplinksManifestConfiguratorTask : DefaultTask() {
 
     @get:InputFile
-    public abstract val deeplinksConfigurationFile: RegularFileProperty
+    public abstract val deepLinkDefinitionsFile: RegularFileProperty
 
     @get:InputFile
     public abstract val mergedManifest: RegularFileProperty
@@ -19,7 +19,7 @@ public abstract class DeeplinksManifestConfiguratorTask : DefaultTask() {
 
     @TaskAction
     public fun taskAction() {
-        val configurationFile = deeplinksConfigurationFile.get().asFile
+        val configurationFile = deepLinkDefinitionsFile.get().asFile
         val inputManifest = mergedManifest.get().asFile
         val outputManifest = updatedManifest.get().asFile
 


### PR DESCRIPTION
For the test helper (#252) the toml file needs to be somewhere where tests can read it. Adding the extension allows us to point the plugin to a toml file in the test resources.  There is still a `convention` to default to the same location as before in the root of the project.