### PR TITLE
replace DestinationType with Overlay marker interface

### DIFF
--- a/codegen-compiler-test/src/test/kotlin/com/test/TestFixtures.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/test/TestFixtures.kt
@@ -3,6 +3,7 @@ package com.test
 import android.os.Parcel
 import android.view.View
 import androidx.viewbinding.ViewBinding
+import com.freeletics.khonshu.codegen.Overlay
 import com.freeletics.khonshu.navigation.NavRoot
 import com.freeletics.khonshu.navigation.NavRoute
 import com.freeletics.khonshu.statemachine.StateMachine
@@ -12,6 +13,11 @@ public class TestScreen
 public class TestClass
 
 public class TestRoute : NavRoute {
+    override fun describeContents(): Int = 0
+    override fun writeToParcel(p0: Parcel, p1: Int) {}
+}
+
+public class TestOverlayRoute : NavRoute, Overlay {
     override fun describeContents(): Int = 0
     override fun writeToParcel(p0: Parcel, p1: Int) {}
 }

--- a/codegen-compiler/codegen-compiler.gradle.kts
+++ b/codegen-compiler/codegen-compiler.gradle.kts
@@ -18,11 +18,11 @@ dependencies {
     api(libs.anvil.compiler.api)
     api(libs.ksp.api)
     api(libs.kotlinpoet)
-    api(projects.codegen)
     implementation(libs.anvil.annotations)
     implementation(libs.anvil.annotations.optional)
     implementation(libs.anvil.compiler.utils)
     implementation(libs.kotlinpoet.ksp)
+    implementation(projects.codegen)
     implementation(projects.navigation)
 
     compileOnly(libs.auto.service.annotations)

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/Data.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/Data.kt
@@ -6,8 +6,6 @@ import com.freeletics.khonshu.codegen.codegen.util.composeScreenDestination
 import com.freeletics.khonshu.codegen.codegen.util.fragmentDestination
 import com.freeletics.khonshu.codegen.codegen.util.fragmentDialogDestination
 import com.freeletics.khonshu.codegen.codegen.util.fragmentScreenDestination
-import com.freeletics.khonshu.codegen.compose.DestinationType
-import com.freeletics.khonshu.codegen.fragment.DestinationType as FragmentDestinationType
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.TypeName
@@ -116,28 +114,28 @@ public sealed interface Navigation {
     public data class Compose(
         override val route: ClassName,
         override val parentScopeIsRoute: Boolean,
-        private val destinationType: DestinationType,
+        private val overlay: Boolean,
         override val destinationScope: ClassName,
     ) : Navigation {
         override val destinationClass: ClassName = composeDestination
 
-        override val destinationMethod: MemberName = when (destinationType) {
-            DestinationType.SCREEN -> composeScreenDestination
-            DestinationType.OVERLAY -> composeOverlayDestination
+        override val destinationMethod: MemberName = when (overlay) {
+            false -> composeScreenDestination
+            true -> composeOverlayDestination
         }
     }
 
     public data class Fragment(
         override val route: ClassName,
         override val parentScopeIsRoute: Boolean,
-        private val destinationType: FragmentDestinationType,
+        private val overlay: Boolean,
         override val destinationScope: ClassName,
     ) : Navigation {
         override val destinationClass: ClassName = fragmentDestination
 
-        override val destinationMethod: MemberName = when (destinationType) {
-            FragmentDestinationType.SCREEN -> fragmentScreenDestination
-            FragmentDestinationType.DIALOG -> fragmentDialogDestination
+        override val destinationMethod: MemberName = when (overlay) {
+            false -> fragmentScreenDestination
+            true -> fragmentDialogDestination
         }
     }
 }

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/util/External.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/util/External.kt
@@ -20,6 +20,8 @@ internal val navHostActivity = ClassName("com.freeletics.khonshu.codegen.compose
 internal val navHostActivityFqName = FqName(navHostActivity.canonicalName)
 internal val appScope = ClassName("com.freeletics.khonshu.codegen", "AppScope")
 internal val activityScope = ClassName("com.freeletics.khonshu.codegen", "ActivityScope")
+internal val overlay = ClassName("com.freeletics.khonshu.codegen", "Overlay")
+internal val overlayFqName = FqName(overlay.canonicalName)
 
 // Codegen Internal API
 internal val asComposeState = MemberName("com.freeletics.khonshu.codegen.internal", "asComposeState")

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/anvil/CommonParser.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/anvil/CommonParser.kt
@@ -8,6 +8,7 @@ import com.freeletics.khonshu.codegen.codegen.util.baseRouteFqName
 import com.freeletics.khonshu.codegen.codegen.util.fragment
 import com.freeletics.khonshu.codegen.codegen.util.functionToLambda
 import com.freeletics.khonshu.codegen.codegen.util.navHostLambda
+import com.freeletics.khonshu.codegen.codegen.util.overlayFqName
 import com.freeletics.khonshu.codegen.codegen.util.stateMachine
 import com.freeletics.khonshu.codegen.codegen.util.viewRendererFactoryFqName
 import com.squareup.anvil.compiler.internal.reference.AnnotationReference
@@ -27,7 +28,10 @@ internal val AnnotationReference.scope: ClassName
     get() = optionalClassArgument("scope", 0) ?: activityScope
 
 internal val AnnotationReference.route: ClassName
-    get() = requireClassArgument("route", 0)
+    get() = routeReference.asClassName()
+
+internal val AnnotationReference.routeReference: ClassReference
+    get() = requireClassReferenceArgument("route", 0)
 
 internal val AnnotationReference.parentScope: ClassName
     get() = parentScopeReference?.asClassName() ?: appScope
@@ -106,5 +110,11 @@ internal fun ClassReference.findRendererFactory(): ClassName {
 internal fun ClassReference?.extendsBaseRoute(): Boolean {
     return this?.allSuperTypeClassReferences()?.any { superType ->
         superType.fqName == baseRouteFqName
+    } == true
+}
+
+internal fun ClassReference?.extendsOverlay(): Boolean {
+    return this?.allSuperTypeClassReferences()?.any { superType ->
+        superType.fqName == overlayFqName
     } == true
 }

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/anvil/ComposeParser.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/anvil/ComposeParser.kt
@@ -5,7 +5,8 @@ import com.freeletics.khonshu.codegen.NavHostActivityData
 import com.freeletics.khonshu.codegen.Navigation
 import com.freeletics.khonshu.codegen.codegen.util.navDestinationFqName
 import com.freeletics.khonshu.codegen.codegen.util.navHostActivityFqName
-import com.freeletics.khonshu.codegen.compose.DestinationType
+import com.freeletics.khonshu.codegen.parser.ksp.extendsBaseRoute
+import com.freeletics.khonshu.codegen.parser.ksp.extendsOverlay
 import com.squareup.anvil.compiler.internal.reference.TopLevelFunctionReference
 import com.squareup.anvil.compiler.internal.reference.asClassName
 
@@ -18,7 +19,7 @@ internal fun TopLevelFunctionReference.toComposeScreenDestinationData(): Compose
     val navigation = Navigation.Compose(
         route = annotation.route,
         parentScopeIsRoute = annotation.parentScopeReference.extendsBaseRoute(),
-        destinationType = DestinationType.valueOf(annotation.destinationType),
+        overlay = annotation.routeReference.extendsOverlay(),
         destinationScope = annotation.destinationScope,
     )
 

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/anvil/FragmentParser.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/anvil/FragmentParser.kt
@@ -5,7 +5,6 @@ import com.freeletics.khonshu.codegen.Navigation
 import com.freeletics.khonshu.codegen.RendererFragmentData
 import com.freeletics.khonshu.codegen.codegen.util.composeFragmentDestinationFqName
 import com.freeletics.khonshu.codegen.codegen.util.rendererFragmentDestinationFqName
-import com.freeletics.khonshu.codegen.fragment.DestinationType
 import com.squareup.anvil.compiler.internal.reference.ClassReference
 import com.squareup.anvil.compiler.internal.reference.TopLevelFunctionReference
 import com.squareup.anvil.compiler.internal.reference.asClassName
@@ -16,7 +15,7 @@ internal fun ClassReference.toRendererFragmentDestinationData(): RendererFragmen
     val navigation = Navigation.Fragment(
         route = annotation.route,
         parentScopeIsRoute = annotation.parentScopeReference.extendsBaseRoute(),
-        destinationType = DestinationType.valueOf(annotation.destinationType),
+        overlay = annotation.routeReference.extendsOverlay(),
         destinationScope = annotation.destinationScope,
     )
 
@@ -41,7 +40,7 @@ internal fun TopLevelFunctionReference.toComposeFragmentDestinationData(): Compo
     val navigation = Navigation.Fragment(
         route = annotation.route,
         parentScopeIsRoute = annotation.parentScopeReference.extendsBaseRoute(),
-        destinationType = DestinationType.valueOf(annotation.destinationType),
+        overlay = annotation.routeReference.extendsOverlay(),
         destinationScope = annotation.destinationScope,
     )
 

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/ksp/CommonParser.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/ksp/CommonParser.kt
@@ -105,11 +105,7 @@ internal fun ClassName.stateMachineParameters(resolver: Resolver, logger: KSPLog
 internal fun KSClassDeclaration.findRendererFactory(logger: KSPLogger): ClassName? {
     val factory = declarations.filterIsInstance<KSClassDeclaration>()
         .firstNotNullOfOrNull {
-            if (it.allSuperTypes(false).any { superType ->
-                    println("test: $superType")
-                    superType == viewRendererFactory
-                }
-            ) {
+            if (it.allSuperTypes(false).any { superType -> superType == viewRendererFactory }) {
                 it.toClassName()
             } else {
                 null

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/ksp/ComposeParser.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/ksp/ComposeParser.kt
@@ -3,7 +3,7 @@ package com.freeletics.khonshu.codegen.parser.ksp
 import com.freeletics.khonshu.codegen.ComposeScreenData
 import com.freeletics.khonshu.codegen.NavHostActivityData
 import com.freeletics.khonshu.codegen.Navigation
-import com.freeletics.khonshu.codegen.compose.DestinationType
+import com.freeletics.khonshu.codegen.parser.anvil.extendsOverlay
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotation
@@ -20,7 +20,7 @@ internal fun KSFunctionDeclaration.toComposeScreenDestinationData(
     val navigation = Navigation.Compose(
         route = annotation.route,
         parentScopeIsRoute = annotation.parentScope.extendsBaseRoute(resolver),
-        destinationType = DestinationType.valueOf(annotation.destinationType),
+        overlay = annotation.route.extendsOverlay(resolver),
         destinationScope = annotation.destinationScope,
     )
 

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/ksp/FragmentParser.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/ksp/FragmentParser.kt
@@ -3,7 +3,6 @@ package com.freeletics.khonshu.codegen.parser.ksp
 import com.freeletics.khonshu.codegen.ComposeFragmentData
 import com.freeletics.khonshu.codegen.Navigation
 import com.freeletics.khonshu.codegen.RendererFragmentData
-import com.freeletics.khonshu.codegen.fragment.DestinationType
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotation
@@ -18,7 +17,7 @@ internal fun KSClassDeclaration.toRendererFragmentDestinationData(
     val navigation = Navigation.Fragment(
         route = annotation.route,
         parentScopeIsRoute = annotation.parentScope.extendsBaseRoute(resolver),
-        destinationType = DestinationType.valueOf(annotation.destinationType),
+        overlay = annotation.route.extendsOverlay(resolver),
         destinationScope = annotation.destinationScope,
     )
 
@@ -45,7 +44,7 @@ internal fun KSFunctionDeclaration.toComposeFragmentDestinationData(
     val navigation = Navigation.Fragment(
         route = annotation.route,
         parentScopeIsRoute = annotation.parentScope.extendsBaseRoute(resolver),
-        destinationType = DestinationType.valueOf(annotation.destinationType),
+        overlay = annotation.route.extendsOverlay(resolver),
         destinationScope = annotation.destinationScope,
     )
 

--- a/codegen/api/android/codegen.api
+++ b/codegen/api/android/codegen.api
@@ -4,17 +4,11 @@ public abstract interface class com/freeletics/khonshu/codegen/ActivityScope {
 public abstract interface class com/freeletics/khonshu/codegen/AppScope {
 }
 
-public final class com/freeletics/khonshu/codegen/compose/DestinationType : java/lang/Enum {
-	public static final field OVERLAY Lcom/freeletics/khonshu/codegen/compose/DestinationType;
-	public static final field SCREEN Lcom/freeletics/khonshu/codegen/compose/DestinationType;
-	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public static fun valueOf (Ljava/lang/String;)Lcom/freeletics/khonshu/codegen/compose/DestinationType;
-	public static fun values ()[Lcom/freeletics/khonshu/codegen/compose/DestinationType;
+public abstract interface class com/freeletics/khonshu/codegen/Overlay {
 }
 
 public abstract interface annotation class com/freeletics/khonshu/codegen/compose/NavDestination : java/lang/annotation/Annotation {
 	public abstract fun destinationScope ()Ljava/lang/Class;
-	public abstract fun destinationType ()Lcom/freeletics/khonshu/codegen/compose/DestinationType;
 	public abstract fun parentScope ()Ljava/lang/Class;
 	public abstract fun route ()Ljava/lang/Class;
 	public abstract fun stateMachine ()Ljava/lang/Class;
@@ -29,24 +23,14 @@ public abstract interface annotation class com/freeletics/khonshu/codegen/compos
 
 public abstract interface annotation class com/freeletics/khonshu/codegen/fragment/ComposeFragmentDestination : java/lang/annotation/Annotation {
 	public abstract fun destinationScope ()Ljava/lang/Class;
-	public abstract fun destinationType ()Lcom/freeletics/khonshu/codegen/fragment/DestinationType;
 	public abstract fun fragmentBaseClass ()Ljava/lang/Class;
 	public abstract fun parentScope ()Ljava/lang/Class;
 	public abstract fun route ()Ljava/lang/Class;
 	public abstract fun stateMachine ()Ljava/lang/Class;
 }
 
-public final class com/freeletics/khonshu/codegen/fragment/DestinationType : java/lang/Enum {
-	public static final field DIALOG Lcom/freeletics/khonshu/codegen/fragment/DestinationType;
-	public static final field SCREEN Lcom/freeletics/khonshu/codegen/fragment/DestinationType;
-	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public static fun valueOf (Ljava/lang/String;)Lcom/freeletics/khonshu/codegen/fragment/DestinationType;
-	public static fun values ()[Lcom/freeletics/khonshu/codegen/fragment/DestinationType;
-}
-
 public abstract interface annotation class com/freeletics/khonshu/codegen/fragment/RendererDestination : java/lang/annotation/Annotation {
 	public abstract fun destinationScope ()Ljava/lang/Class;
-	public abstract fun destinationType ()Lcom/freeletics/khonshu/codegen/fragment/DestinationType;
 	public abstract fun fragmentBaseClass ()Ljava/lang/Class;
 	public abstract fun parentScope ()Ljava/lang/Class;
 	public abstract fun route ()Ljava/lang/Class;

--- a/codegen/api/jvm/codegen.api
+++ b/codegen/api/jvm/codegen.api
@@ -4,17 +4,11 @@ public abstract interface class com/freeletics/khonshu/codegen/ActivityScope {
 public abstract interface class com/freeletics/khonshu/codegen/AppScope {
 }
 
-public final class com/freeletics/khonshu/codegen/compose/DestinationType : java/lang/Enum {
-	public static final field OVERLAY Lcom/freeletics/khonshu/codegen/compose/DestinationType;
-	public static final field SCREEN Lcom/freeletics/khonshu/codegen/compose/DestinationType;
-	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public static fun valueOf (Ljava/lang/String;)Lcom/freeletics/khonshu/codegen/compose/DestinationType;
-	public static fun values ()[Lcom/freeletics/khonshu/codegen/compose/DestinationType;
+public abstract interface class com/freeletics/khonshu/codegen/Overlay {
 }
 
 public abstract interface annotation class com/freeletics/khonshu/codegen/compose/NavDestination : java/lang/annotation/Annotation {
 	public abstract fun destinationScope ()Ljava/lang/Class;
-	public abstract fun destinationType ()Lcom/freeletics/khonshu/codegen/compose/DestinationType;
 	public abstract fun parentScope ()Ljava/lang/Class;
 	public abstract fun route ()Ljava/lang/Class;
 	public abstract fun stateMachine ()Ljava/lang/Class;
@@ -29,24 +23,14 @@ public abstract interface annotation class com/freeletics/khonshu/codegen/compos
 
 public abstract interface annotation class com/freeletics/khonshu/codegen/fragment/ComposeFragmentDestination : java/lang/annotation/Annotation {
 	public abstract fun destinationScope ()Ljava/lang/Class;
-	public abstract fun destinationType ()Lcom/freeletics/khonshu/codegen/fragment/DestinationType;
 	public abstract fun fragmentBaseClass ()Ljava/lang/Class;
 	public abstract fun parentScope ()Ljava/lang/Class;
 	public abstract fun route ()Ljava/lang/Class;
 	public abstract fun stateMachine ()Ljava/lang/Class;
 }
 
-public final class com/freeletics/khonshu/codegen/fragment/DestinationType : java/lang/Enum {
-	public static final field DIALOG Lcom/freeletics/khonshu/codegen/fragment/DestinationType;
-	public static final field SCREEN Lcom/freeletics/khonshu/codegen/fragment/DestinationType;
-	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public static fun valueOf (Ljava/lang/String;)Lcom/freeletics/khonshu/codegen/fragment/DestinationType;
-	public static fun values ()[Lcom/freeletics/khonshu/codegen/fragment/DestinationType;
-}
-
 public abstract interface annotation class com/freeletics/khonshu/codegen/fragment/RendererDestination : java/lang/annotation/Annotation {
 	public abstract fun destinationScope ()Ljava/lang/Class;
-	public abstract fun destinationType ()Lcom/freeletics/khonshu/codegen/fragment/DestinationType;
 	public abstract fun fragmentBaseClass ()Ljava/lang/Class;
 	public abstract fun parentScope ()Ljava/lang/Class;
 	public abstract fun route ()Ljava/lang/Class;

--- a/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/Overlay.kt
+++ b/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/Overlay.kt
@@ -1,0 +1,8 @@
+package com.freeletics.khonshu.codegen
+
+/**
+ * Marker interface to add to a `NavRoute`. This will make the codegen generate
+ * an `OverlayDestination` instead of a `ScreenDestination` for Composables
+ * using such a route.
+ */
+public interface Overlay

--- a/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/compose/DestinationType.kt
+++ b/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/compose/DestinationType.kt
@@ -1,9 +1,0 @@
-package com.freeletics.khonshu.codegen.compose
-
-/**
- * Describing the type of [com.freeletics.khonshu.navigation.compose.NavDestination].
- */
-public enum class DestinationType {
-    SCREEN,
-    OVERLAY,
-}

--- a/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/compose/NavDestination.kt
+++ b/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/compose/NavDestination.kt
@@ -22,6 +22,5 @@ public annotation class NavDestination(
     val route: KClass<out BaseRoute>,
     val parentScope: KClass<*> = AppScope::class,
     val stateMachine: KClass<out StateMachine<*, *>>,
-    val destinationType: DestinationType = DestinationType.SCREEN,
     val destinationScope: KClass<*> = AppScope::class,
 )

--- a/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/fragment/ComposeFragmentDestination.kt
+++ b/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/fragment/ComposeFragmentDestination.kt
@@ -23,7 +23,6 @@ public annotation class ComposeFragmentDestination(
     val route: KClass<out BaseRoute>,
     val parentScope: KClass<*> = AppScope::class,
     val stateMachine: KClass<out StateMachine<*, *>>,
-    val destinationType: DestinationType = DestinationType.SCREEN,
     val destinationScope: KClass<*> = AppScope::class,
     val fragmentBaseClass: KClass<out Fragment> = Fragment::class,
 )

--- a/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/fragment/DestinationType.kt
+++ b/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/fragment/DestinationType.kt
@@ -1,9 +1,0 @@
-package com.freeletics.khonshu.codegen.fragment
-
-/**
- * Describing the type of [com.freeletics.khonshu.navigation.fragment.NavDestination].
- */
-public enum class DestinationType {
-    SCREEN,
-    DIALOG,
-}

--- a/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/fragment/RendererDestination.kt
+++ b/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/fragment/RendererDestination.kt
@@ -22,7 +22,6 @@ public annotation class RendererDestination(
     val route: KClass<out BaseRoute>,
     val parentScope: KClass<*> = AppScope::class,
     val stateMachine: KClass<out StateMachine<*, *>>,
-    val destinationType: DestinationType = DestinationType.SCREEN,
     val destinationScope: KClass<*> = AppScope::class,
     val fragmentBaseClass: KClass<out Fragment> = Fragment::class,
 )

--- a/docs/codegen/get-started.md
+++ b/docs/codegen/get-started.md
@@ -46,7 +46,6 @@ it falls into the `Fragment` category.
         route = ExampleRoute::class,
         parentScope = AppScope::class, // AppScope is the default value and can be omitted
         stateMachine = ExampleStateMachine::class,
-        destinationType = DestintionType.SCREEN, // SCREEN is the default value and can be omitted
         destinationScope = AppScope::class, // AppScope is the default value and can be omitted
     )
     @Composable
@@ -57,7 +56,7 @@ it falls into the `Fragment` category.
       // composable logic ...
     }
     ```
-    *`scope`, `parentScope`, destionationScope` and `destinationType` are described in the next sections*
+    *`scope`, `parentScope` and destionationScope` are described in the next sections*
 
     The generated `KhonshuExampleUi` function will use the generated component, the
     annotated composable as well as the `stateMachine` parameter from the
@@ -80,7 +79,6 @@ it falls into the `Fragment` category.
         route = ExampleRoute::class,
         parentScope = AppScope::class, // AppScope is the default value and can be omitted
         stateMachine = ExampleStateMachine::class,
-        destinationType = DestintionType.SCREEN, // SCREEN is the default value and can be omitted
         destinationScope = AppScope::class, // AppScope is the default value and can be omitted
     )
     @Composable
@@ -91,7 +89,7 @@ it falls into the `Fragment` category.
       // composable logic ...
     }
     ```
-    *`scope`, `parentScope`, destionationScope` and `destinationType` are described in the next sections*
+    *`scope`, `parentScope` and destionationScope` are described in the next sections*
 
     The generated `KhonshuExampleUiFragment` will use the generated component, the
     annotated composable as well as the `stateMachine` parameter from the
@@ -120,7 +118,6 @@ it falls into the `Fragment` category.
         route = ExampleRoute::class,
         parentScope = AppScope::class, // AppScope is the default value and can be omitted
         stateMachine = ExampleStateMachine::class,
-        destinationType = DestintionType.SCREEN, // SCREEN is the default value and can be omitted
         destinationScope = AppScope::class, // AppScope is the default value and can be omitted
     )
     internal class ExampleRenderer @AssistedInject constructor(
@@ -135,7 +132,7 @@ it falls into the `Fragment` category.
         abstract class Factory : ViewRenderer.Factory<ExampleViewBinding, ExampleRenderer>(ExampleViewBinding::inflate)
     }
     ```
-    *`scope`, `parentScope`, destionationScope` and `destinationType` are described in the next sections*
+    *`scope`, `parentScope` and destionationScope` are described in the next sections*
 
     The generated `KhonshuExampleRendererFragment` will use the generated component, the
     annotated composable as well as the `stateMachine`. It will use the `ViewRenderer.Factory`
@@ -183,7 +180,8 @@ qualifier needs to be added.
 ## NavDestination
 
 A `NavDestination` is automatically generated for each annotated screen. The type of the generated
-destination is determined by the `destinationType` parameter of the annotation.
+destination is based on the used `NavRoute`. To get an `OverlayDestination` (`DialogDestination` for
+Fragments) the route class needs to implement the `Overlay` marker interface.
 
 To avoid having to access any generated code the destination is directly contributed to
 a `Set<NavDestination>` which can then be injected where the `NavHost` or `NavHostFragment` is
@@ -253,7 +251,6 @@ class ExampleNavigator @Inject constructor() : NavEventNavigator() {
         route = ExampleRoute::class, // the route used to navigate to ExampleUi
         parentScope = AppScope::class, // the scope of the app level component, AppScope is the default value and can be omitted
         stateMachine = ExampleStateMachine::class, // the state machine used for this ui
-        destinationType = DestinationType.SCREEN, // whether it's a screen, dialog or bottom sheet, SCREEN is the default value and can be omitted
         destinationScope = AppScope::class, // contribute the generated destination to AppScope, AppScope is the default value and can be omitted
     )
     @Composable
@@ -272,7 +269,6 @@ class ExampleNavigator @Inject constructor() : NavEventNavigator() {
         route = ExampleRoute::class, // the route used to navigate to ExampleUi
         parentScope = AppScope::class, // the scope of the app level component, AppScope is the default value and can be omitted
         stateMachine = ExampleStateMachine::class, // the state machine used for this ui
-        destinationType = DestinationType.SCREEN, // whether it's a screen, dialog or bottom sheet, SCREEN is the default value and can be omitted
         destinationScope = AppScope::class, // contribute the generated destination to AppScope, AppScope is the default value and can be omitted
     )
     @Composable
@@ -291,7 +287,6 @@ class ExampleNavigator @Inject constructor() : NavEventNavigator() {
         route = ExampleRoute::class, // the route used to navigate to ExampleUi
         parentScope = AppScope::class, // the scope of the app level component, AppScope is the default value and can be omitted
         stateMachine = ExampleStateMachine::class, // the state machine used for this ui
-        destinationType = DestinationType.SCREEN, // whether it's a screen, dialog or bottom sheet, SCREEN is the default value and can be omitted
         destinationScope = AppScope::class, // contribute the generated destination to AppScope, AppScope is the default value and can be omitted
     )
     internal class ExampleRenderer @AssistedInject constructor(

--- a/sample/simple/feature/bottom-sheet/implementation/src/main/kotlin/kotlin/com/freeletics/khonshu/sample/feature/bottomsheet/BottomSheetScreen.kt
+++ b/sample/simple/feature/bottom-sheet/implementation/src/main/kotlin/kotlin/com/freeletics/khonshu/sample/feature/bottomsheet/BottomSheetScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.freeletics.khonshu.codegen.compose.DestinationType
 import com.freeletics.khonshu.codegen.compose.NavDestination
 import com.freeletics.khonshu.sample.feature.bottomsheet.nav.BottomSheetRoute
 
@@ -18,7 +17,6 @@ import com.freeletics.khonshu.sample.feature.bottomsheet.nav.BottomSheetRoute
 @NavDestination(
     route = BottomSheetRoute::class,
     stateMachine = BottomSheetStateMachine::class,
-    destinationType = DestinationType.OVERLAY,
 )
 @Composable
 fun BottomSheetScreen(

--- a/sample/simple/feature/bottom-sheet/nav/feature-bottom-sheet-nav.gradle.kts
+++ b/sample/simple/feature/bottom-sheet/nav/feature-bottom-sheet-nav.gradle.kts
@@ -3,5 +3,6 @@ plugins {
 }
 
 dependencies {
+    api(libs.khonshu.codegen)
     api(libs.khonshu.navigator)
 }

--- a/sample/simple/feature/bottom-sheet/nav/src/main/kotlin/com/freeletics/khonshu/sample/feature/bottomsheet/nav/BottomSheetRoute.kt
+++ b/sample/simple/feature/bottom-sheet/nav/src/main/kotlin/com/freeletics/khonshu/sample/feature/bottomsheet/nav/BottomSheetRoute.kt
@@ -1,7 +1,8 @@
 package com.freeletics.khonshu.sample.feature.bottomsheet.nav
 
+import com.freeletics.khonshu.codegen.Overlay
 import com.freeletics.khonshu.navigation.NavRoute
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-data object BottomSheetRoute : NavRoute
+data object BottomSheetRoute : NavRoute, Overlay

--- a/sample/simple/feature/dialog/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/dialog/DialogScreen.kt
+++ b/sample/simple/feature/dialog/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/dialog/DialogScreen.kt
@@ -11,14 +11,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
-import com.freeletics.khonshu.codegen.compose.DestinationType
 import com.freeletics.khonshu.codegen.compose.NavDestination
 import com.freeletics.khonshu.sample.feature.dialog.nav.DialogRoute
 
 @NavDestination(
     route = DialogRoute::class,
     stateMachine = DialogStateMachine::class,
-    destinationType = DestinationType.OVERLAY,
 )
 @Composable
 fun DialogScreen(

--- a/sample/simple/feature/dialog/nav/feature-dialog-nav.gradle.kts
+++ b/sample/simple/feature/dialog/nav/feature-dialog-nav.gradle.kts
@@ -3,5 +3,6 @@ plugins {
 }
 
 dependencies {
+    api(libs.khonshu.codegen)
     api(libs.khonshu.navigator)
 }

--- a/sample/simple/feature/dialog/nav/src/main/kotlin/com/freeletics/khonshu/sample/feature/dialog/nav/DialogRoute.kt
+++ b/sample/simple/feature/dialog/nav/src/main/kotlin/com/freeletics/khonshu/sample/feature/dialog/nav/DialogRoute.kt
@@ -1,7 +1,8 @@
 package com.freeletics.khonshu.sample.feature.dialog.nav
 
+import com.freeletics.khonshu.codegen.Overlay
 import com.freeletics.khonshu.navigation.NavRoute
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-data object DialogRoute : NavRoute
+data object DialogRoute : NavRoute, Overlay


### PR DESCRIPTION
Instead of having the `DestinationType` enum to decide whether to generate a `ScreenDestination` or an `OverlayDestination` (for fragments `DialogDestination`) this introduces an `Overlay` marker interface which can be added to any `NavRoute`. If it was added the codegen behaves like `DestinationType.OVERLAY` before.

The advantage of this is that other parts for example a destination change listener can check whether a new destination is an overlay by simply doing `route is Overlay`. We will use that instead of the Fragment class in our listener to decide whether bottom navigation should be shown or not.