### PR TITLE
use ImmutableSet for NavHost parameters

### DIFF
--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestNavHostActivity.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/FileGeneratorTestNavHostActivity.kt
@@ -98,10 +98,14 @@ internal class FileGeneratorTestNavHostActivity {
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
             import dagger.Module
+            import dagger.Provides
             import dagger.multibindings.Multibinds
             import java.io.Closeable
             import kotlin.OptIn
             import kotlin.collections.Set
+            import kotlin.jvm.JvmSuppressWildcards
+            import kotlinx.collections.immutable.ImmutableSet
+            import kotlinx.collections.immutable.toImmutableSet
             import kotlinx.coroutines.launch
 
             @OptIn(InternalCodegenApi::class)
@@ -116,11 +120,11 @@ internal class FileGeneratorTestNavHostActivity {
               @get:ForScope(TestScreen::class)
               public val navEventNavigator: NavEventNavigator
 
-              public val destinations: Set<NavDestination>
+              public val destinations: ImmutableSet<NavDestination>
 
-              public val deepLinkHandlers: Set<DeepLinkHandler>
+              public val deepLinkHandlers: ImmutableSet<DeepLinkHandler>
 
-              public val deepLinkPrefixes: Set<DeepLinkHandler.Prefix>
+              public val deepLinkPrefixes: ImmutableSet<DeepLinkHandler.Prefix>
 
               @get:ForScope(TestScreen::class)
               public val closeables: Set<Closeable>
@@ -160,6 +164,21 @@ internal class FileGeneratorTestNavHostActivity {
 
               @Multibinds
               public fun bindDeepLinkPrefix(): Set<DeepLinkHandler.Prefix>
+
+              public companion object {
+                @Provides
+                public fun provideImmutableNavDestinations(destinations: @JvmSuppressWildcards
+                    Set<NavDestination>): ImmutableSet<NavDestination> = destinations.toImmutableSet()
+
+                @Provides
+                public fun provideImmutableDeepLinkHandlers(handlers: @JvmSuppressWildcards
+                    Set<DeepLinkHandler>): ImmutableSet<DeepLinkHandler> = handlers.toImmutableSet()
+
+                @Provides
+                public fun provideImmutableDeepLinkPrefixes(prefixes: @JvmSuppressWildcards
+                    Set<DeepLinkHandler.Prefix>): ImmutableSet<DeepLinkHandler.Prefix> =
+                    prefixes.toImmutableSet()
+              }
             }
 
             @OptIn(InternalCodegenApi::class)
@@ -273,10 +292,14 @@ internal class FileGeneratorTestNavHostActivity {
             import com.squareup.anvil.annotations.optional.SingleIn
             import dagger.BindsInstance
             import dagger.Module
+            import dagger.Provides
             import dagger.multibindings.Multibinds
             import java.io.Closeable
             import kotlin.OptIn
             import kotlin.collections.Set
+            import kotlin.jvm.JvmSuppressWildcards
+            import kotlinx.collections.immutable.ImmutableSet
+            import kotlinx.collections.immutable.toImmutableSet
             import kotlinx.coroutines.launch
 
             @OptIn(InternalCodegenApi::class)
@@ -291,11 +314,11 @@ internal class FileGeneratorTestNavHostActivity {
               @get:ForScope(ActivityScope::class)
               public val navEventNavigator: NavEventNavigator
 
-              public val destinations: Set<NavDestination>
+              public val destinations: ImmutableSet<NavDestination>
 
-              public val deepLinkHandlers: Set<DeepLinkHandler>
+              public val deepLinkHandlers: ImmutableSet<DeepLinkHandler>
 
-              public val deepLinkPrefixes: Set<DeepLinkHandler.Prefix>
+              public val deepLinkPrefixes: ImmutableSet<DeepLinkHandler.Prefix>
 
               @get:ForScope(ActivityScope::class)
               public val closeables: Set<Closeable>
@@ -335,6 +358,21 @@ internal class FileGeneratorTestNavHostActivity {
 
               @Multibinds
               public fun bindDeepLinkPrefix(): Set<DeepLinkHandler.Prefix>
+
+              public companion object {
+                @Provides
+                public fun provideImmutableNavDestinations(destinations: @JvmSuppressWildcards
+                    Set<NavDestination>): ImmutableSet<NavDestination> = destinations.toImmutableSet()
+
+                @Provides
+                public fun provideImmutableDeepLinkHandlers(handlers: @JvmSuppressWildcards
+                    Set<DeepLinkHandler>): ImmutableSet<DeepLinkHandler> = handlers.toImmutableSet()
+
+                @Provides
+                public fun provideImmutableDeepLinkPrefixes(prefixes: @JvmSuppressWildcards
+                    Set<DeepLinkHandler.Prefix>): ImmutableSet<DeepLinkHandler.Prefix> =
+                    prefixes.toImmutableSet()
+              }
             }
 
             @OptIn(InternalCodegenApi::class)
@@ -472,6 +510,7 @@ internal class FileGeneratorTestNavHostActivity {
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
             import dagger.Module
+            import dagger.Provides
             import dagger.multibindings.Multibinds
             import java.io.Closeable
             import kotlin.Int
@@ -479,6 +518,9 @@ internal class FileGeneratorTestNavHostActivity {
             import kotlin.String
             import kotlin.collections.Map
             import kotlin.collections.Set
+            import kotlin.jvm.JvmSuppressWildcards
+            import kotlinx.collections.immutable.ImmutableSet
+            import kotlinx.collections.immutable.toImmutableSet
             import kotlinx.coroutines.launch
 
             @OptIn(InternalCodegenApi::class)
@@ -501,11 +543,11 @@ internal class FileGeneratorTestNavHostActivity {
 
               public val testMap: Map<String, Int>
 
-              public val destinations: Set<NavDestination>
+              public val destinations: ImmutableSet<NavDestination>
 
-              public val deepLinkHandlers: Set<DeepLinkHandler>
+              public val deepLinkHandlers: ImmutableSet<DeepLinkHandler>
 
-              public val deepLinkPrefixes: Set<DeepLinkHandler.Prefix>
+              public val deepLinkPrefixes: ImmutableSet<DeepLinkHandler.Prefix>
 
               @get:ForScope(TestScreen::class)
               public val closeables: Set<Closeable>
@@ -545,6 +587,21 @@ internal class FileGeneratorTestNavHostActivity {
 
               @Multibinds
               public fun bindDeepLinkPrefix(): Set<DeepLinkHandler.Prefix>
+
+              public companion object {
+                @Provides
+                public fun provideImmutableNavDestinations(destinations: @JvmSuppressWildcards
+                    Set<NavDestination>): ImmutableSet<NavDestination> = destinations.toImmutableSet()
+
+                @Provides
+                public fun provideImmutableDeepLinkHandlers(handlers: @JvmSuppressWildcards
+                    Set<DeepLinkHandler>): ImmutableSet<DeepLinkHandler> = handlers.toImmutableSet()
+
+                @Provides
+                public fun provideImmutableDeepLinkPrefixes(prefixes: @JvmSuppressWildcards
+                    Set<DeepLinkHandler.Prefix>): ImmutableSet<DeepLinkHandler.Prefix> =
+                    prefixes.toImmutableSet()
+              }
             }
 
             @OptIn(InternalCodegenApi::class)
@@ -664,10 +721,14 @@ internal class FileGeneratorTestNavHostActivity {
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
             import dagger.Module
+            import dagger.Provides
             import dagger.multibindings.Multibinds
             import java.io.Closeable
             import kotlin.OptIn
             import kotlin.collections.Set
+            import kotlin.jvm.JvmSuppressWildcards
+            import kotlinx.collections.immutable.ImmutableSet
+            import kotlinx.collections.immutable.toImmutableSet
 
             @OptIn(InternalCodegenApi::class)
             @SingleIn(TestScreen::class)
@@ -681,11 +742,11 @@ internal class FileGeneratorTestNavHostActivity {
               @get:ForScope(TestScreen::class)
               public val navEventNavigator: NavEventNavigator
 
-              public val destinations: Set<NavDestination>
+              public val destinations: ImmutableSet<NavDestination>
 
-              public val deepLinkHandlers: Set<DeepLinkHandler>
+              public val deepLinkHandlers: ImmutableSet<DeepLinkHandler>
 
-              public val deepLinkPrefixes: Set<DeepLinkHandler.Prefix>
+              public val deepLinkPrefixes: ImmutableSet<DeepLinkHandler.Prefix>
 
               @get:ForScope(TestScreen::class)
               public val closeables: Set<Closeable>
@@ -725,6 +786,21 @@ internal class FileGeneratorTestNavHostActivity {
 
               @Multibinds
               public fun bindDeepLinkPrefix(): Set<DeepLinkHandler.Prefix>
+
+              public companion object {
+                @Provides
+                public fun provideImmutableNavDestinations(destinations: @JvmSuppressWildcards
+                    Set<NavDestination>): ImmutableSet<NavDestination> = destinations.toImmutableSet()
+
+                @Provides
+                public fun provideImmutableDeepLinkHandlers(handlers: @JvmSuppressWildcards
+                    Set<DeepLinkHandler>): ImmutableSet<DeepLinkHandler> = handlers.toImmutableSet()
+
+                @Provides
+                public fun provideImmutableDeepLinkPrefixes(prefixes: @JvmSuppressWildcards
+                    Set<DeepLinkHandler.Prefix>): ImmutableSet<DeepLinkHandler.Prefix> =
+                    prefixes.toImmutableSet()
+              }
             }
 
             @OptIn(InternalCodegenApi::class)
@@ -835,10 +911,14 @@ internal class FileGeneratorTestNavHostActivity {
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
             import dagger.Module
+            import dagger.Provides
             import dagger.multibindings.Multibinds
             import java.io.Closeable
             import kotlin.OptIn
             import kotlin.collections.Set
+            import kotlin.jvm.JvmSuppressWildcards
+            import kotlinx.collections.immutable.ImmutableSet
+            import kotlinx.collections.immutable.toImmutableSet
             import kotlinx.coroutines.launch
 
             @OptIn(InternalCodegenApi::class)
@@ -853,11 +933,11 @@ internal class FileGeneratorTestNavHostActivity {
               @get:ForScope(TestScreen::class)
               public val navEventNavigator: NavEventNavigator
 
-              public val destinations: Set<NavDestination>
+              public val destinations: ImmutableSet<NavDestination>
 
-              public val deepLinkHandlers: Set<DeepLinkHandler>
+              public val deepLinkHandlers: ImmutableSet<DeepLinkHandler>
 
-              public val deepLinkPrefixes: Set<DeepLinkHandler.Prefix>
+              public val deepLinkPrefixes: ImmutableSet<DeepLinkHandler.Prefix>
 
               @get:ForScope(TestScreen::class)
               public val closeables: Set<Closeable>
@@ -897,6 +977,21 @@ internal class FileGeneratorTestNavHostActivity {
 
               @Multibinds
               public fun bindDeepLinkPrefix(): Set<DeepLinkHandler.Prefix>
+
+              public companion object {
+                @Provides
+                public fun provideImmutableNavDestinations(destinations: @JvmSuppressWildcards
+                    Set<NavDestination>): ImmutableSet<NavDestination> = destinations.toImmutableSet()
+
+                @Provides
+                public fun provideImmutableDeepLinkHandlers(handlers: @JvmSuppressWildcards
+                    Set<DeepLinkHandler>): ImmutableSet<DeepLinkHandler> = handlers.toImmutableSet()
+
+                @Provides
+                public fun provideImmutableDeepLinkPrefixes(prefixes: @JvmSuppressWildcards
+                    Set<DeepLinkHandler.Prefix>): ImmutableSet<DeepLinkHandler.Prefix> =
+                    prefixes.toImmutableSet()
+              }
             }
 
             @OptIn(InternalCodegenApi::class)
@@ -1009,10 +1104,14 @@ internal class FileGeneratorTestNavHostActivity {
             import com.test.parent.TestParentScope
             import dagger.BindsInstance
             import dagger.Module
+            import dagger.Provides
             import dagger.multibindings.Multibinds
             import java.io.Closeable
             import kotlin.OptIn
             import kotlin.collections.Set
+            import kotlin.jvm.JvmSuppressWildcards
+            import kotlinx.collections.immutable.ImmutableSet
+            import kotlinx.collections.immutable.toImmutableSet
             import kotlinx.coroutines.launch
 
             @OptIn(InternalCodegenApi::class)
@@ -1027,11 +1126,11 @@ internal class FileGeneratorTestNavHostActivity {
               @get:ForScope(TestScreen::class)
               public val navEventNavigator: NavEventNavigator
 
-              public val destinations: Set<NavDestination>
+              public val destinations: ImmutableSet<NavDestination>
 
-              public val deepLinkHandlers: Set<DeepLinkHandler>
+              public val deepLinkHandlers: ImmutableSet<DeepLinkHandler>
 
-              public val deepLinkPrefixes: Set<DeepLinkHandler.Prefix>
+              public val deepLinkPrefixes: ImmutableSet<DeepLinkHandler.Prefix>
 
               @get:ForScope(TestScreen::class)
               public val closeables: Set<Closeable>
@@ -1071,6 +1170,21 @@ internal class FileGeneratorTestNavHostActivity {
 
               @Multibinds
               public fun bindDeepLinkPrefix(): Set<DeepLinkHandler.Prefix>
+
+              public companion object {
+                @Provides
+                public fun provideImmutableNavDestinations(destinations: @JvmSuppressWildcards
+                    Set<NavDestination>): ImmutableSet<NavDestination> = destinations.toImmutableSet()
+
+                @Provides
+                public fun provideImmutableDeepLinkHandlers(handlers: @JvmSuppressWildcards
+                    Set<DeepLinkHandler>): ImmutableSet<DeepLinkHandler> = handlers.toImmutableSet()
+
+                @Provides
+                public fun provideImmutableDeepLinkPrefixes(prefixes: @JvmSuppressWildcards
+                    Set<DeepLinkHandler.Prefix>): ImmutableSet<DeepLinkHandler.Prefix> =
+                    prefixes.toImmutableSet()
+              }
             }
 
             @OptIn(InternalCodegenApi::class)

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/common/ComponentGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/common/ComponentGenerator.kt
@@ -11,6 +11,7 @@ import com.freeletics.khonshu.codegen.codegen.util.contributesToAnnotation
 import com.freeletics.khonshu.codegen.codegen.util.deepLinkHandler
 import com.freeletics.khonshu.codegen.codegen.util.deepLinkPrefix
 import com.freeletics.khonshu.codegen.codegen.util.forScope
+import com.freeletics.khonshu.codegen.codegen.util.immutableSet
 import com.freeletics.khonshu.codegen.codegen.util.navEventNavigator
 import com.freeletics.khonshu.codegen.codegen.util.optInAnnotation
 import com.freeletics.khonshu.codegen.codegen.util.savedStateHandle
@@ -80,9 +81,9 @@ internal class ComponentGenerator(
                 }
                 if (data is NavHostActivityData) {
                     properties += listOf(
-                        PropertySpec.builder("destinations", SET.parameterizedBy(composeDestination)).build(),
-                        PropertySpec.builder("deepLinkHandlers", SET.parameterizedBy(deepLinkHandler)).build(),
-                        PropertySpec.builder("deepLinkPrefixes", SET.parameterizedBy(deepLinkPrefix)).build(),
+                        PropertySpec.builder("destinations", immutableSet.parameterizedBy(composeDestination)).build(),
+                        PropertySpec.builder("deepLinkHandlers", immutableSet.parameterizedBy(deepLinkHandler)).build(),
+                        PropertySpec.builder("deepLinkPrefixes", immutableSet.parameterizedBy(deepLinkPrefix)).build(),
                     )
                 }
             }

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/compose/ActivityModuleGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/compose/ActivityModuleGenerator.kt
@@ -2,11 +2,16 @@ package com.freeletics.khonshu.codegen.codegen.compose
 
 import com.freeletics.khonshu.codegen.BaseData
 import com.freeletics.khonshu.codegen.codegen.Generator
+import com.freeletics.khonshu.codegen.codegen.util.composeDestination
 import com.freeletics.khonshu.codegen.codegen.util.contributesToAnnotation
 import com.freeletics.khonshu.codegen.codegen.util.deepLinkHandler
 import com.freeletics.khonshu.codegen.codegen.util.deepLinkPrefix
+import com.freeletics.khonshu.codegen.codegen.util.immutableSet
+import com.freeletics.khonshu.codegen.codegen.util.jvmSuppressWildcards
 import com.freeletics.khonshu.codegen.codegen.util.module
 import com.freeletics.khonshu.codegen.codegen.util.multibinds
+import com.freeletics.khonshu.codegen.codegen.util.provides
+import com.freeletics.khonshu.codegen.codegen.util.toImmutableSet
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier.ABSTRACT
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
@@ -25,6 +30,7 @@ internal class ActivityModuleGenerator(
             .addAnnotation(contributesToAnnotation(data.scope))
             .addFunction(bindDeepLinkHandlerFunction())
             .addFunction(bindDeepLinkPrefixFunction())
+            .addType(companionObject())
             .build()
     }
 
@@ -41,6 +47,41 @@ internal class ActivityModuleGenerator(
             .addModifiers(ABSTRACT)
             .addAnnotation(multibinds)
             .returns(SET.parameterizedBy(deepLinkPrefix))
+            .build()
+    }
+
+    private fun companionObject(): TypeSpec {
+        return TypeSpec.companionObjectBuilder()
+            .addFunction(provideImmutableNavDestinationsFunction())
+            .addFunction(provideImmutableDeepLinkHandlersFunction())
+            .addFunction(provideImmutableDeepLinkHandlerPrefixesFunction())
+            .build()
+    }
+
+    private fun provideImmutableNavDestinationsFunction(): FunSpec {
+        return FunSpec.builder("provideImmutableNavDestinations")
+            .addAnnotation(provides)
+            .addParameter("destinations", SET.parameterizedBy(composeDestination).jvmSuppressWildcards())
+            .returns(immutableSet.parameterizedBy(composeDestination))
+            .addStatement("return destinations.%M()", toImmutableSet)
+            .build()
+    }
+
+    private fun provideImmutableDeepLinkHandlersFunction(): FunSpec {
+        return FunSpec.builder("provideImmutableDeepLinkHandlers")
+            .addAnnotation(provides)
+            .addParameter("handlers", SET.parameterizedBy(deepLinkHandler).jvmSuppressWildcards())
+            .returns(immutableSet.parameterizedBy(deepLinkHandler))
+            .addStatement("return handlers.%M()", toImmutableSet)
+            .build()
+    }
+
+    private fun provideImmutableDeepLinkHandlerPrefixesFunction(): FunSpec {
+        return FunSpec.builder("provideImmutableDeepLinkPrefixes")
+            .addAnnotation(provides)
+            .addParameter("prefixes", SET.parameterizedBy(deepLinkPrefix).jvmSuppressWildcards())
+            .returns(immutableSet.parameterizedBy(deepLinkPrefix))
+            .addStatement("return prefixes.%M()", toImmutableSet)
             .build()
     }
 }

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/util/External.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/util/External.kt
@@ -73,6 +73,10 @@ internal val function3 = ClassName("kotlin", "Function3")
 // Coroutines
 internal val launch = MemberName("kotlinx.coroutines", "launch")
 
+// Collections Immutable
+internal val immutableSet = ClassName("kotlinx.collections.immutable", "ImmutableSet")
+internal val toImmutableSet = MemberName("kotlinx.collections.immutable", "toImmutableSet")
+
 // Dagger
 internal val provides = ClassName("dagger", "Provides")
 internal val multibinds = ClassName("dagger.multibindings", "Multibinds")

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/util/KotlinPoet.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/util/KotlinPoet.kt
@@ -45,6 +45,11 @@ internal fun bindsInstanceParameter(
         .build()
 }
 
+internal fun TypeName.jvmSuppressWildcards(): TypeName {
+    val suppress = AnnotationSpec.builder(JvmSuppressWildcards::class).build()
+    return copy(annotations = annotations + suppress)
+}
+
 internal fun navHostParameter(parameter: ComposableParameter): ParameterSpec {
     return ParameterSpec.builder(parameter.name, simpleNavHost)
         .build()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -65,6 +65,8 @@ kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 
+collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version = "0.3.6"}
+
 androidx-compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "androidx-compose-compiler" }
 androidx-compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "androidx-compose-runtime" }
 androidx-compose-runtime-saveable = { module = "androidx.compose.runtime:runtime-saveable", version.ref = "androidx-compose-runtime" }

--- a/navigation-compose/api/navigation-compose.api
+++ b/navigation-compose/api/navigation-compose.api
@@ -14,8 +14,8 @@ public final class com/freeletics/khonshu/navigation/compose/NavHostDefaults {
 }
 
 public final class com/freeletics/khonshu/navigation/compose/NavHostKt {
-	public static final fun NavHost (Lcom/freeletics/khonshu/navigation/NavRoot;Ljava/util/Set;Landroidx/compose/ui/Modifier;Ljava/util/Set;Ljava/util/Set;Lcom/freeletics/khonshu/navigation/NavEventNavigator;Lkotlin/jvm/functions/Function1;Lcom/freeletics/khonshu/navigation/compose/NavHostTransitionAnimations;Landroidx/compose/runtime/Composer;II)V
-	public static final fun NavHost (Lcom/freeletics/khonshu/navigation/NavRoute;Ljava/util/Set;Landroidx/compose/ui/Modifier;Ljava/util/Set;Ljava/util/Set;Lcom/freeletics/khonshu/navigation/NavEventNavigator;Lkotlin/jvm/functions/Function1;Lcom/freeletics/khonshu/navigation/compose/NavHostTransitionAnimations;Landroidx/compose/runtime/Composer;II)V
+	public static final fun NavHost (Lcom/freeletics/khonshu/navigation/NavRoot;Lkotlinx/collections/immutable/ImmutableSet;Landroidx/compose/ui/Modifier;Lkotlinx/collections/immutable/ImmutableSet;Lkotlinx/collections/immutable/ImmutableSet;Lcom/freeletics/khonshu/navigation/NavEventNavigator;Lkotlin/jvm/functions/Function1;Lcom/freeletics/khonshu/navigation/compose/NavHostTransitionAnimations;Landroidx/compose/runtime/Composer;II)V
+	public static final fun NavHost (Lcom/freeletics/khonshu/navigation/NavRoute;Lkotlinx/collections/immutable/ImmutableSet;Landroidx/compose/ui/Modifier;Lkotlinx/collections/immutable/ImmutableSet;Lkotlinx/collections/immutable/ImmutableSet;Lcom/freeletics/khonshu/navigation/NavEventNavigator;Lkotlin/jvm/functions/Function1;Lcom/freeletics/khonshu/navigation/compose/NavHostTransitionAnimations;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/freeletics/khonshu/navigation/compose/NavHostTransitionAnimations {

--- a/navigation-compose/navigation-compose.gradle.kts
+++ b/navigation-compose/navigation-compose.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     api(libs.androidx.compose.runtime)
     api(libs.androidx.compose.ui)
     api(libs.androidx.navigation.common)
+    api(libs.collections.immutable)
 
     implementation(projects.navigationAndroidx)
     implementation(libs.coroutines.core)

--- a/navigation-compose/src/main/kotlin/com/freeletics/khonshu/navigation/compose/NavHost.kt
+++ b/navigation-compose/src/main/kotlin/com/freeletics/khonshu/navigation/compose/NavHost.kt
@@ -44,6 +44,8 @@ import com.freeletics.khonshu.navigation.internal.getArguments
 import com.freeletics.khonshu.navigation.internal.handleDeepLink
 import com.freeletics.khonshu.navigation.internal.requireRoute
 import java.io.Serializable
+import kotlinx.collections.immutable.ImmutableSet
+import kotlinx.collections.immutable.persistentSetOf
 
 /**
  * Create a new [androidx.navigation.compose.NavHost] with a [androidx.navigation.NavGraph]
@@ -68,10 +70,10 @@ import java.io.Serializable
 @NonRestartableComposable
 public fun NavHost(
     startRoute: NavRoot,
-    destinations: Set<NavDestination>,
+    destinations: ImmutableSet<NavDestination>,
     modifier: Modifier = Modifier,
-    deepLinkHandlers: Set<DeepLinkHandler> = emptySet(),
-    deepLinkPrefixes: Set<DeepLinkHandler.Prefix> = emptySet(),
+    deepLinkHandlers: ImmutableSet<DeepLinkHandler> = persistentSetOf(),
+    deepLinkPrefixes: ImmutableSet<DeepLinkHandler.Prefix> = persistentSetOf(),
     navEventNavigator: NavEventNavigator? = null,
     destinationChangedCallback: ((BaseRoute) -> Unit)? = null,
     transitionAnimations: NavHostTransitionAnimations = NavHostDefaults.transitionAnimations(),
@@ -112,10 +114,10 @@ public fun NavHost(
 @Deprecated("Will eventually be removed. The start destination should use a NavRoot")
 public fun NavHost(
     startRoute: NavRoute,
-    destinations: Set<NavDestination>,
+    destinations: ImmutableSet<NavDestination>,
     modifier: Modifier = Modifier,
-    deepLinkHandlers: Set<DeepLinkHandler> = emptySet(),
-    deepLinkPrefixes: Set<DeepLinkHandler.Prefix> = emptySet(),
+    deepLinkHandlers: ImmutableSet<DeepLinkHandler> = persistentSetOf(),
+    deepLinkPrefixes: ImmutableSet<DeepLinkHandler.Prefix> = persistentSetOf(),
     navEventNavigator: NavEventNavigator? = null,
     destinationChangedCallback: ((BaseRoute) -> Unit)? = null,
     transitionAnimations: NavHostTransitionAnimations = NavHostDefaults.transitionAnimations(),

--- a/navigation-experimental/api/navigation-experimental.api
+++ b/navigation-experimental/api/navigation-experimental.api
@@ -7,7 +7,7 @@ public abstract interface class com/freeletics/khonshu/navigation/compose/NavDes
 }
 
 public final class com/freeletics/khonshu/navigation/compose/NavHostKt {
-	public static final fun NavHost (Lcom/freeletics/khonshu/navigation/NavRoot;Ljava/util/Set;Landroidx/compose/ui/Modifier;Ljava/util/Set;Ljava/util/Set;Lcom/freeletics/khonshu/navigation/NavEventNavigator;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public static final fun NavHost (Lcom/freeletics/khonshu/navigation/NavRoot;Lkotlinx/collections/immutable/ImmutableSet;Landroidx/compose/ui/Modifier;Lkotlinx/collections/immutable/ImmutableSet;Lkotlinx/collections/immutable/ImmutableSet;Lcom/freeletics/khonshu/navigation/NavEventNavigator;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/freeletics/khonshu/navigation/compose/NavigationSetupKt {

--- a/navigation-experimental/navigation-experimental.gradle.kts
+++ b/navigation-experimental/navigation-experimental.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     api(projects.navigation)
     api(libs.androidx.compose.runtime)
     api(libs.androidx.compose.ui)
+    api(libs.collections.immutable)
 
     implementation(libs.coroutines.core)
     implementation(libs.androidx.annotations)

--- a/navigation-experimental/src/main/kotlin/com/freeletics/khonshu/navigation/compose/NavHost.kt
+++ b/navigation-experimental/src/main/kotlin/com/freeletics/khonshu/navigation/compose/NavHost.kt
@@ -25,6 +25,7 @@ import com.freeletics.khonshu.navigation.internal.InternalNavigationApi
 import com.freeletics.khonshu.navigation.internal.NavigationExecutor
 import java.io.Closeable
 import java.lang.ref.WeakReference
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -69,20 +70,10 @@ public fun NavHost(
         }
 
         Box(modifier = modifier) {
-            val entries = executor.visibleEntries.value
-            Show(entries, executor, saveableStateHolder)
+            executor.visibleEntries.value.forEach { entry ->
+                Show(entry, executor, saveableStateHolder)
+            }
         }
-    }
-}
-
-@Composable
-private fun Show(
-    entries: List<StackEntry<*>>,
-    executor: MultiStackNavigationExecutor,
-    saveableStateHolder: SaveableStateHolder,
-) {
-    entries.forEach { entry ->
-        Show(entry, executor, saveableStateHolder)
     }
 }
 

--- a/navigation-experimental/src/main/kotlin/com/freeletics/khonshu/navigation/compose/NavHost.kt
+++ b/navigation-experimental/src/main/kotlin/com/freeletics/khonshu/navigation/compose/NavHost.kt
@@ -25,7 +25,6 @@ import com.freeletics.khonshu.navigation.internal.InternalNavigationApi
 import com.freeletics.khonshu.navigation.internal.NavigationExecutor
 import java.io.Closeable
 import java.lang.ref.WeakReference
-import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.coroutines.flow.distinctUntilChanged

--- a/navigation-experimental/src/main/kotlin/com/freeletics/khonshu/navigation/compose/NavHost.kt
+++ b/navigation-experimental/src/main/kotlin/com/freeletics/khonshu/navigation/compose/NavHost.kt
@@ -25,6 +25,8 @@ import com.freeletics.khonshu.navigation.internal.InternalNavigationApi
 import com.freeletics.khonshu.navigation.internal.NavigationExecutor
 import java.io.Closeable
 import java.lang.ref.WeakReference
+import kotlinx.collections.immutable.ImmutableSet
+import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 
@@ -48,10 +50,10 @@ import kotlinx.coroutines.flow.map
 @Composable
 public fun NavHost(
     startRoute: NavRoot,
-    destinations: Set<NavDestination>,
+    destinations: ImmutableSet<NavDestination>,
     modifier: Modifier = Modifier,
-    deepLinkHandlers: Set<DeepLinkHandler> = emptySet(),
-    deepLinkPrefixes: Set<DeepLinkHandler.Prefix> = emptySet(),
+    deepLinkHandlers: ImmutableSet<DeepLinkHandler> = persistentSetOf(),
+    deepLinkPrefixes: ImmutableSet<DeepLinkHandler.Prefix> = persistentSetOf(),
     navEventNavigator: NavEventNavigator? = null,
     destinationChangedCallback: ((BaseRoute) -> Unit)? = null,
 ) {

--- a/navigation-experimental/src/main/kotlin/com/freeletics/khonshu/navigation/compose/internal/MultiStack.kt
+++ b/navigation-experimental/src/main/kotlin/com/freeletics/khonshu/navigation/compose/internal/MultiStack.kt
@@ -12,6 +12,7 @@ import com.freeletics.khonshu.navigation.compose.ContentDestination
 import com.freeletics.khonshu.navigation.internal.DestinationId
 import com.freeletics.khonshu.navigation.internal.destinationId
 import java.util.UUID
+import kotlinx.collections.immutable.ImmutableList
 
 internal class MultiStack(
     private val allStacks: MutableList<Stack>,
@@ -22,9 +23,9 @@ internal class MultiStack(
     private val idGenerator: () -> String,
 ) {
 
-    private val visibleEntryState: MutableState<List<StackEntry<*>>> =
+    private val visibleEntryState: MutableState<ImmutableList<StackEntry<*>>> =
         mutableStateOf(currentStack.computeVisibleEntries())
-    val visibleEntries: State<List<StackEntry<*>>>
+    val visibleEntries: State<ImmutableList<StackEntry<*>>>
         get() = visibleEntryState
 
     private val canNavigateBackState: MutableState<Boolean> =

--- a/navigation-experimental/src/main/kotlin/com/freeletics/khonshu/navigation/compose/internal/MultiStackNavigationExecutor.kt
+++ b/navigation-experimental/src/main/kotlin/com/freeletics/khonshu/navigation/compose/internal/MultiStackNavigationExecutor.kt
@@ -11,6 +11,7 @@ import com.freeletics.khonshu.navigation.internal.DestinationId
 import com.freeletics.khonshu.navigation.internal.NavigationExecutor
 import com.freeletics.khonshu.navigation.internal.destinationId
 import java.io.Serializable
+import kotlinx.collections.immutable.ImmutableList
 
 internal class MultiStackNavigationExecutor(
     private val stack: MultiStack,
@@ -19,11 +20,9 @@ internal class MultiStackNavigationExecutor(
     deepLinkRoutes: List<Parcelable>,
 ) : NavigationExecutor {
 
-    @Suppress("unused") // TODO
-    val visibleEntries: State<List<StackEntry<*>>>
+    val visibleEntries: State<ImmutableList<StackEntry<*>>>
         get() = stack.visibleEntries
 
-    @Suppress("unused") // TODO
     val canNavigateBack: State<Boolean>
         get() = stack.canNavigateBack
 

--- a/navigation-experimental/src/main/kotlin/com/freeletics/khonshu/navigation/compose/internal/Stack.kt
+++ b/navigation-experimental/src/main/kotlin/com/freeletics/khonshu/navigation/compose/internal/Stack.kt
@@ -10,6 +10,9 @@ import com.freeletics.khonshu.navigation.compose.ScreenDestination
 import com.freeletics.khonshu.navigation.internal.DestinationId
 import com.freeletics.khonshu.navigation.internal.destinationId
 import java.util.UUID
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 
 internal class Stack private constructor(
     initialStack: List<StackEntry<*>>,
@@ -30,9 +33,9 @@ internal class Stack private constructor(
         return stack.findLast { it.destinationId == destinationId } as StackEntry<T>?
     }
 
-    fun computeVisibleEntries(): List<StackEntry<*>> {
+    fun computeVisibleEntries(): ImmutableList<StackEntry<*>> {
         if (stack.size == 1) {
-            return stack.toList()
+            return persistentListOf(stack.single())
         }
 
         // go through the stack from the top until reaching the first ScreenDestination
@@ -45,7 +48,7 @@ internal class Stack private constructor(
                     while (iterator.hasNext()) {
                         add(iterator.next())
                     }
-                }
+                }.toImmutableList()
             }
         }
 


### PR DESCRIPTION
Closes #609 

Allow compose to infer the immutability of the destination and deeplink sets by using `ImmutableSet` instead. In the codegen we're generating a provides for each set that turns Dagger's set into an immutable one.

I've also updated the internal `visibleEntries` list of the experimental implementation to use `ImmutableList`.