### PR TITLE
add deep links test helper

### DIFF
--- a/navigation-testing/api/android/navigation-testing.api
+++ b/navigation-testing/api/android/navigation-testing.api
@@ -113,6 +113,10 @@ public final class com/freeletics/khonshu/navigation/deeplinks/DeepLinkDefinitio
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/freeletics/khonshu/navigation/deeplinks/DeepLinkTestingKt {
+	public static final fun containsAllDeepLinks (Lcom/freeletics/khonshu/navigation/deeplinks/DeepLinkDefinitions;Ljava/util/Set;Ljava/util/Set;)V
+}
+
 public final class com/freeletics/khonshu/navigation/deeplinks/PatternDefinition {
 	public static final field Companion Lcom/freeletics/khonshu/navigation/deeplinks/PatternDefinition$Companion;
 	public static final synthetic fun box-impl (Ljava/lang/String;)Lcom/freeletics/khonshu/navigation/deeplinks/PatternDefinition;

--- a/navigation-testing/api/jvm/navigation-testing.api
+++ b/navigation-testing/api/jvm/navigation-testing.api
@@ -69,6 +69,10 @@ public final class com/freeletics/khonshu/navigation/deeplinks/DeepLinkDefinitio
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/freeletics/khonshu/navigation/deeplinks/DeepLinkTestingKt {
+	public static final fun containsAllDeepLinks (Lcom/freeletics/khonshu/navigation/deeplinks/DeepLinkDefinitions;Ljava/util/Set;Ljava/util/Set;)V
+}
+
 public final class com/freeletics/khonshu/navigation/deeplinks/PatternDefinition {
 	public static final field Companion Lcom/freeletics/khonshu/navigation/deeplinks/PatternDefinition$Companion;
 	public static final synthetic fun box-impl (Ljava/lang/String;)Lcom/freeletics/khonshu/navigation/deeplinks/PatternDefinition;

--- a/navigation-testing/navigation-testing.gradle.kts
+++ b/navigation-testing/navigation-testing.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
 dependencies {
     "commonMainApi"(projects.navigation)
     "commonMainApi"(libs.serialization)
+    "commonMainApi"(libs.kotlin.test)
 
     "commonMainImplementation"(libs.toml)
 

--- a/navigation-testing/src/commonMain/kotlin/com/freeletics/khonshu/navigation/deeplinks/DeepLinkTesting.kt
+++ b/navigation-testing/src/commonMain/kotlin/com/freeletics/khonshu/navigation/deeplinks/DeepLinkTesting.kt
@@ -1,0 +1,36 @@
+package com.freeletics.khonshu.navigation.deeplinks
+
+import kotlin.test.assertTrue
+
+public fun DeepLinkDefinitions.containsAllDeepLinks(
+    deepLinkHandlers: Set<DeepLinkHandler>,
+    defaultPrefixes: Set<DeepLinkHandler.Prefix>,
+) {
+    val codePrefixPatternCombinations = deepLinkHandlers.flatMapTo(HashSet()) { handler ->
+        handler.prefixes.ifEmpty { defaultPrefixes }.flatMap { prefix ->
+            handler.patterns.map { pattern ->
+                prefix to pattern
+            }
+        }
+    }
+
+    val definedPrefixPatternCombinations = deepLinks.values.flatMapTo(HashSet()) { deepLink ->
+        deepLink.prefixes.ifEmpty { prefixes }.flatMap { prefix ->
+            deepLink.patterns.map { pattern ->
+                DeepLinkHandler.Prefix("${prefix.scheme}://${prefix.host}") to
+                    DeepLinkHandler.Pattern(pattern.value)
+            }
+        }
+    }
+
+    val codeOnly = codePrefixPatternCombinations - definedPrefixPatternCombinations
+    assertTrue(
+        codeOnly.isEmpty(),
+        "The following deep links are not defined in TOML but are present in code: $codeOnly",
+    )
+    val tomlOnly = definedPrefixPatternCombinations - codePrefixPatternCombinations
+    assertTrue(
+        tomlOnly.isEmpty(),
+        "The following deep links are not defined in code but are present in the TOML file: $tomlOnly",
+    )
+}


### PR DESCRIPTION
Adds a `DeepLinkDefinitions.containsAllDeepLinks` method to check that all deep links loaded from the TOML file have a `DeepLinkHandler` and the other way around. 

Closes #572 