### PR TITLE
Add optional executor param to NavigationSetup function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Change Log
 
 ## 0.20.1 **UNRELEASED**
 
+### Navigation
+
+- **New** Add optional `executor: NavigationExecutor` parameter to `NavigationSetup` to allow for usage outside of
+`NavHost` for compose navigation.
 
 ## 0.20.0 *(2023-11-17)*
 

--- a/navigation-compose/api/navigation-compose.api
+++ b/navigation-compose/api/navigation-compose.api
@@ -34,7 +34,7 @@ public final class com/freeletics/khonshu/navigation/compose/NavHostTransitionAn
 }
 
 public final class com/freeletics/khonshu/navigation/compose/NavigationSetupKt {
-	public static final fun NavigationSetup (Lcom/freeletics/khonshu/navigation/NavEventNavigator;Landroidx/compose/runtime/Composer;I)V
+	public static final fun NavigationSetup (Lcom/freeletics/khonshu/navigation/NavEventNavigator;Lcom/freeletics/khonshu/navigation/internal/NavigationExecutor;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/freeletics/khonshu/navigation/compose/OverlayDestination : com/freeletics/khonshu/navigation/compose/ContentDestination {

--- a/navigation-compose/src/main/kotlin/com/freeletics/khonshu/navigation/compose/NavigationSetup.kt
+++ b/navigation-compose/src/main/kotlin/com/freeletics/khonshu/navigation/compose/NavigationSetup.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import com.freeletics.khonshu.navigation.ContractResultOwner
 import com.freeletics.khonshu.navigation.NavEventNavigator
+import com.freeletics.khonshu.navigation.internal.NavigationExecutor
 import com.freeletics.khonshu.navigation.internal.collectAndHandleNavEvents
 import com.freeletics.khonshu.navigation.internal.collectAndHandleNavigationResults
 import com.freeletics.khonshu.navigation.internal.deliverResult
@@ -22,8 +23,7 @@ import com.freeletics.khonshu.navigation.internal.deliverResult
  * are handled while the composition is active.
  */
 @Composable
-public fun NavigationSetup(navigator: NavEventNavigator) {
-    val executor = LocalNavigationExecutor.current
+public fun NavigationSetup(navigator: NavEventNavigator, executor: NavigationExecutor = LocalNavigationExecutor.current) {
     val lifecycleOwner = LocalLifecycleOwner.current
     val context = LocalContext.current
 


### PR DESCRIPTION
Add optional `executor: NavigationExecutor` parameter to `NavigationSetup` to allow for usage outside of `NavHost` for compose navigation.