### PR TITLE
fix: error "Navigator ... is replacing an already attached ..."

### DIFF
--- a/navigation-compose/src/main/kotlin/com/freeletics/khonshu/navigation/compose/NavHost.kt
+++ b/navigation-compose/src/main/kotlin/com/freeletics/khonshu/navigation/compose/NavHost.kt
@@ -1,7 +1,5 @@
 package com.freeletics.khonshu.navigation.compose
 
-import androidx.navigation.NavDestination as AndroidXNavDestination
-import androidx.navigation.compose.NavHost as AndroidXNavHost
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
@@ -12,8 +10,10 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavArgument
 import androidx.navigation.NavController
 import androidx.navigation.NavController.OnDestinationChangedListener
+import androidx.navigation.NavDestination as AndroidXNavDestination
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.compose.NavHost as AndroidXNavHost
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.createGraph
 import androidx.navigation.get


### PR DESCRIPTION
When changing `startRoute`, that causes `navController.navigatorProvider.addNavigator(CustomActivityNavigator(context))` is called again.
`check(previousNavigator?.isAttached != true)` don't passes.


```kotlin
package androidx.navigation

public open class NavigatorProvider {
 @CallSuper
    public open fun addNavigator(
        name: String,
        navigator: Navigator<out NavDestination>
    ): Navigator<out NavDestination>? {
        ...
        val previousNavigator = _navigators[name]
        if (previousNavigator == navigator) {
            return navigator
        }
        check(previousNavigator?.isAttached != true) {
            "Navigator $navigator is replacing an already attached $previousNavigator"
        }
       ...
    }
}
```

P/S:
Although changing startRoute does not follow [Fixed start destination](https://developer.android.com/guide/navigation/principles?hl=en#fixed_start_destination), but in some cases, we must to do this.
