### PR TITLE
Add Modifier to NavHost Composable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Change Log
 
 ## 0.19.1 **UNRELEASED**
 
+### Navigation
+
+- **New** Add `Modifier` parameter to `NavHost` Composable.
 
 ## 0.19.0 *(2023-11-09)*
 

--- a/navigation-compose/api/navigation-compose.api
+++ b/navigation-compose/api/navigation-compose.api
@@ -6,7 +6,7 @@ public abstract interface class com/freeletics/khonshu/navigation/compose/NavDes
 }
 
 public final class com/freeletics/khonshu/navigation/compose/NavHostKt {
-	public static final fun NavHost (Lcom/freeletics/khonshu/navigation/NavRoot;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Landroidx/navigation/NavHostController;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public static final fun NavHost (Lcom/freeletics/khonshu/navigation/NavRoot;Ljava/util/Set;Landroidx/compose/ui/Modifier;Ljava/util/Set;Ljava/util/Set;Landroidx/navigation/NavHostController;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/freeletics/khonshu/navigation/compose/NavigationSetupKt {

--- a/navigation-compose/src/main/kotlin/com/freeletics/khonshu/navigation/compose/NavHost.kt
+++ b/navigation-compose/src/main/kotlin/com/freeletics/khonshu/navigation/compose/NavHost.kt
@@ -15,6 +15,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.ComposeNavigator
 import androidx.navigation.compose.NavHost as AndroidXNavHost
+import androidx.compose.ui.Modifier
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.createGraph
 import androidx.navigation.get
@@ -55,6 +56,7 @@ import java.io.Serializable
 public fun NavHost(
     startRoute: NavRoot,
     destinations: Set<NavDestination>,
+    modifier: Modifier = Modifier,
     deepLinkHandlers: Set<DeepLinkHandler> = emptySet(),
     deepLinkPrefixes: Set<DeepLinkHandler.Prefix> = emptySet(),
     navController: NavHostController = rememberNavController(),
@@ -102,6 +104,7 @@ public fun NavHost(
         AndroidXNavHost(
             navController = navController,
             graph = graph,
+            modifier = modifier,
         )
 
         OverlayHost(

--- a/navigation-compose/src/main/kotlin/com/freeletics/khonshu/navigation/compose/NavHost.kt
+++ b/navigation-compose/src/main/kotlin/com/freeletics/khonshu/navigation/compose/NavHost.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavArgument
 import androidx.navigation.NavController
@@ -15,7 +16,6 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.ComposeNavigator
 import androidx.navigation.compose.NavHost as AndroidXNavHost
-import androidx.compose.ui.Modifier
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.createGraph
 import androidx.navigation.get


### PR DESCRIPTION
Makes putting `NavHost` into containers customizable and not take all space by default.