### PR TITLE
support Modifier parameter in codegen and experimental navigation

### DIFF
--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestNavHostActivity.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestNavHostActivity.kt
@@ -6,10 +6,8 @@ import com.freeletics.khonshu.codegen.ActivityScope
 import com.freeletics.khonshu.codegen.AppScope
 import com.freeletics.khonshu.codegen.ComposableParameter
 import com.freeletics.khonshu.codegen.NavHostActivityData
-import com.freeletics.khonshu.navigation.NavRoot
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.INT
-import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.MAP
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.SET
@@ -30,13 +28,7 @@ internal class FileGeneratorTestNavHostActivity {
         activityBaseClass = ClassName("androidx.activity", "ComponentActivity"),
         navHostParameter = ComposableParameter(
             "navHost",
-            LambdaTypeName.get(
-                null,
-                NavRoot::class.asClassName(),
-                LambdaTypeName.get(null, ClassName("com.freeletics.khonshu.navigation", "BaseRoute"), returnType = UNIT)
-                    .copy(nullable = true),
-                returnType = UNIT,
-            ),
+            ClassName("com.freeletics.khonshu.codegen.compose", "SimpleNavHost"),
         ),
         stateParameter = ComposableParameter("state", ClassName("com.test", "TestState")),
         sendActionParameter = ComposableParameter(
@@ -57,8 +49,9 @@ internal class FileGeneratorTestNavHostActivity {
 
             import androidx.activity.ComponentActivity
             import androidx.compose.runtime.Composable
+            import androidx.compose.ui.Modifier
             import com.freeletics.khonshu.codegen.compose.NavHostActivity
-            import com.freeletics.khonshu.navigation.BaseRoute
+            import com.freeletics.khonshu.codegen.compose.SimpleNavHost
             import com.freeletics.khonshu.navigation.NavRoot
             import com.test.parent.TestParentScope
 
@@ -73,9 +66,9 @@ internal class FileGeneratorTestNavHostActivity {
             public fun Test(
               state: TestState,
               sendAction: (TestAction) -> Unit,
-              navHost: @Composable (NavRoot, ((BaseRoute) -> Unit)?) -> Unit,
+              navHost: SimpleNavHost,
             ) {
-                navHost(TestRoot()) {}
+                navHost(TestRoot(), Modifier) {}
             }
         """.trimIndent()
 
@@ -93,9 +86,8 @@ internal class FileGeneratorTestNavHostActivity {
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
             import com.freeletics.khonshu.codegen.`internal`.asComposeState
             import com.freeletics.khonshu.codegen.`internal`.component
-            import com.freeletics.khonshu.navigation.BaseRoute
+            import com.freeletics.khonshu.codegen.compose.SimpleNavHost
             import com.freeletics.khonshu.navigation.NavEventNavigator
-            import com.freeletics.khonshu.navigation.NavRoot
             import com.freeletics.khonshu.navigation.compose.NavDestination
             import com.freeletics.khonshu.navigation.compose.NavHost
             import com.freeletics.khonshu.navigation.deeplinks.DeepLinkHandler
@@ -109,7 +101,6 @@ internal class FileGeneratorTestNavHostActivity {
             import dagger.multibindings.Multibinds
             import java.io.Closeable
             import kotlin.OptIn
-            import kotlin.Unit
             import kotlin.collections.Set
             import kotlinx.coroutines.launch
 
@@ -185,10 +176,11 @@ internal class FileGeneratorTestNavHostActivity {
                 }
 
                 setContent {
-                  KhonshuTest(khonshuTestComponent) { startRoute, destinationChangedCallback ->
+                  KhonshuTest(khonshuTestComponent) { startRoute, modifier, destinationChangedCallback ->
                     NavHost(
                       startRoute = startRoute,
                       destinations = khonshuTestComponent.destinations,
+                      modifier = modifier,
                       deepLinkHandlers = khonshuTestComponent.deepLinkHandlers,
                       deepLinkPrefixes = khonshuTestComponent.deepLinkPrefixes,
                       navEventNavigator = khonshuTestComponent.navEventNavigator,
@@ -201,8 +193,7 @@ internal class FileGeneratorTestNavHostActivity {
 
             @Composable
             @OptIn(InternalCodegenApi::class)
-            private fun KhonshuTest(component: KhonshuTestComponent, navHost: @Composable (NavRoot,
-                ((BaseRoute) -> Unit)?) -> Unit) {
+            private fun KhonshuTest(component: KhonshuTestComponent, navHost: SimpleNavHost) {
               val stateMachine = remember { component.testStateMachine }
               val state = stateMachine.asComposeState()
               val currentState = state.value
@@ -234,10 +225,10 @@ internal class FileGeneratorTestNavHostActivity {
 
             import androidx.activity.ComponentActivity
             import androidx.compose.runtime.Composable
+            import androidx.compose.ui.Modifier
             import com.freeletics.khonshu.codegen.ActivityScope
             import com.freeletics.khonshu.codegen.compose.NavHostActivity
-            import com.freeletics.khonshu.navigation.BaseRoute
-            import com.freeletics.khonshu.navigation.deeplinks.DeepLinkHandler
+            import com.freeletics.khonshu.codegen.compose.SimpleNavHost
             import com.freeletics.khonshu.navigation.NavRoot
 
             @NavHostActivity(
@@ -249,9 +240,9 @@ internal class FileGeneratorTestNavHostActivity {
             public fun Test(
               state: TestState,
               sendAction: (TestAction) -> Unit,
-              navHost: @Composable (NavRoot, ((BaseRoute) -> Unit)?) -> Unit,
+              navHost: SimpleNavHost,
             ) {
-                navHost(TestRoot()) {}
+                navHost(TestRoot(), Modifier) {}
             }
         """.trimIndent()
 
@@ -271,9 +262,8 @@ internal class FileGeneratorTestNavHostActivity {
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
             import com.freeletics.khonshu.codegen.`internal`.asComposeState
             import com.freeletics.khonshu.codegen.`internal`.component
-            import com.freeletics.khonshu.navigation.BaseRoute
+            import com.freeletics.khonshu.codegen.compose.SimpleNavHost
             import com.freeletics.khonshu.navigation.NavEventNavigator
-            import com.freeletics.khonshu.navigation.NavRoot
             import com.freeletics.khonshu.navigation.compose.NavDestination
             import com.freeletics.khonshu.navigation.compose.NavHost
             import com.freeletics.khonshu.navigation.deeplinks.DeepLinkHandler
@@ -286,7 +276,6 @@ internal class FileGeneratorTestNavHostActivity {
             import dagger.multibindings.Multibinds
             import java.io.Closeable
             import kotlin.OptIn
-            import kotlin.Unit
             import kotlin.collections.Set
             import kotlinx.coroutines.launch
 
@@ -362,10 +351,11 @@ internal class FileGeneratorTestNavHostActivity {
                 }
 
                 setContent {
-                  KhonshuTest(khonshuTestComponent) { startRoute, destinationChangedCallback ->
+                  KhonshuTest(khonshuTestComponent) { startRoute, modifier, destinationChangedCallback ->
                     NavHost(
                       startRoute = startRoute,
                       destinations = khonshuTestComponent.destinations,
+                      modifier = modifier,
                       deepLinkHandlers = khonshuTestComponent.deepLinkHandlers,
                       deepLinkPrefixes = khonshuTestComponent.deepLinkPrefixes,
                       navEventNavigator = khonshuTestComponent.navEventNavigator,
@@ -378,8 +368,7 @@ internal class FileGeneratorTestNavHostActivity {
 
             @Composable
             @OptIn(InternalCodegenApi::class)
-            private fun KhonshuTest(component: KhonshuTestComponent, navHost: @Composable (NavRoot,
-                ((BaseRoute) -> Unit)?) -> Unit) {
+            private fun KhonshuTest(component: KhonshuTestComponent, navHost: SimpleNavHost) {
               val stateMachine = remember { component.testStateMachine }
               val state = stateMachine.asComposeState()
               val currentState = state.value
@@ -428,8 +417,9 @@ internal class FileGeneratorTestNavHostActivity {
 
             import androidx.activity.ComponentActivity
             import androidx.compose.runtime.Composable
+            import androidx.compose.ui.Modifier
             import com.freeletics.khonshu.codegen.compose.NavHostActivity
-            import com.freeletics.khonshu.navigation.BaseRoute
+            import com.freeletics.khonshu.codegen.compose.SimpleNavHost
             import com.freeletics.khonshu.navigation.NavRoot
             import com.test.other.TestClass2
             import com.test.parent.TestParentScope
@@ -449,9 +439,9 @@ internal class FileGeneratorTestNavHostActivity {
                 test: TestClass2,
                 testSet: Set<String>,
                 testMap: Map<String, Int>,
-                navHost: @Composable (NavRoot, ((BaseRoute) -> Unit)?) -> Unit,
+                navHost: SimpleNavHost,
             ) {
-                navHost(TestRoot()) {}
+                navHost(TestRoot(), Modifier) {}
             }
         """.trimIndent()
 
@@ -469,9 +459,8 @@ internal class FileGeneratorTestNavHostActivity {
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
             import com.freeletics.khonshu.codegen.`internal`.asComposeState
             import com.freeletics.khonshu.codegen.`internal`.component
-            import com.freeletics.khonshu.navigation.BaseRoute
+            import com.freeletics.khonshu.codegen.compose.SimpleNavHost
             import com.freeletics.khonshu.navigation.NavEventNavigator
-            import com.freeletics.khonshu.navigation.NavRoot
             import com.freeletics.khonshu.navigation.compose.NavDestination
             import com.freeletics.khonshu.navigation.compose.NavHost
             import com.freeletics.khonshu.navigation.deeplinks.DeepLinkHandler
@@ -488,7 +477,6 @@ internal class FileGeneratorTestNavHostActivity {
             import kotlin.Int
             import kotlin.OptIn
             import kotlin.String
-            import kotlin.Unit
             import kotlin.collections.Map
             import kotlin.collections.Set
             import kotlinx.coroutines.launch
@@ -573,10 +561,11 @@ internal class FileGeneratorTestNavHostActivity {
                 }
 
                 setContent {
-                  KhonshuTest2(khonshuTest2Component) { startRoute, destinationChangedCallback ->
+                  KhonshuTest2(khonshuTest2Component) { startRoute, modifier, destinationChangedCallback ->
                     NavHost(
                       startRoute = startRoute,
                       destinations = khonshuTest2Component.destinations,
+                      modifier = modifier,
                       deepLinkHandlers = khonshuTest2Component.deepLinkHandlers,
                       deepLinkPrefixes = khonshuTest2Component.deepLinkPrefixes,
                       navEventNavigator = khonshuTest2Component.navEventNavigator,
@@ -589,8 +578,7 @@ internal class FileGeneratorTestNavHostActivity {
 
             @Composable
             @OptIn(InternalCodegenApi::class)
-            private fun KhonshuTest2(component: KhonshuTest2Component, navHost: @Composable (NavRoot,
-                ((BaseRoute) -> Unit)?) -> Unit) {
+            private fun KhonshuTest2(component: KhonshuTest2Component, navHost: SimpleNavHost) {
               val testClass = remember { component.testClass }
               val test = remember { component.test }
               val testSet = remember { component.testSet }
@@ -629,8 +617,9 @@ internal class FileGeneratorTestNavHostActivity {
 
             import androidx.activity.ComponentActivity
             import androidx.compose.runtime.Composable
+            import androidx.compose.ui.Modifier
             import com.freeletics.khonshu.codegen.compose.NavHostActivity
-            import com.freeletics.khonshu.navigation.BaseRoute
+            import com.freeletics.khonshu.codegen.compose.SimpleNavHost
             import com.freeletics.khonshu.navigation.NavRoot
             import com.test.parent.TestParentScope
 
@@ -644,9 +633,9 @@ internal class FileGeneratorTestNavHostActivity {
             @Suppress("unused_parameter")
             public fun Test(
               state: TestState,
-              navHost: @Composable (NavRoot, ((BaseRoute) -> Unit)?) -> Unit,
+              navHost: SimpleNavHost,
             ) {
-                navHost(TestRoot()) {}
+                navHost(TestRoot(), Modifier) {}
             }
         """.trimIndent()
 
@@ -663,9 +652,8 @@ internal class FileGeneratorTestNavHostActivity {
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
             import com.freeletics.khonshu.codegen.`internal`.asComposeState
             import com.freeletics.khonshu.codegen.`internal`.component
-            import com.freeletics.khonshu.navigation.BaseRoute
+            import com.freeletics.khonshu.codegen.compose.SimpleNavHost
             import com.freeletics.khonshu.navigation.NavEventNavigator
-            import com.freeletics.khonshu.navigation.NavRoot
             import com.freeletics.khonshu.navigation.compose.NavDestination
             import com.freeletics.khonshu.navigation.compose.NavHost
             import com.freeletics.khonshu.navigation.deeplinks.DeepLinkHandler
@@ -679,7 +667,6 @@ internal class FileGeneratorTestNavHostActivity {
             import dagger.multibindings.Multibinds
             import java.io.Closeable
             import kotlin.OptIn
-            import kotlin.Unit
             import kotlin.collections.Set
 
             @OptIn(InternalCodegenApi::class)
@@ -754,10 +741,11 @@ internal class FileGeneratorTestNavHostActivity {
                 }
 
                 setContent {
-                  KhonshuTest(khonshuTestComponent) { startRoute, destinationChangedCallback ->
+                  KhonshuTest(khonshuTestComponent) { startRoute, modifier, destinationChangedCallback ->
                     NavHost(
                       startRoute = startRoute,
                       destinations = khonshuTestComponent.destinations,
+                      modifier = modifier,
                       deepLinkHandlers = khonshuTestComponent.deepLinkHandlers,
                       deepLinkPrefixes = khonshuTestComponent.deepLinkPrefixes,
                       navEventNavigator = khonshuTestComponent.navEventNavigator,
@@ -770,8 +758,7 @@ internal class FileGeneratorTestNavHostActivity {
 
             @Composable
             @OptIn(InternalCodegenApi::class)
-            private fun KhonshuTest(component: KhonshuTestComponent, navHost: @Composable (NavRoot,
-                ((BaseRoute) -> Unit)?) -> Unit) {
+            private fun KhonshuTest(component: KhonshuTestComponent, navHost: SimpleNavHost) {
               val stateMachine = remember { component.testStateMachine }
               val state = stateMachine.asComposeState()
               val currentState = state.value
@@ -800,8 +787,9 @@ internal class FileGeneratorTestNavHostActivity {
 
             import androidx.activity.ComponentActivity
             import androidx.compose.runtime.Composable
+            import androidx.compose.ui.Modifier
             import com.freeletics.khonshu.codegen.compose.NavHostActivity
-            import com.freeletics.khonshu.navigation.BaseRoute
+            import com.freeletics.khonshu.codegen.compose.SimpleNavHost
             import com.freeletics.khonshu.navigation.NavRoot
             import com.test.parent.TestParentScope
 
@@ -815,9 +803,9 @@ internal class FileGeneratorTestNavHostActivity {
             @Suppress("unused_parameter")
             public fun Test(
               sendAction: (TestAction) -> Unit,
-              navHost: @Composable (NavRoot, ((BaseRoute) -> Unit)?) -> Unit,
+              navHost: SimpleNavHost,
             ) {
-                navHost(TestRoot()) {}
+                navHost(TestRoot(), Modifier) {}
             }
         """.trimIndent()
 
@@ -835,9 +823,8 @@ internal class FileGeneratorTestNavHostActivity {
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
             import com.freeletics.khonshu.codegen.`internal`.asComposeState
             import com.freeletics.khonshu.codegen.`internal`.component
-            import com.freeletics.khonshu.navigation.BaseRoute
+            import com.freeletics.khonshu.codegen.compose.SimpleNavHost
             import com.freeletics.khonshu.navigation.NavEventNavigator
-            import com.freeletics.khonshu.navigation.NavRoot
             import com.freeletics.khonshu.navigation.compose.NavDestination
             import com.freeletics.khonshu.navigation.compose.NavHost
             import com.freeletics.khonshu.navigation.deeplinks.DeepLinkHandler
@@ -851,7 +838,6 @@ internal class FileGeneratorTestNavHostActivity {
             import dagger.multibindings.Multibinds
             import java.io.Closeable
             import kotlin.OptIn
-            import kotlin.Unit
             import kotlin.collections.Set
             import kotlinx.coroutines.launch
 
@@ -927,10 +913,11 @@ internal class FileGeneratorTestNavHostActivity {
                 }
 
                 setContent {
-                  KhonshuTest(khonshuTestComponent) { startRoute, destinationChangedCallback ->
+                  KhonshuTest(khonshuTestComponent) { startRoute, modifier, destinationChangedCallback ->
                     NavHost(
                       startRoute = startRoute,
                       destinations = khonshuTestComponent.destinations,
+                      modifier = modifier,
                       deepLinkHandlers = khonshuTestComponent.deepLinkHandlers,
                       deepLinkPrefixes = khonshuTestComponent.deepLinkPrefixes,
                       navEventNavigator = khonshuTestComponent.navEventNavigator,
@@ -943,8 +930,7 @@ internal class FileGeneratorTestNavHostActivity {
 
             @Composable
             @OptIn(InternalCodegenApi::class)
-            private fun KhonshuTest(component: KhonshuTestComponent, navHost: @Composable (NavRoot,
-                ((BaseRoute) -> Unit)?) -> Unit) {
+            private fun KhonshuTest(component: KhonshuTestComponent, navHost: SimpleNavHost) {
               val stateMachine = remember { component.testStateMachine }
               val state = stateMachine.asComposeState()
               val currentState = state.value
@@ -960,5 +946,180 @@ internal class FileGeneratorTestNavHostActivity {
         """.trimIndent()
 
         test(withoutSendAction, "com/test/Test.kt", source, expected)
+    }
+
+    @Test
+    fun `generates code for NavHostActivityData with lambda parameter`() {
+        // nothing changes on the data side
+        val withLambdaParameter = data
+
+        @Language("kotlin")
+        val source = """
+            package com.test
+
+            import androidx.activity.ComponentActivity
+            import androidx.compose.runtime.Composable
+            import androidx.compose.ui.Modifier
+            import com.freeletics.khonshu.codegen.compose.NavHostActivity
+            import com.freeletics.khonshu.codegen.compose.SimpleNavHost
+            import com.freeletics.khonshu.navigation.BaseRoute
+            import com.freeletics.khonshu.navigation.NavRoot
+            import com.test.parent.TestParentScope
+
+            @NavHostActivity(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+              stateMachine = TestStateMachine::class,
+              activityBaseClass = ComponentActivity::class,
+            )
+            @Composable
+            @Suppress("unused_parameter")
+            public fun Test(
+              state: TestState,
+              sendAction: (TestAction) -> Unit,
+              navHost: @Composable (NavRoot, Modifier, ((BaseRoute) -> Unit)?) -> Unit,
+            ) {
+                navHost(TestRoot(), Modifier) {}
+            }
+        """.trimIndent()
+
+        @Language("kotlin")
+        val expected = """
+            package com.test
+
+            import android.os.Bundle
+            import androidx.activity.ComponentActivity
+            import androidx.activity.compose.setContent
+            import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.remember
+            import androidx.compose.runtime.rememberCoroutineScope
+            import androidx.lifecycle.SavedStateHandle
+            import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
+            import com.freeletics.khonshu.codegen.`internal`.asComposeState
+            import com.freeletics.khonshu.codegen.`internal`.component
+            import com.freeletics.khonshu.codegen.compose.SimpleNavHost
+            import com.freeletics.khonshu.navigation.NavEventNavigator
+            import com.freeletics.khonshu.navigation.compose.NavDestination
+            import com.freeletics.khonshu.navigation.compose.NavHost
+            import com.freeletics.khonshu.navigation.deeplinks.DeepLinkHandler
+            import com.squareup.anvil.annotations.ContributesSubcomponent
+            import com.squareup.anvil.annotations.ContributesTo
+            import com.squareup.anvil.annotations.optional.ForScope
+            import com.squareup.anvil.annotations.optional.SingleIn
+            import com.test.parent.TestParentScope
+            import dagger.BindsInstance
+            import dagger.Module
+            import dagger.multibindings.Multibinds
+            import java.io.Closeable
+            import kotlin.OptIn
+            import kotlin.collections.Set
+            import kotlinx.coroutines.launch
+
+            @OptIn(InternalCodegenApi::class)
+            @SingleIn(TestScreen::class)
+            @ContributesSubcomponent(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+            )
+            public interface KhonshuTestComponent : Closeable {
+              public val testStateMachine: TestStateMachine
+
+              @get:ForScope(TestScreen::class)
+              public val navEventNavigator: NavEventNavigator
+
+              public val destinations: Set<NavDestination>
+
+              public val deepLinkHandlers: Set<DeepLinkHandler>
+
+              public val deepLinkPrefixes: Set<DeepLinkHandler.Prefix>
+
+              @get:ForScope(TestScreen::class)
+              public val closeables: Set<Closeable>
+
+              override fun close() {
+                closeables.forEach {
+                  it.close()
+                }
+              }
+
+              @ContributesSubcomponent.Factory
+              public interface Factory {
+                public fun create(@BindsInstance @ForScope(TestScreen::class)
+                    savedStateHandle: SavedStateHandle, @BindsInstance @ForScope(TestScreen::class)
+                    arguments: Bundle): KhonshuTestComponent
+              }
+
+              @ContributesTo(TestParentScope::class)
+              public interface ParentComponent {
+                public fun khonshuTestComponentFactory(): Factory
+              }
+            }
+
+            @Module
+            @ContributesTo(TestScreen::class)
+            public interface KhonshuTestModule {
+              @Multibinds
+              @ForScope(TestScreen::class)
+              public fun bindCloseables(): Set<Closeable>
+            }
+
+            @Module
+            @ContributesTo(TestScreen::class)
+            public interface KhonshuTestActivityModule {
+              @Multibinds
+              public fun bindDeepLinkHandler(): Set<DeepLinkHandler>
+
+              @Multibinds
+              public fun bindDeepLinkPrefix(): Set<DeepLinkHandler.Prefix>
+            }
+
+            @OptIn(InternalCodegenApi::class)
+            public class KhonshuTestActivity : ComponentActivity() {
+              private lateinit var khonshuTestComponent: KhonshuTestComponent
+
+              override fun onCreate(savedInstanceState: Bundle?) {
+                super.onCreate(savedInstanceState)
+                if (!::khonshuTestComponent.isInitialized) {
+                  khonshuTestComponent = component(this, this, TestParentScope::class, intent.extras) {
+                      parentComponent: KhonshuTestComponent.ParentComponent, savedStateHandle, extras ->
+                    parentComponent.khonshuTestComponentFactory().create(savedStateHandle, extras)
+                  }
+                }
+
+                setContent {
+                  KhonshuTest(khonshuTestComponent) { startRoute, modifier, destinationChangedCallback ->
+                    NavHost(
+                      startRoute = startRoute,
+                      destinations = khonshuTestComponent.destinations,
+                      modifier = modifier,
+                      deepLinkHandlers = khonshuTestComponent.deepLinkHandlers,
+                      deepLinkPrefixes = khonshuTestComponent.deepLinkPrefixes,
+                      navEventNavigator = khonshuTestComponent.navEventNavigator,
+                      destinationChangedCallback = destinationChangedCallback,
+                    )
+                  }
+                }
+              }
+            }
+
+            @Composable
+            @OptIn(InternalCodegenApi::class)
+            private fun KhonshuTest(component: KhonshuTestComponent, navHost: SimpleNavHost) {
+              val stateMachine = remember { component.testStateMachine }
+              val state = stateMachine.asComposeState()
+              val currentState = state.value
+              if (currentState != null) {
+                val scope = rememberCoroutineScope()
+                Test(
+                  state = currentState,
+                  sendAction = { scope.launch { stateMachine.dispatch(it) } },
+                  navHost = navHost,
+                )
+              }
+            }
+
+        """.trimIndent()
+
+        test(withLambdaParameter, "com/test/Test.kt", source, expected)
     }
 }

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/TestHelper.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/TestHelper.kt
@@ -12,7 +12,7 @@ import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
 
 internal fun test(data: BaseData, fileName: String, source: String, expectedCode: String) {
     compile(fileName = fileName, source = source, data = data, expectedCode = expectedCode)
-    compileWithAnvil(fileName = fileName, source = source, expectedCode = expectedCode)
+//    compileWithAnvil(fileName = fileName, source = source, expectedCode = expectedCode)
     compileWithKsp(fileName = fileName, source = source, expectedCode = expectedCode)
 }
 

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/TestHelper.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/TestHelper.kt
@@ -12,7 +12,7 @@ import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
 
 internal fun test(data: BaseData, fileName: String, source: String, expectedCode: String) {
     compile(fileName = fileName, source = source, data = data, expectedCode = expectedCode)
-//    compileWithAnvil(fileName = fileName, source = source, expectedCode = expectedCode)
+    compileWithAnvil(fileName = fileName, source = source, expectedCode = expectedCode)
     compileWithKsp(fileName = fileName, source = source, expectedCode = expectedCode)
 }
 

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/compose/ActivityGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/compose/ActivityGenerator.kt
@@ -59,13 +59,14 @@ internal class ActivityGenerator(
             .addStatement("")
             .beginControlFlow("%M", setContent)
             .beginControlFlow(
-                "%L(%L) { startRoute, destinationChangedCallback ->",
+                "%L(%L) { startRoute, modifier, destinationChangedCallback ->",
                 composableName,
                 retainedComponentClassName.propertyName,
             )
             .addStatement("%M(", navHost)
             .addStatement("  startRoute = startRoute,")
             .addStatement("  destinations = %L.destinations,", retainedComponentClassName.propertyName)
+            .addStatement("  modifier = modifier,")
             .addStatement("  deepLinkHandlers = %L.deepLinkHandlers,", retainedComponentClassName.propertyName)
             .addStatement("  deepLinkPrefixes = %L.deepLinkPrefixes,", retainedComponentClassName.propertyName)
             .addStatement("  navEventNavigator = %L.navEventNavigator,", retainedComponentClassName.propertyName)

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/util/External.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/util/External.kt
@@ -52,9 +52,11 @@ internal val fragmentDialogDestination = MemberName("com.freeletics.khonshu.navi
 internal val fragmentRequireRoute = MemberName("com.freeletics.khonshu.navigation.fragment", "requireRoute")
 internal val internalNavigatorApi = ClassName("com.freeletics.khonshu.navigation.internal", "InternalNavigationApi")
 
-internal val navHostLambda = LambdaTypeName.get(
+internal val simpleNavHost = ClassName("com.freeletics.khonshu.codegen.compose", "SimpleNavHost")
+internal val simpleNavHostLambda = LambdaTypeName.get(
     null,
     NavRoot::class.asClassName(),
+    ClassName("androidx.compose.ui", "Modifier"),
     LambdaTypeName.get(null, baseRoute, returnType = UNIT).copy(nullable = true),
     returnType = UNIT,
 )
@@ -66,6 +68,7 @@ internal val stateMachine = ClassName("com.freeletics.khonshu.statemachine", "St
 internal val optIn = ClassName("kotlin", "OptIn")
 internal val function1 = ClassName("kotlin", "Function1")
 internal val function2 = ClassName("kotlin", "Function2")
+internal val function3 = ClassName("kotlin", "Function3")
 
 // Coroutines
 internal val launch = MemberName("kotlinx.coroutines", "launch")

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/util/KotlinPoet.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/util/KotlinPoet.kt
@@ -46,10 +46,7 @@ internal fun bindsInstanceParameter(
 }
 
 internal fun navHostParameter(parameter: ComposableParameter): ParameterSpec {
-    return ParameterSpec.builder(
-        parameter.name,
-        parameter.typeName.copy(annotations = listOf(AnnotationSpec.builder(composable).build())),
-    )
+    return ParameterSpec.builder(parameter.name, simpleNavHost)
         .build()
 }
 
@@ -141,7 +138,7 @@ internal fun TypeName.asLambdaParameter(): TypeName {
 // KSP and Anvil don't have the same behavior for returning lambdas
 // this turns all Function1 and Function2 types into lambdas
 internal fun TypeName.functionToLambda(): TypeName {
-    if (this is ParameterizedTypeName && (rawType == function1 || rawType == function2)) {
+    if (this is ParameterizedTypeName && (rawType == function1 || rawType == function2 || rawType == function3)) {
         val parameters = typeArguments.dropLast(1).map { it.functionToLambda() }.toTypedArray()
         return LambdaTypeName.get(null, *parameters, returnType = typeArguments.last())
             .copy(nullable = isNullable)

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/anvil/CommonParser.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/anvil/CommonParser.kt
@@ -7,8 +7,9 @@ import com.freeletics.khonshu.codegen.codegen.util.asLambdaParameter
 import com.freeletics.khonshu.codegen.codegen.util.baseRouteFqName
 import com.freeletics.khonshu.codegen.codegen.util.fragment
 import com.freeletics.khonshu.codegen.codegen.util.functionToLambda
-import com.freeletics.khonshu.codegen.codegen.util.navHostLambda
 import com.freeletics.khonshu.codegen.codegen.util.overlayFqName
+import com.freeletics.khonshu.codegen.codegen.util.simpleNavHost
+import com.freeletics.khonshu.codegen.codegen.util.simpleNavHostLambda
 import com.freeletics.khonshu.codegen.codegen.util.stateMachine
 import com.squareup.anvil.compiler.internal.reference.AnnotationReference
 import com.squareup.anvil.compiler.internal.reference.AnvilCompilationExceptionClassReference
@@ -69,10 +70,10 @@ private fun ParameterReference.toComposableParameter(condition: (TypeName) -> Bo
 }
 
 internal fun TopLevelFunctionReference.navHostParameter(): ComposableParameter {
-    return getParameterWithType(navHostLambda)
+    return getParameterWithType(simpleNavHost) ?: getParameterWithType(simpleNavHostLambda)
         ?: throw AnvilCompilationExceptionFunctionReference(
             this,
-            "Could not find a NavHost parameter with type $navHostLambda",
+            "Could not find a NavHost parameter with type $simpleNavHostLambda",
         )
 }
 

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/ksp/CommonParser.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/ksp/CommonParser.kt
@@ -3,8 +3,9 @@ package com.freeletics.khonshu.codegen.parser.ksp
 import com.freeletics.khonshu.codegen.ComposableParameter
 import com.freeletics.khonshu.codegen.codegen.util.asLambdaParameter
 import com.freeletics.khonshu.codegen.codegen.util.baseRoute
-import com.freeletics.khonshu.codegen.codegen.util.navHostLambda
 import com.freeletics.khonshu.codegen.codegen.util.overlay
+import com.freeletics.khonshu.codegen.codegen.util.simpleNavHost
+import com.freeletics.khonshu.codegen.codegen.util.simpleNavHostLambda
 import com.freeletics.khonshu.codegen.codegen.util.stateMachine
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.KSPLogger
@@ -74,9 +75,9 @@ private fun KSValueParameter.toComposableParameter(condition: (TypeName) -> Bool
 }
 
 internal fun KSFunctionDeclaration.navHostParameter(logger: KSPLogger): ComposableParameter? {
-    val parameter = getParameterWithType(navHostLambda)
+    val parameter = getParameterWithType(simpleNavHost) ?: getParameterWithType(simpleNavHostLambda)
     if (parameter == null) {
-        logger.error("Could not find a NavHost parameter with type $navHostLambda")
+        logger.error("Could not find a NavHost parameter with type $simpleNavHostLambda")
     }
     return parameter
 }

--- a/codegen/codegen.gradle.kts
+++ b/codegen/codegen.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     "commonMainApi"(projects.stateMachine)
     "commonMainApi"(projects.navigation)
     "commonMainApi"(libs.jetbrains.compose.runtime)
+    "commonMainApi"(libs.jetbrains.compose.ui)
     "commonMainApi"(libs.inject)
 
     "androidMainApi"(libs.androidx.viewmodel)

--- a/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/compose/NavHostActivity.kt
+++ b/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/compose/NavHostActivity.kt
@@ -1,7 +1,11 @@
 package com.freeletics.khonshu.codegen.compose
 
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import com.freeletics.khonshu.codegen.ActivityScope
 import com.freeletics.khonshu.codegen.AppScope
+import com.freeletics.khonshu.navigation.BaseRoute
+import com.freeletics.khonshu.navigation.NavRoot
 import com.freeletics.khonshu.statemachine.StateMachine
 import kotlin.reflect.KClass
 
@@ -9,15 +13,12 @@ import kotlin.reflect.KClass
  * Add this annotation to a [androidx.compose.runtime.Composable] function. It is required that
  * the annotated function has `State` as first parameter and `(Action) -> Unit` as second parameter,
  * where `State` and `Action` match the given `StateMachine`. It should also have a parameter of
- * type `@Composable (NavRoot, ((BaseRoute) -> Unit)?) -> Unit`, which is a `NavHost` composable
- * that should be placed within the annotated composable.
+ * type `SimpleNavHost`, which is a `NavHost` composable that should be placed within the annotated composable.
  *
  * This will trigger the generation of
  * - an `Activity` that extends [activityBaseClass] and displays the annotated composable
  * - a wrapper Composable that sets up the annotated Composable with the given [stateMachine]
  * - a Dagger subcomponent that uses [scope] as scope marker and [parentScope] as `parentScope`
- * - a `NavDestination` for [route] based on the given [destinationType] that is contributed
- *   to the Dagger component that uses [destinationScope]
  */
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
@@ -27,3 +28,13 @@ public annotation class NavHostActivity(
     val stateMachine: KClass<out StateMachine<*, *>>,
     val activityBaseClass: KClass<*>,
 )
+
+/**
+ * A simplified wrapper around `NavHost`
+ *
+ * Parameters:
+ * - [NavRoot]: the start destination of the `NavHost`
+ * - [Modifier]: passed to `NavHost`
+ * - an optional destination changed callback
+ */
+public typealias SimpleNavHost = @Composable (NavRoot, Modifier, ((BaseRoute) -> Unit)?) -> Unit

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,8 +69,10 @@ androidx-compose-compiler = { module = "androidx.compose.compiler:compiler", ver
 androidx-compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "androidx-compose-runtime" }
 androidx-compose-runtime-saveable = { module = "androidx.compose.runtime:runtime-saveable", version.ref = "androidx-compose-runtime" }
 androidx-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "androidx-compose-ui" }
+androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "androidx-compose-ui" }
 androidx-compose-animation = { module = "androidx.compose.animation:animation", version.ref = "androidx-compose-animation" }
 jetbrains-compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "jetbrains-compose" }
+jetbrains-compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "jetbrains-compose" }
 jetbrains-compose-compiler = { module = "org.jetbrains.compose.compiler:compiler", version.ref = "jetbrains-compose-compiler" }
 
 androidx-activity = { module = "androidx.activity:activity-ktx", version.ref = "androidx-activity" }

--- a/navigation-experimental/api/navigation-experimental.api
+++ b/navigation-experimental/api/navigation-experimental.api
@@ -7,7 +7,7 @@ public abstract interface class com/freeletics/khonshu/navigation/compose/NavDes
 }
 
 public final class com/freeletics/khonshu/navigation/compose/NavHostKt {
-	public static final fun NavHost (Lcom/freeletics/khonshu/navigation/NavRoot;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Lcom/freeletics/khonshu/navigation/NavEventNavigator;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public static final fun NavHost (Lcom/freeletics/khonshu/navigation/NavRoot;Ljava/util/Set;Landroidx/compose/ui/Modifier;Ljava/util/Set;Ljava/util/Set;Lcom/freeletics/khonshu/navigation/NavEventNavigator;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/freeletics/khonshu/navigation/compose/NavigationSetupKt {

--- a/navigation-experimental/navigation-experimental.gradle.kts
+++ b/navigation-experimental/navigation-experimental.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation(libs.androidx.activity)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.compose.runtime.saveable)
+    implementation(libs.androidx.compose.foundation)
     implementation(libs.androidx.core)
     implementation(libs.androidx.lifecycle.common)
     implementation(libs.androidx.viewmodel)

--- a/navigation-experimental/src/main/kotlin/com/freeletics/khonshu/navigation/compose/NavHost.kt
+++ b/navigation-experimental/src/main/kotlin/com/freeletics/khonshu/navigation/compose/NavHost.kt
@@ -2,6 +2,7 @@ package com.freeletics.khonshu.navigation.compose
 
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
@@ -12,6 +13,7 @@ import androidx.compose.runtime.saveable.SaveableStateHolder
 import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Modifier
 import com.freeletics.khonshu.navigation.BaseRoute
 import com.freeletics.khonshu.navigation.NavEventNavigator
 import com.freeletics.khonshu.navigation.NavRoot
@@ -47,6 +49,7 @@ import kotlinx.coroutines.flow.map
 public fun NavHost(
     startRoute: NavRoot,
     destinations: Set<NavDestination>,
+    modifier: Modifier = Modifier,
     deepLinkHandlers: Set<DeepLinkHandler> = emptySet(),
     deepLinkPrefixes: Set<DeepLinkHandler.Prefix> = emptySet(),
     navEventNavigator: NavEventNavigator? = null,
@@ -63,8 +66,10 @@ public fun NavHost(
             NavigationSetup(navEventNavigator)
         }
 
-        val entries = executor.visibleEntries.value
-        Show(entries, executor, saveableStateHolder)
+        Box(modifier = modifier) {
+            val entries = executor.visibleEntries.value
+            Show(entries, executor, saveableStateHolder)
+        }
     }
 }
 

--- a/sample/simple/feature/main/feature-main.gradle.kts
+++ b/sample/simple/feature/main/feature-main.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
 
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.compose.foundation)
     implementation(libs.androidx.lifecycle.common)
     implementation(libs.androidx.lifecycle.viewmodel)
     implementation(libs.khonshu.navigator)

--- a/sample/simple/feature/main/src/main/kotlin/com/freeletics/khonshu/sample/feature/main/MainScreen.kt
+++ b/sample/simple/feature/main/src/main/kotlin/com/freeletics/khonshu/sample/feature/main/MainScreen.kt
@@ -1,10 +1,11 @@
 package com.freeletics.khonshu.sample.feature.main
 
 import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import com.freeletics.khonshu.codegen.compose.NavHostActivity
-import com.freeletics.khonshu.navigation.BaseRoute
-import com.freeletics.khonshu.navigation.NavRoot
+import com.freeletics.khonshu.codegen.compose.SimpleNavHost
 import com.freeletics.khonshu.sample.feature.root.nav.RootRoute
 
 @NavHostActivity(
@@ -13,7 +14,7 @@ import com.freeletics.khonshu.sample.feature.root.nav.RootRoute
 )
 @Composable
 internal fun MainScreen(
-    navHost: @Composable (NavRoot, ((BaseRoute) -> Unit)?) -> Unit,
+    navHost: SimpleNavHost,
 ) {
-    navHost(RootRoute) {}
+    navHost(RootRoute, Modifier.fillMaxSize()) {}
 }


### PR DESCRIPTION
I've introduced `SimpleNavHost` as a typealias for the nav host function that codegen requires. That makes future changes easier (they're still breaking changes since an additional parameter needs to be passed).

On the experimental navigation side the `Modifier` is for now used for a `Box` that wraps the content. This will probably change once we look into animations and/or predictive back. The AndroidX `NavHost` is using it on `AnimatedContent` that wraps the screens.