### PR TITLE
extract interfaces out of NavEventNavigator

### DIFF
--- a/navigation-androidx/src/main/kotlin/com/freeletics/khonshu/navigation/internal/AndroidXNavigationExecutor.kt
+++ b/navigation-androidx/src/main/kotlin/com/freeletics/khonshu/navigation/internal/AndroidXNavigationExecutor.kt
@@ -16,15 +16,15 @@ public class AndroidXNavigationExecutor(
     private val controller: NavController,
 ) : NavigationExecutor {
 
-    override fun navigate(route: NavRoute) {
+    override fun navigateTo(route: NavRoute) {
         controller.navigate(route.destinationId(), route.getArguments())
     }
 
-    override fun navigate(route: ActivityRoute) {
+    override fun navigateTo(route: ActivityRoute) {
         controller.navigate(route.destinationId(), route.getArguments())
     }
 
-    override fun navigate(root: NavRoot, restoreRootState: Boolean) {
+    override fun navigateToRoot(root: NavRoot, restoreRootState: Boolean) {
         val options = NavOptions.Builder()
             // save the state of the current root before leaving it
             .setPopUpTo(
@@ -49,8 +49,8 @@ public class AndroidXNavigationExecutor(
         controller.navigateUp()
     }
 
-    override fun <T : BaseRoute> navigateBackTo(destinationId: DestinationId<T>, isInclusive: Boolean) {
-        controller.popBackStack(destinationId.destinationId(), isInclusive)
+    override fun <T : BaseRoute> navigateBackToInternal(popUpTo: DestinationId<T>, inclusive: Boolean) {
+        controller.popBackStack(popUpTo.destinationId(), inclusive)
     }
 
     override fun resetToRoot(root: NavRoot) {

--- a/navigation-experimental/src/main/kotlin/com/freeletics/khonshu/navigation/compose/internal/MultiStackNavigationExecutor.kt
+++ b/navigation-experimental/src/main/kotlin/com/freeletics/khonshu/navigation/compose/internal/MultiStackNavigationExecutor.kt
@@ -41,7 +41,7 @@ internal class MultiStackNavigationExecutor(
                         stack.push(route, clearTargetStack = true)
                     }
                     is NavRoute -> stack.push(route)
-                    is ActivityRoute -> navigate(route)
+                    is ActivityRoute -> navigateTo(route)
                 }
             }
         }
@@ -54,15 +54,15 @@ internal class MultiStackNavigationExecutor(
         }
     }
 
-    override fun navigate(route: NavRoute) {
+    override fun navigateTo(route: NavRoute) {
         stack.push(route)
     }
 
-    override fun navigate(root: NavRoot, restoreRootState: Boolean) {
+    override fun navigateToRoot(root: NavRoot, restoreRootState: Boolean) {
         stack.push(root, clearTargetStack = !restoreRootState)
     }
 
-    override fun navigate(route: ActivityRoute) {
+    override fun navigateTo(route: ActivityRoute) {
         activityStarter(route)
     }
 
@@ -74,11 +74,11 @@ internal class MultiStackNavigationExecutor(
         stack.pop()
     }
 
-    override fun <T : BaseRoute> navigateBackTo(
-        destinationId: DestinationId<T>,
-        isInclusive: Boolean,
+    override fun <T : BaseRoute> navigateBackToInternal(
+        popUpTo: DestinationId<T>,
+        inclusive: Boolean,
     ) {
-        stack.popUpTo(destinationId, isInclusive)
+        stack.popUpTo(popUpTo, inclusive)
     }
 
     override fun resetToRoot(root: NavRoot) {

--- a/navigation-experimental/src/test/kotlin/com/freeletics/khonshu/navigation/compose/internal/MultiStackNavigationExecutorTest.kt
+++ b/navigation-experimental/src/test/kotlin/com/freeletics/khonshu/navigation/compose/internal/MultiStackNavigationExecutorTest.kt
@@ -227,7 +227,7 @@ internal class MultiStackNavigationExecutorTest {
     @Test
     fun `visibleEntries contains new entry after navigating to screen destination`() {
         val executor = underTest()
-        executor.navigate(SimpleRoute(2))
+        executor.navigateTo(SimpleRoute(2))
 
         assertThat(executor.visibleEntries.value)
             .containsExactly(
@@ -242,7 +242,7 @@ internal class MultiStackNavigationExecutorTest {
     @Test
     fun `visibleEntries contains original and new entry after navigating to dialog destination`() {
         val executor = underTest()
-        executor.navigate(OtherRoute(3))
+        executor.navigateTo(OtherRoute(3))
 
         assertThat(executor.visibleEntries.value)
             .containsExactly(
@@ -258,7 +258,7 @@ internal class MultiStackNavigationExecutorTest {
     @Test
     fun `visibleEntries contains original and new entry after navigating to bottom sheet destination`() {
         val executor = underTest()
-        executor.navigate(ThirdRoute(4))
+        executor.navigateTo(ThirdRoute(4))
 
         assertThat(executor.visibleEntries.value)
             .containsExactly(
@@ -274,15 +274,15 @@ internal class MultiStackNavigationExecutorTest {
     @Test
     fun `visibleEntries contains all entries starting from last screen`() {
         val executor = underTest()
-        executor.navigate(SimpleRoute(2))
-        executor.navigate(SimpleRoute(3))
-        executor.navigate(SimpleRoute(4))
-        executor.navigate(SimpleRoute(5))
-        executor.navigate(OtherRoute(6))
-        executor.navigate(ThirdRoute(7))
-        executor.navigate(OtherRoute(8))
-        executor.navigate(OtherRoute(9))
-        executor.navigate(ThirdRoute(10))
+        executor.navigateTo(SimpleRoute(2))
+        executor.navigateTo(SimpleRoute(3))
+        executor.navigateTo(SimpleRoute(4))
+        executor.navigateTo(SimpleRoute(5))
+        executor.navigateTo(OtherRoute(6))
+        executor.navigateTo(ThirdRoute(7))
+        executor.navigateTo(OtherRoute(8))
+        executor.navigateTo(OtherRoute(9))
+        executor.navigateTo(ThirdRoute(10))
 
         assertThat(executor.visibleEntries.value)
             .containsExactly(
@@ -302,15 +302,15 @@ internal class MultiStackNavigationExecutorTest {
     @Test
     fun `visibleEntries contains all entries starting from last screen 2`() {
         val executor = underTest()
-        executor.navigate(SimpleRoute(2))
-        executor.navigate(SimpleRoute(3))
-        executor.navigate(SimpleRoute(4))
-        executor.navigate(OtherRoute(5))
-        executor.navigate(ThirdRoute(6))
-        executor.navigate(SimpleRoute(7))
-        executor.navigate(OtherRoute(8))
-        executor.navigate(OtherRoute(9))
-        executor.navigate(ThirdRoute(10))
+        executor.navigateTo(SimpleRoute(2))
+        executor.navigateTo(SimpleRoute(3))
+        executor.navigateTo(SimpleRoute(4))
+        executor.navigateTo(OtherRoute(5))
+        executor.navigateTo(ThirdRoute(6))
+        executor.navigateTo(SimpleRoute(7))
+        executor.navigateTo(OtherRoute(8))
+        executor.navigateTo(OtherRoute(9))
+        executor.navigateTo(ThirdRoute(10))
 
         assertThat(executor.visibleEntries.value)
             .containsExactly(
@@ -328,7 +328,7 @@ internal class MultiStackNavigationExecutorTest {
     @Test
     fun `navigate with root and without clearing the target executor`() {
         val executor = underTest()
-        executor.navigate(OtherRoot(1), restoreRootState = true)
+        executor.navigateToRoot(OtherRoot(1), restoreRootState = true)
 
         assertThat(executor.visibleEntries.value)
             .containsExactly(
@@ -343,9 +343,9 @@ internal class MultiStackNavigationExecutorTest {
     @Test
     fun `navigate with same root twice`() {
         val executor = underTest()
-        executor.navigate(OtherRoot(1), restoreRootState = true)
+        executor.navigateToRoot(OtherRoot(1), restoreRootState = true)
         val exception = assertThrows(IllegalStateException::class.java) {
-            executor.navigate(OtherRoot(1), restoreRootState = true)
+            executor.navigateToRoot(OtherRoot(1), restoreRootState = true)
         }
 
         assertThat(exception).hasMessageThat()
@@ -355,7 +355,7 @@ internal class MultiStackNavigationExecutorTest {
     @Test
     fun `navigate with root multiple times without clearing the target executor`() {
         val executor = underTest()
-        executor.navigate(OtherRoot(1), restoreRootState = true)
+        executor.navigateToRoot(OtherRoot(1), restoreRootState = true)
 
         assertThat(executor.visibleEntries.value)
             .containsExactly(
@@ -364,7 +364,7 @@ internal class MultiStackNavigationExecutorTest {
             .inOrder()
         assertThat(executor.canNavigateBack.value).isTrue()
 
-        executor.navigate(SimpleRoot(1), restoreRootState = true)
+        executor.navigateToRoot(SimpleRoot(1), restoreRootState = true)
 
         assertThat(executor.visibleEntries.value)
             .containsExactly(
@@ -373,7 +373,7 @@ internal class MultiStackNavigationExecutorTest {
             .inOrder()
         assertThat(executor.canNavigateBack.value).isFalse()
 
-        executor.navigate(OtherRoot(1), restoreRootState = true)
+        executor.navigateToRoot(OtherRoot(1), restoreRootState = true)
 
         assertThat(executor.visibleEntries.value)
             .containsExactly(
@@ -388,7 +388,7 @@ internal class MultiStackNavigationExecutorTest {
     @Test
     fun `navigate with root multiple times with clearing the target executor`() {
         val executor = underTest()
-        executor.navigate(OtherRoot(1), restoreRootState = false)
+        executor.navigateToRoot(OtherRoot(1), restoreRootState = false)
 
         assertThat(executor.visibleEntries.value)
             .containsExactly(
@@ -403,7 +403,7 @@ internal class MultiStackNavigationExecutorTest {
     @Test
     fun `navigate with root and clearing the target executor`() {
         val executor = underTest()
-        executor.navigate(OtherRoot(1), restoreRootState = false)
+        executor.navigateToRoot(OtherRoot(1), restoreRootState = false)
 
         assertThat(executor.visibleEntries.value)
             .containsExactly(
@@ -412,7 +412,7 @@ internal class MultiStackNavigationExecutorTest {
             .inOrder()
         assertThat(executor.canNavigateBack.value).isTrue()
 
-        executor.navigate(SimpleRoot(1), restoreRootState = false)
+        executor.navigateToRoot(SimpleRoot(1), restoreRootState = false)
 
         assertThat(executor.visibleEntries.value)
             .containsExactly(
@@ -421,7 +421,7 @@ internal class MultiStackNavigationExecutorTest {
             .inOrder()
         assertThat(executor.canNavigateBack.value).isFalse()
 
-        executor.navigate(OtherRoot(1), restoreRootState = false)
+        executor.navigateToRoot(OtherRoot(1), restoreRootState = false)
 
         assertThat(executor.visibleEntries.value)
             .containsExactly(
@@ -436,8 +436,8 @@ internal class MultiStackNavigationExecutorTest {
     @Test
     fun `navigate with root and without clearing the target executor from within back executor`() {
         val executor = underTest()
-        executor.navigate(SimpleRoute(1))
-        executor.navigate(OtherRoot(1), restoreRootState = true)
+        executor.navigateTo(SimpleRoute(1))
+        executor.navigateToRoot(OtherRoot(1), restoreRootState = true)
 
         assertThat(executor.visibleEntries.value)
             .containsExactly(
@@ -452,9 +452,9 @@ internal class MultiStackNavigationExecutorTest {
     @Test
     fun `navigate with root multiple times and without clearing the target executor from within back executor`() {
         val executor = underTest()
-        executor.navigate(SimpleRoute(1))
-        executor.navigate(OtherRoot(1), restoreRootState = true)
-        executor.navigate(SimpleRoot(1), restoreRootState = true)
+        executor.navigateTo(SimpleRoute(1))
+        executor.navigateToRoot(OtherRoot(1), restoreRootState = true)
+        executor.navigateToRoot(SimpleRoot(1), restoreRootState = true)
 
         assertThat(executor.visibleEntries.value)
             .containsExactly(
@@ -469,7 +469,7 @@ internal class MultiStackNavigationExecutorTest {
     @Test
     fun `resetToRoot with start root from start executor`() {
         val executor = underTest()
-        executor.navigate(SimpleRoute(1))
+        executor.navigateTo(SimpleRoute(1))
         executor.resetToRoot(SimpleRoot(2))
 
         assertThat(executor.visibleEntries.value)
@@ -485,7 +485,7 @@ internal class MultiStackNavigationExecutorTest {
     @Test
     fun `resetToRoot with start root from other executor`() {
         val executor = underTest()
-        executor.navigate(OtherRoot(1), restoreRootState = true)
+        executor.navigateToRoot(OtherRoot(1), restoreRootState = true)
         executor.resetToRoot(SimpleRoot(2))
 
         assertThat(executor.visibleEntries.value)
@@ -524,7 +524,7 @@ internal class MultiStackNavigationExecutorTest {
     @Test
     fun `visibleEntries contains root entry after navigateUp`() {
         val executor = underTest()
-        executor.navigate(SimpleRoute(2))
+        executor.navigateTo(SimpleRoute(2))
 
         assertThat(executor.visibleEntries.value)
             .containsExactly(
@@ -548,7 +548,7 @@ internal class MultiStackNavigationExecutorTest {
     @Test
     fun `navigating the same route again after navigateUp will result in different executor entries`() {
         val executor = underTest()
-        executor.navigate(SimpleRoute(2))
+        executor.navigateTo(SimpleRoute(2))
 
         assertThat(executor.visibleEntries.value)
             .containsExactly(
@@ -558,7 +558,7 @@ internal class MultiStackNavigationExecutorTest {
         assertThat(executor.canNavigateBack.value).isTrue()
 
         executor.navigateUp()
-        executor.navigate(SimpleRoute(2))
+        executor.navigateTo(SimpleRoute(2))
 
         assertThat(executor.visibleEntries.value)
             .containsExactly(
@@ -573,7 +573,7 @@ internal class MultiStackNavigationExecutorTest {
     @Test
     fun `navigateUp from the root of a second executor`() {
         val executor = underTest()
-        executor.navigate(OtherRoot(2), restoreRootState = false)
+        executor.navigateToRoot(OtherRoot(2), restoreRootState = false)
 
         val exception = assertThrows(IllegalStateException::class.java) {
             executor.navigateUp()
@@ -585,8 +585,8 @@ internal class MultiStackNavigationExecutorTest {
     @Test
     fun `navigateUp in a second executor`() {
         val executor = underTest()
-        executor.navigate(OtherRoot(2), restoreRootState = false)
-        executor.navigate(SimpleRoute(3))
+        executor.navigateToRoot(OtherRoot(2), restoreRootState = false)
+        executor.navigateTo(SimpleRoute(3))
 
         assertThat(executor.visibleEntries.value)
             .containsExactly(
@@ -620,7 +620,7 @@ internal class MultiStackNavigationExecutorTest {
     @Test
     fun `visibleEntries contains root entry after pop`() {
         val executor = underTest()
-        executor.navigate(SimpleRoute(2))
+        executor.navigateTo(SimpleRoute(2))
 
         assertThat(executor.visibleEntries.value)
             .containsExactly(
@@ -644,7 +644,7 @@ internal class MultiStackNavigationExecutorTest {
     @Test
     fun `navigating the same route again after pop will result in different executor entries`() {
         val executor = underTest()
-        executor.navigate(SimpleRoute(2))
+        executor.navigateTo(SimpleRoute(2))
 
         assertThat(executor.visibleEntries.value)
             .containsExactly(
@@ -654,7 +654,7 @@ internal class MultiStackNavigationExecutorTest {
         assertThat(executor.canNavigateBack.value).isTrue()
 
         executor.navigateBack()
-        executor.navigate(SimpleRoute(2))
+        executor.navigateTo(SimpleRoute(2))
 
         assertThat(executor.visibleEntries.value)
             .containsExactly(
@@ -669,7 +669,7 @@ internal class MultiStackNavigationExecutorTest {
     @Test
     fun `navigateBack from a second root`() {
         val executor = underTest()
-        executor.navigate(OtherRoot(2), restoreRootState = false)
+        executor.navigateToRoot(OtherRoot(2), restoreRootState = false)
 
         assertThat(executor.visibleEntries.value)
             .containsExactly(
@@ -693,7 +693,7 @@ internal class MultiStackNavigationExecutorTest {
     @Test
     fun `navigateBack from a second root and navigating there again`() {
         val executor = underTest()
-        executor.navigate(OtherRoot(2), restoreRootState = false)
+        executor.navigateToRoot(OtherRoot(2), restoreRootState = false)
 
         assertThat(executor.visibleEntries.value)
             .containsExactly(
@@ -703,7 +703,7 @@ internal class MultiStackNavigationExecutorTest {
         assertThat(executor.canNavigateBack.value).isTrue()
 
         executor.navigateBack()
-        executor.navigate(OtherRoot(2), restoreRootState = false)
+        executor.navigateToRoot(OtherRoot(2), restoreRootState = false)
 
         assertThat(executor.visibleEntries.value)
             .containsExactly(
@@ -718,8 +718,8 @@ internal class MultiStackNavigationExecutorTest {
     @Test
     fun `navigateBack in a second root`() {
         val executor = underTest()
-        executor.navigate(OtherRoot(2), restoreRootState = false)
-        executor.navigate(SimpleRoute(3))
+        executor.navigateToRoot(OtherRoot(2), restoreRootState = false)
+        executor.navigateTo(SimpleRoute(3))
 
         assertThat(executor.visibleEntries.value)
             .containsExactly(
@@ -743,19 +743,19 @@ internal class MultiStackNavigationExecutorTest {
     @Test
     fun `popUpTo removes all destinations until first matching entry, inclusive false`() {
         val executor = underTest()
-        executor.navigate(SimpleRoute(2))
-        executor.navigate(SimpleRoute(3))
-        executor.navigate(SimpleRoute(4))
-        executor.navigate(SimpleRoute(5))
-        executor.navigate(OtherRoute(6))
-        executor.navigate(ThirdRoute(7))
-        executor.navigate(OtherRoute(8))
-        executor.navigate(OtherRoute(9))
-        executor.navigate(ThirdRoute(10))
+        executor.navigateTo(SimpleRoute(2))
+        executor.navigateTo(SimpleRoute(3))
+        executor.navigateTo(SimpleRoute(4))
+        executor.navigateTo(SimpleRoute(5))
+        executor.navigateTo(OtherRoute(6))
+        executor.navigateTo(ThirdRoute(7))
+        executor.navigateTo(OtherRoute(8))
+        executor.navigateTo(OtherRoute(9))
+        executor.navigateTo(ThirdRoute(10))
 
         assertThat(executor.visibleEntries.value).hasSize(6)
 
-        executor.navigateBackTo(simpleRouteDestination.id, isInclusive = false)
+        executor.navigateBackToInternal(simpleRouteDestination.id, inclusive = false)
 
         assertThat(executor.visibleEntries.value)
             .containsExactly(
@@ -776,19 +776,19 @@ internal class MultiStackNavigationExecutorTest {
     @Test
     fun `popUpTo removes all destinations until first matching entry, inclusive true`() {
         val executor = underTest()
-        executor.navigate(SimpleRoute(2))
-        executor.navigate(SimpleRoute(3))
-        executor.navigate(SimpleRoute(4))
-        executor.navigate(SimpleRoute(5))
-        executor.navigate(OtherRoute(6))
-        executor.navigate(ThirdRoute(7))
-        executor.navigate(OtherRoute(8))
-        executor.navigate(OtherRoute(9))
-        executor.navigate(ThirdRoute(10))
+        executor.navigateTo(SimpleRoute(2))
+        executor.navigateTo(SimpleRoute(3))
+        executor.navigateTo(SimpleRoute(4))
+        executor.navigateTo(SimpleRoute(5))
+        executor.navigateTo(OtherRoute(6))
+        executor.navigateTo(ThirdRoute(7))
+        executor.navigateTo(OtherRoute(8))
+        executor.navigateTo(OtherRoute(9))
+        executor.navigateTo(ThirdRoute(10))
 
         assertThat(executor.visibleEntries.value).hasSize(6)
 
-        executor.navigateBackTo(simpleRouteDestination.id, isInclusive = true)
+        executor.navigateBackToInternal(simpleRouteDestination.id, inclusive = true)
 
         assertThat(executor.visibleEntries.value)
             .containsExactly(
@@ -810,19 +810,19 @@ internal class MultiStackNavigationExecutorTest {
     @Test
     fun `popUpTo with root and inclusive false removes all destinations`() {
         val executor = underTest()
-        executor.navigate(SimpleRoute(2))
-        executor.navigate(SimpleRoute(3))
-        executor.navigate(SimpleRoute(4))
-        executor.navigate(SimpleRoute(5))
-        executor.navigate(OtherRoute(6))
-        executor.navigate(ThirdRoute(7))
-        executor.navigate(OtherRoute(8))
-        executor.navigate(OtherRoute(9))
-        executor.navigate(ThirdRoute(10))
+        executor.navigateTo(SimpleRoute(2))
+        executor.navigateTo(SimpleRoute(3))
+        executor.navigateTo(SimpleRoute(4))
+        executor.navigateTo(SimpleRoute(5))
+        executor.navigateTo(OtherRoute(6))
+        executor.navigateTo(ThirdRoute(7))
+        executor.navigateTo(OtherRoute(8))
+        executor.navigateTo(OtherRoute(9))
+        executor.navigateTo(ThirdRoute(10))
 
         assertThat(executor.visibleEntries.value).hasSize(6)
 
-        executor.navigateBackTo(simpleRootDestination.id, isInclusive = false)
+        executor.navigateBackToInternal(simpleRootDestination.id, inclusive = false)
 
         assertThat(executor.visibleEntries.value)
             .containsExactly(
@@ -847,20 +847,20 @@ internal class MultiStackNavigationExecutorTest {
     @Test
     fun `popUpTo with root and inclusive true throws exception`() {
         val executor = underTest()
-        executor.navigate(SimpleRoute(2))
-        executor.navigate(SimpleRoute(3))
-        executor.navigate(SimpleRoute(4))
-        executor.navigate(SimpleRoute(5))
-        executor.navigate(OtherRoute(6))
-        executor.navigate(ThirdRoute(7))
-        executor.navigate(OtherRoute(8))
-        executor.navigate(OtherRoute(9))
-        executor.navigate(ThirdRoute(10))
+        executor.navigateTo(SimpleRoute(2))
+        executor.navigateTo(SimpleRoute(3))
+        executor.navigateTo(SimpleRoute(4))
+        executor.navigateTo(SimpleRoute(5))
+        executor.navigateTo(OtherRoute(6))
+        executor.navigateTo(ThirdRoute(7))
+        executor.navigateTo(OtherRoute(8))
+        executor.navigateTo(OtherRoute(9))
+        executor.navigateTo(ThirdRoute(10))
 
         assertThat(executor.visibleEntries.value).hasSize(6)
 
         val exception = assertThrows(IllegalStateException::class.java) {
-            executor.navigateBackTo(simpleRootDestination.id, isInclusive = true)
+            executor.navigateBackToInternal(simpleRootDestination.id, inclusive = true)
         }
         assertThat(exception).hasMessageThat().isEqualTo("Can't pop the root of the back stack")
 
@@ -880,17 +880,17 @@ internal class MultiStackNavigationExecutorTest {
     @Test
     fun `popUpTo with route not present on the executor throws exception`() {
         val executor = underTest()
-        executor.navigate(SimpleRoute(2))
-        executor.navigate(SimpleRoute(3))
-        executor.navigate(SimpleRoute(4))
-        executor.navigate(SimpleRoute(5))
-        executor.navigate(ThirdRoute(6))
-        executor.navigate(ThirdRoute(7))
+        executor.navigateTo(SimpleRoute(2))
+        executor.navigateTo(SimpleRoute(3))
+        executor.navigateTo(SimpleRoute(4))
+        executor.navigateTo(SimpleRoute(5))
+        executor.navigateTo(ThirdRoute(6))
+        executor.navigateTo(ThirdRoute(7))
 
         assertThat(executor.visibleEntries.value).hasSize(3)
 
         val exception = assertThrows(IllegalStateException::class.java) {
-            executor.navigateBackTo(otherRouteDestination.id, isInclusive = false)
+            executor.navigateBackToInternal(otherRouteDestination.id, inclusive = false)
         }
         assertThat(exception).hasMessageThat()
             .isEqualTo(

--- a/navigation-experimental/src/test/kotlin/com/freeletics/khonshu/navigation/compose/test/Routes.kt
+++ b/navigation-experimental/src/test/kotlin/com/freeletics/khonshu/navigation/compose/test/Routes.kt
@@ -10,23 +10,23 @@ import kotlinx.parcelize.Parcelize
 
 @Poko
 @Parcelize
-internal class SimpleRoute(val number: Int) : NavRoute
+internal class SimpleRoute(val number: Int) : NavRoute, Parcelable
 
 @Poko
 @Parcelize
-internal class OtherRoute(val number: Int) : NavRoute
+internal class OtherRoute(val number: Int) : NavRoute, Parcelable
 
 @Poko
 @Parcelize
-internal class ThirdRoute(val number: Int) : NavRoute
+internal class ThirdRoute(val number: Int) : NavRoute, Parcelable
 
 @Poko
 @Parcelize
-internal class SimpleRoot(val number: Int) : NavRoot
+internal class SimpleRoot(val number: Int) : NavRoot, Parcelable
 
 @Poko
 @Parcelize
-internal class OtherRoot(val number: Int) : NavRoot
+internal class OtherRoot(val number: Int) : NavRoot, Parcelable
 
 @Poko
 @Parcelize

--- a/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavigatorTurbine.kt
+++ b/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavigatorTurbine.kt
@@ -122,7 +122,7 @@ public interface NavigatorTurbine {
      *
      * @throws AssertionError - if the next event was not a matching event.
      */
-    public suspend fun <T : BaseRoute> awaitNavigateBackTo(
+    public suspend fun <T : NavRoute> awaitNavigateBackTo(
         popUpTo: KClass<T>,
         inclusive: Boolean,
     )
@@ -243,7 +243,7 @@ internal class DefaultNavigatorTurbine(
         Truth.assertThat(turbine.awaitItem()).isEqualTo(event)
     }
 
-    override suspend fun <T : BaseRoute> awaitNavigateBackTo(
+    override suspend fun <T : NavRoute> awaitNavigateBackTo(
         popUpTo: KClass<T>,
         inclusive: Boolean,
     ) {

--- a/navigation/api/android/navigation.api
+++ b/navigation/api/android/navigation.api
@@ -1,3 +1,10 @@
+public abstract interface class com/freeletics/khonshu/navigation/ActivityResultNavigator {
+	public abstract fun navigateForResult (Lcom/freeletics/khonshu/navigation/ActivityResultRequest;)V
+	public abstract fun navigateForResult (Lcom/freeletics/khonshu/navigation/ActivityResultRequest;Ljava/lang/Object;)V
+	public abstract fun requestPermissions (Lcom/freeletics/khonshu/navigation/PermissionsResultRequest;Ljava/util/List;)V
+	public abstract fun requestPermissions (Lcom/freeletics/khonshu/navigation/PermissionsResultRequest;[Ljava/lang/String;)V
+}
+
 public final class com/freeletics/khonshu/navigation/ActivityResultRequest : com/freeletics/khonshu/navigation/ContractResultOwner {
 }
 
@@ -8,6 +15,11 @@ public abstract interface class com/freeletics/khonshu/navigation/ActivityRoute 
 public final class com/freeletics/khonshu/navigation/ActivityRouteKt {
 	public static final fun getRoute (Landroid/app/Activity;)Lcom/freeletics/khonshu/navigation/InternalActivityRoute;
 	public static final fun requireRoute (Landroid/app/Activity;)Lcom/freeletics/khonshu/navigation/InternalActivityRoute;
+}
+
+public abstract interface class com/freeletics/khonshu/navigation/BackInterceptor {
+	public abstract fun backPresses ()Lkotlinx/coroutines/flow/Flow;
+	public abstract fun backPresses (Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 }
 
 public abstract interface class com/freeletics/khonshu/navigation/BaseRoute : android/os/Parcelable {
@@ -25,28 +37,25 @@ public abstract class com/freeletics/khonshu/navigation/InternalActivityRoute : 
 	public final fun fillInIntent ()Landroid/content/Intent;
 }
 
-public class com/freeletics/khonshu/navigation/NavEventNavigator {
+public class com/freeletics/khonshu/navigation/NavEventNavigator : com/freeletics/khonshu/navigation/ActivityResultNavigator, com/freeletics/khonshu/navigation/BackInterceptor, com/freeletics/khonshu/navigation/Navigator, com/freeletics/khonshu/navigation/ResultNavigator {
 	public fun <init> ()V
-	public final fun backPresses ()Lkotlinx/coroutines/flow/Flow;
-	public final fun backPresses (Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public final fun deliverNavigationResult (Lcom/freeletics/khonshu/navigation/NavigationResultRequest$Key;Landroid/os/Parcelable;)V
+	public fun backPresses ()Lkotlinx/coroutines/flow/Flow;
+	public fun backPresses (Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public fun deliverNavigationResult (Lcom/freeletics/khonshu/navigation/NavigationResultRequest$Key;Landroid/os/Parcelable;)V
 	public final fun navigate (Lkotlin/jvm/functions/Function1;)V
-	public final fun navigateBack ()V
-	public final fun navigateBackTo-UamjCxQ (Lkotlin/reflect/KClass;Z)V
-	public static synthetic fun navigateBackTo-UamjCxQ$default (Lcom/freeletics/khonshu/navigation/NavEventNavigator;Lkotlin/reflect/KClass;ZILjava/lang/Object;)V
-	public final fun navigateForResult (Lcom/freeletics/khonshu/navigation/ActivityResultRequest;)V
-	public final fun navigateForResult (Lcom/freeletics/khonshu/navigation/ActivityResultRequest;Ljava/lang/Object;)V
-	public final fun navigateTo (Lcom/freeletics/khonshu/navigation/ActivityRoute;)V
-	public final fun navigateTo (Lcom/freeletics/khonshu/navigation/NavRoute;)V
-	public final fun navigateToRoot (Lcom/freeletics/khonshu/navigation/NavRoot;Z)V
-	public static synthetic fun navigateToRoot$default (Lcom/freeletics/khonshu/navigation/NavEventNavigator;Lcom/freeletics/khonshu/navigation/NavRoot;ZILjava/lang/Object;)V
-	public final fun navigateUp ()V
+	public fun navigateBack ()V
+	public fun navigateForResult (Lcom/freeletics/khonshu/navigation/ActivityResultRequest;)V
+	public fun navigateForResult (Lcom/freeletics/khonshu/navigation/ActivityResultRequest;Ljava/lang/Object;)V
+	public fun navigateTo (Lcom/freeletics/khonshu/navigation/ActivityRoute;)V
+	public fun navigateTo (Lcom/freeletics/khonshu/navigation/NavRoute;)V
+	public fun navigateToRoot (Lcom/freeletics/khonshu/navigation/NavRoot;Z)V
+	public fun navigateUp ()V
 	protected final fun registerForActivityResult (Landroidx/activity/result/contract/ActivityResultContract;)Lcom/freeletics/khonshu/navigation/ActivityResultRequest;
 	public final fun registerForNavigationResult-UamjCxQ (Lkotlin/reflect/KClass;Ljava/lang/String;)Lcom/freeletics/khonshu/navigation/NavigationResultRequest;
 	protected final fun registerForPermissionsResult ()Lcom/freeletics/khonshu/navigation/PermissionsResultRequest;
-	public final fun requestPermissions (Lcom/freeletics/khonshu/navigation/PermissionsResultRequest;Ljava/util/List;)V
-	public final fun requestPermissions (Lcom/freeletics/khonshu/navigation/PermissionsResultRequest;[Ljava/lang/String;)V
-	public final fun resetToRoot (Lcom/freeletics/khonshu/navigation/NavRoot;)V
+	public fun requestPermissions (Lcom/freeletics/khonshu/navigation/PermissionsResultRequest;Ljava/util/List;)V
+	public fun requestPermissions (Lcom/freeletics/khonshu/navigation/PermissionsResultRequest;[Ljava/lang/String;)V
+	public fun resetToRoot (Lcom/freeletics/khonshu/navigation/NavRoot;)V
 }
 
 public abstract interface class com/freeletics/khonshu/navigation/NavRoot : com/freeletics/khonshu/navigation/BaseRoute {
@@ -76,6 +85,20 @@ public final class com/freeletics/khonshu/navigation/NavigationResultRequest$Key
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public abstract interface class com/freeletics/khonshu/navigation/Navigator {
+	public static final field Companion Lcom/freeletics/khonshu/navigation/Navigator$Companion;
+	public abstract fun navigateBack ()V
+	public abstract fun navigateTo (Lcom/freeletics/khonshu/navigation/ActivityRoute;)V
+	public abstract fun navigateTo (Lcom/freeletics/khonshu/navigation/NavRoute;)V
+	public abstract fun navigateToRoot (Lcom/freeletics/khonshu/navigation/NavRoot;Z)V
+	public static synthetic fun navigateToRoot$default (Lcom/freeletics/khonshu/navigation/Navigator;Lcom/freeletics/khonshu/navigation/NavRoot;ZILjava/lang/Object;)V
+	public abstract fun navigateUp ()V
+	public abstract fun resetToRoot (Lcom/freeletics/khonshu/navigation/NavRoot;)V
+}
+
+public final class com/freeletics/khonshu/navigation/Navigator$Companion {
+}
+
 public final class com/freeletics/khonshu/navigation/PermissionsResultRequest : com/freeletics/khonshu/navigation/ContractResultOwner {
 	public synthetic fun getContract ()Landroidx/activity/result/contract/ActivityResultContract;
 }
@@ -96,6 +119,10 @@ public final class com/freeletics/khonshu/navigation/PermissionsResultRequest$Pe
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/freeletics/khonshu/navigation/ResultNavigator {
+	public abstract fun deliverNavigationResult (Lcom/freeletics/khonshu/navigation/NavigationResultRequest$Key;Landroid/os/Parcelable;)V
 }
 
 public abstract class com/freeletics/khonshu/navigation/ResultOwner {
@@ -181,15 +208,6 @@ public final class com/freeletics/khonshu/navigation/internal/InitialValue$Creat
 }
 
 public abstract interface annotation class com/freeletics/khonshu/navigation/internal/InternalNavigationApi : java/lang/annotation/Annotation {
-}
-
-public final class com/freeletics/khonshu/navigation/internal/NavEventCollector {
-	public final fun navigateBack ()V
-	public final fun navigateBackTo-UamjCxQ (Lkotlin/reflect/KClass;Z)V
-	public final fun navigateTo (Lcom/freeletics/khonshu/navigation/NavRoute;)V
-	public final fun navigateToRoot (Lcom/freeletics/khonshu/navigation/NavRoot;Z)V
-	public final fun navigateUp ()V
-	public final fun resetToRoot (Lcom/freeletics/khonshu/navigation/NavRoot;)V
 }
 
 public final class com/freeletics/khonshu/navigation/internal/NavigationSetupKt {

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavEventNavigator.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavEventNavigator.kt
@@ -22,6 +22,118 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 
+public interface Navigator {
+    /**
+     * Triggers navigation to the given [route].
+     */
+    public fun navigateTo(route: NavRoute)
+
+    /**
+     * Triggers navigation to the given [root]. The current back stack will be removed
+     * and saved. Whether the backstack of the given `root` is restored depends on
+     * [restoreRootState].
+     */
+    public fun navigateToRoot(
+        root: NavRoot,
+        restoreRootState: Boolean = false,
+    )
+
+    /**
+     * Triggers navigation to the given [route].
+     */
+    public fun navigateTo(route: ActivityRoute)
+
+    /**
+     * Triggers up navigation.
+     */
+    public fun navigateUp()
+
+    /**
+     * Removes the top entry from the backstack to show the previous destination.
+     */
+    public fun navigateBack()
+
+    /**
+     * Removes all entries from the backstack until [T]. If [inclusive] is
+     * `true` [T] itself will also be removed.
+     */
+    @InternalNavigationApi
+    public fun <T : BaseRoute> navigateBackToInternal(popUpTo: DestinationId<T>, inclusive: Boolean = false)
+
+    /**
+     * Reset the back stack to the given [root]. The current back stack will cleared and if
+     * root was already on it it will be recreated.
+     */
+    public fun resetToRoot(root: NavRoot)
+
+    public companion object {
+        /**
+         * Removes all entries from the backstack until [T]. If [inclusive] is
+         * `true` [T] itself will also be removed.
+         */
+        public inline fun <reified T : NavRoute> Navigator.navigateBackTo(inclusive: Boolean = false) {
+            navigateBackToInternal(DestinationId(T::class), inclusive)
+        }
+    }
+}
+
+public interface ResultNavigator {
+    /**
+     * Delivers the [result] to the destination that created [key].
+     */
+    public fun <O : Parcelable> deliverNavigationResult(key: NavigationResultRequest.Key<O>, result: O)
+}
+
+public interface ActivityResultNavigator {
+    /**
+     * Launches the given [request].
+     */
+    public fun navigateForResult(request: ActivityResultRequest<Void?, *>)
+
+    /**
+     * Launches the given [request] with the given [input].
+     */
+    public fun <I> navigateForResult(request: ActivityResultRequest<I, *>, input: I)
+
+    /**
+     * Launches the [request] for the given [permissions].
+     *
+     * Compared to using [navigateForResult] with
+     * [androidx.activity.result.contract.ActivityResultContracts.RequestPermission] this provides
+     * a `PermissionResult` instead of a `boolean. See `[PermissionsResultRequest.PermissionResult]`
+     * for more information.
+     */
+    public fun requestPermissions(request: PermissionsResultRequest, vararg permissions: String)
+
+    /**
+     * Launches the [request] for the given [permissions].
+     *
+     * Compared to using [navigateForResult] with
+     * [androidx.activity.result.contract.ActivityResultContracts.RequestPermission] this provides
+     * a `PermissionResult` instead of a `boolean. See `[PermissionsResultRequest.PermissionResult]`
+     * for more information.
+     */
+    public fun requestPermissions(request: PermissionsResultRequest, permissions: List<String>)
+}
+
+public interface BackInterceptor {
+    /**
+     * Returns a [Flow] that will emit [Unit] on every back press. While this Flow is being collected
+     * all back presses will be intercepted and none of the default back press handling happens.
+     *
+     * When this is called multiple times only the latest caller will receive emissions.
+     */
+    public fun backPresses(): Flow<Unit>
+
+    /**
+     * Returns a [Flow] that will emit [value] on every back press. While this Flow is being collected
+     * all back presses will be intercepted and none of the default back press handling happens.
+     *
+     * When this is called multiple times only the latest caller will receive emissions.
+     */
+    public fun <T> backPresses(value: T): Flow<T>
+}
+
 /**
  * This allows to trigger navigation actions from outside the view layer
  * without keeping references to Android framework classes that might leak. It also improves
@@ -32,7 +144,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
  * permission requests can be handled through [registerForActivityResult]/[navigateForResult]
  * and [registerForPermissionsResult]/[requestPermissions] respectively.
  */
-public open class NavEventNavigator {
+public open class NavEventNavigator : Navigator, ResultNavigator, ActivityResultNavigator, BackInterceptor {
 
     private val _navEvents = Channel<NavEvent>(Channel.UNLIMITED)
 
@@ -117,7 +229,7 @@ public open class NavEventNavigator {
     /**
      * Triggers a new [NavEvent] to navigate to the given [route].
      */
-    public fun navigateTo(route: NavRoute) {
+    override fun navigateTo(route: NavRoute) {
         val event = NavigateToEvent(route)
         sendNavEvent(event)
     }
@@ -127,9 +239,9 @@ public open class NavEventNavigator {
      * be popped and saved. Whether the backstack of the given `root` is restored depends on
      * [restoreRootState].
      */
-    public fun navigateToRoot(
+    override fun navigateToRoot(
         root: NavRoot,
-        restoreRootState: Boolean = false,
+        restoreRootState: Boolean,
     ) {
         val event = NavEvent.NavigateToRootEvent(root, restoreRootState)
         sendNavEvent(event)
@@ -138,7 +250,7 @@ public open class NavEventNavigator {
     /**
      * Triggers a new [NavEvent] to navigate to the given [route].
      */
-    public fun navigateTo(route: ActivityRoute) {
+    override fun navigateTo(route: ActivityRoute) {
         val event = NavigateToActivityEvent(route)
         sendNavEvent(event)
     }
@@ -146,7 +258,7 @@ public open class NavEventNavigator {
     /**
      * Triggers a new [NavEvent] that causes up navigation.
      */
-    public fun navigateUp() {
+    override fun navigateUp() {
         val event = UpEvent
         sendNavEvent(event)
     }
@@ -154,7 +266,7 @@ public open class NavEventNavigator {
     /**
      * Triggers a new [NavEvent] that pops the back stack to the previous destination.
      */
-    public fun navigateBack() {
+    override fun navigateBack() {
         val event = BackEvent
         sendNavEvent(event)
     }
@@ -166,21 +278,13 @@ public open class NavEventNavigator {
      * Note: This should be used when navigating multiple times, for example calling `navigateBackTo`
      * followed by `navigateTo`.
      */
-    public fun navigate(block: NavEventCollector.() -> Unit) {
+    public fun navigate(block: Navigator.() -> Unit) {
         val navEvents = NavEventCollector().apply(block).navEvents
         sendNavEvent(MultiNavEvent(navEvents))
     }
 
-    /**
-     * Triggers a new [NavEvent] that pops the back stack to [T]. If [inclusive] is
-     * `true` [T] itself will also be popped.
-     */
-    public inline fun <reified T : NavRoute> navigateBackTo(inclusive: Boolean = false) {
-        navigateBackTo(DestinationId(T::class), inclusive)
-    }
-
-    @PublishedApi
-    internal fun <T : BaseRoute> navigateBackTo(popUpTo: DestinationId<T>, inclusive: Boolean = false) {
+    @InternalNavigationApi
+    override fun <T : BaseRoute> navigateBackToInternal(popUpTo: DestinationId<T>, inclusive: Boolean) {
         val event = BackToEvent(popUpTo, inclusive)
         sendNavEvent(event)
     }
@@ -189,7 +293,7 @@ public open class NavEventNavigator {
      * Reset the back stack to the given [root]. The current back stack will cleared and if
      * root was already on it it will be recreated.
      */
-    public fun resetToRoot(root: NavRoot) {
+    override fun resetToRoot(root: NavRoot) {
         val event = NavEvent.ResetToRoot(root)
         sendNavEvent(event)
     }
@@ -199,7 +303,7 @@ public open class NavEventNavigator {
      *
      * The [request] can be obtained by calling [registerForActivityResult].
      */
-    public fun navigateForResult(request: ActivityResultRequest<Void?, *>) {
+    override fun navigateForResult(request: ActivityResultRequest<Void?, *>) {
         navigateForResult(request, null)
     }
 
@@ -208,7 +312,7 @@ public open class NavEventNavigator {
      *
      * The [request] can be obtained by calling [registerForActivityResult].
      */
-    public fun <I> navigateForResult(request: ActivityResultRequest<I, *>, input: I) {
+    override fun <I> navigateForResult(request: ActivityResultRequest<I, *>, input: I) {
         val event = ActivityResultEvent(request, input)
         sendNavEvent(event)
     }
@@ -223,7 +327,7 @@ public open class NavEventNavigator {
      *
      * The [request] can be obtained by calling [registerForPermissionsResult].
      */
-    public fun requestPermissions(request: PermissionsResultRequest, vararg permissions: String) {
+    override fun requestPermissions(request: PermissionsResultRequest, vararg permissions: String) {
         requestPermissions(request, permissions.toList())
     }
 
@@ -237,7 +341,7 @@ public open class NavEventNavigator {
      *
      * The [request] can be obtained by calling [registerForPermissionsResult].
      */
-    public fun requestPermissions(request: PermissionsResultRequest, permissions: List<String>) {
+    override fun requestPermissions(request: PermissionsResultRequest, permissions: List<String>) {
         val event = ActivityResultEvent(request, permissions)
         sendNavEvent(event)
     }
@@ -245,7 +349,7 @@ public open class NavEventNavigator {
     /**
      * Delivers the [result] to the destination that created [key].
      */
-    public fun <O : Parcelable> deliverNavigationResult(key: NavigationResultRequest.Key<O>, result: O) {
+    override fun <O : Parcelable> deliverNavigationResult(key: NavigationResultRequest.Key<O>, result: O) {
         val event = NavEvent.DestinationResultEvent(key, result)
         sendNavEvent(event)
     }
@@ -261,7 +365,7 @@ public open class NavEventNavigator {
      *
      * When this is called multiple times only the latest caller will receive emissions.
      */
-    public fun backPresses(): Flow<Unit> {
+    override fun backPresses(): Flow<Unit> {
         return backPresses(Unit)
     }
 
@@ -271,7 +375,7 @@ public open class NavEventNavigator {
      *
      * When this is called multiple times only the latest caller will receive emissions.
      */
-    public fun <T> backPresses(value: T): Flow<T> {
+    override fun <T> backPresses(value: T): Flow<T> {
         return callbackFlow {
             val onBackPressed = {
                 check(trySendBlocking(value).isSuccess)

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/NavEvent.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/NavEvent.kt
@@ -2,6 +2,7 @@ package com.freeletics.khonshu.navigation.internal
 
 import android.os.Parcelable
 import com.freeletics.khonshu.navigation.ActivityRoute
+import com.freeletics.khonshu.navigation.BaseRoute
 import com.freeletics.khonshu.navigation.ContractResultOwner
 import com.freeletics.khonshu.navigation.NavRoot
 import com.freeletics.khonshu.navigation.NavRoute
@@ -39,7 +40,7 @@ public sealed interface NavEvent {
     @InternalNavigationApi
     @Poko
     public class BackToEvent(
-        internal val popUpTo: DestinationId<*>,
+        internal val popUpTo: DestinationId<out BaseRoute>,
         internal val inclusive: Boolean,
     ) : NavEvent
 

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/NavEventCollector.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/NavEventCollector.kt
@@ -1,44 +1,48 @@
 package com.freeletics.khonshu.navigation.internal
 
+import com.freeletics.khonshu.navigation.ActivityRoute
+import com.freeletics.khonshu.navigation.BaseRoute
 import com.freeletics.khonshu.navigation.NavRoot
 import com.freeletics.khonshu.navigation.NavRoute
+import com.freeletics.khonshu.navigation.Navigator
 
-public class NavEventCollector internal constructor() {
+internal class NavEventCollector : Navigator {
 
     private val _navEvents = mutableListOf<NavEvent>()
     internal val navEvents: List<NavEvent> = _navEvents
 
-    public fun navigateTo(route: NavRoute) {
+    override fun navigateTo(route: NavRoute) {
         val event = NavEvent.NavigateToEvent(route)
         _navEvents.add(event)
     }
 
-    public fun navigateToRoot(root: NavRoot, restoreRootState: Boolean) {
+    override fun navigateToRoot(root: NavRoot, restoreRootState: Boolean) {
         val event = NavEvent.NavigateToRootEvent(root, restoreRootState)
         _navEvents.add(event)
     }
 
-    public fun navigateUp() {
+    override fun navigateTo(route: ActivityRoute) {
+        val event = NavEvent.NavigateToActivityEvent(route)
+        _navEvents.add(event)
+    }
+
+    override fun navigateUp() {
         val event = NavEvent.UpEvent
         _navEvents.add(event)
     }
 
-    public fun navigateBack() {
+    override fun navigateBack() {
         val event = NavEvent.BackEvent
         _navEvents.add(event)
     }
 
-    public inline fun <reified T : NavRoute> navigateBackTo(inclusive: Boolean) {
-        navigateBackTo(DestinationId(T::class), inclusive)
-    }
-
-    @PublishedApi
-    internal fun <T : NavRoute> navigateBackTo(destination: DestinationId<T>, inclusive: Boolean) {
-        val event = NavEvent.BackToEvent(destination, inclusive)
+    @InternalNavigationApi
+    override fun <T : BaseRoute> navigateBackToInternal(popUpTo: DestinationId<T>, inclusive: Boolean) {
+        val event = NavEvent.BackToEvent(popUpTo, inclusive)
         _navEvents.add(event)
     }
 
-    public fun resetToRoot(root: NavRoot) {
+    override fun resetToRoot(root: NavRoot) {
         val event = NavEvent.ResetToRoot(root)
         _navEvents.add(event)
     }

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/NavigationExecutor.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/NavigationExecutor.kt
@@ -1,22 +1,13 @@
 package com.freeletics.khonshu.navigation.internal
 
 import androidx.lifecycle.SavedStateHandle
-import com.freeletics.khonshu.navigation.ActivityRoute
 import com.freeletics.khonshu.navigation.BaseRoute
-import com.freeletics.khonshu.navigation.NavRoot
-import com.freeletics.khonshu.navigation.NavRoute
+import com.freeletics.khonshu.navigation.Navigator
 import java.io.Serializable
 import kotlin.reflect.KClass
 
 @InternalNavigationApi
-public interface NavigationExecutor {
-    public fun navigate(route: NavRoute)
-    public fun navigate(root: NavRoot, restoreRootState: Boolean)
-    public fun navigate(route: ActivityRoute)
-    public fun navigateUp()
-    public fun navigateBack()
-    public fun <T : BaseRoute> navigateBackTo(destinationId: DestinationId<T>, isInclusive: Boolean)
-    public fun resetToRoot(root: NavRoot)
+public interface NavigationExecutor : Navigator {
     public fun <T : BaseRoute> routeFor(destinationId: DestinationId<T>): T
     public fun <T : BaseRoute> savedStateHandleFor(destinationId: DestinationId<T>): SavedStateHandle
     public fun <T : BaseRoute> storeFor(destinationId: DestinationId<T>): Store

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/NavigationSetup.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/NavigationSetup.kt
@@ -1,7 +1,6 @@
 package com.freeletics.khonshu.navigation.internal
 
 import android.app.Activity
-import android.os.Parcelable
 import androidx.activity.result.ActivityResultLauncher
 import androidx.core.app.ActivityCompat
 import androidx.lifecycle.Lifecycle
@@ -35,24 +34,24 @@ public suspend fun NavEventNavigator.collectAndHandleNavEvents(
     withContext(Dispatchers.Main.immediate) {
         navEvents.flowWithLifecycle(lifecycle, minActiveState = Lifecycle.State.RESUMED)
             .collect { event ->
-                executor.navigate(event, activityLaunchers)
+                executor.navigateTo(event, activityLaunchers)
             }
     }
 }
 
-private fun NavigationExecutor.navigate(
+private fun NavigationExecutor.navigateTo(
     event: NavEvent,
     activityLaunchers: Map<ContractResultOwner<*, *, *>, ActivityResultLauncher<*>>,
 ) {
     when (event) {
         is NavEvent.NavigateToEvent -> {
-            navigate(event.route)
+            navigateTo(event.route)
         }
         is NavEvent.NavigateToRootEvent -> {
-            navigate(event.root, event.restoreRootState)
+            navigateToRoot(event.root, event.restoreRootState)
         }
         is NavEvent.NavigateToActivityEvent -> {
-            navigate(event.route)
+            navigateTo(event.route)
         }
         is NavEvent.UpEvent -> {
             navigateUp()
@@ -61,7 +60,7 @@ private fun NavigationExecutor.navigate(
             navigateBack()
         }
         is NavEvent.BackToEvent -> {
-            navigateBackTo(event.popUpTo, event.inclusive)
+            navigateBackToInternal(event.popUpTo, event.inclusive)
         }
         is NavEvent.ResetToRoot -> {
             resetToRoot(event.root)
@@ -79,7 +78,7 @@ private fun NavigationExecutor.navigate(
             savedStateHandleFor(event.key.destinationId)[event.key.requestKey] = event.result
         }
         is NavEvent.MultiNavEvent -> {
-            event.navEvents.forEach { navigate(it, activityLaunchers) }
+            event.navEvents.forEach { navigateTo(it, activityLaunchers) }
         }
     }
 }

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/NavEventNavigatorTest.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/NavEventNavigatorTest.kt
@@ -2,6 +2,7 @@ package com.freeletics.khonshu.navigation
 
 import androidx.activity.result.contract.ActivityResultContracts
 import app.cash.turbine.test
+import com.freeletics.khonshu.navigation.Navigator.Companion.navigateBackTo
 import com.freeletics.khonshu.navigation.internal.DestinationId
 import com.freeletics.khonshu.navigation.internal.NavEvent
 import com.freeletics.khonshu.navigation.internal.NavEvent.NavigateToActivityEvent

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/NavigationSetupTest.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/NavigationSetupTest.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.Lifecycle.State.RESUMED
 import androidx.lifecycle.testing.TestLifecycleOwner
 import app.cash.turbine.test
 import com.freeletics.khonshu.navigation.ContractResultOwner
+import com.freeletics.khonshu.navigation.Navigator.Companion.navigateBackTo
 import com.freeletics.khonshu.navigation.PermissionsResultRequest.PermissionResult
 import com.freeletics.khonshu.navigation.test.SimpleActivity
 import com.freeletics.khonshu.navigation.test.SimpleRoot

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/Routes.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/Routes.kt
@@ -9,22 +9,22 @@ import kotlinx.parcelize.Parcelize
 
 @Poko
 @Parcelize
-internal class SimpleRoute(val number: Int) : NavRoute
+internal class SimpleRoute(val number: Int) : NavRoute, Parcelable
 
 @Poko
 @Parcelize
-internal class OtherRoute(val number: Int) : NavRoute
+internal class OtherRoute(val number: Int) : NavRoute, Parcelable
 
 @Poko
 @Parcelize
 internal class DeepLinkRoute(
     val pathParameters: Map<String, String>,
     val queryParameters: Map<String, String>,
-) : NavRoute
+) : NavRoute, Parcelable
 
 @Poko
 @Parcelize
-internal class SimpleRoot(val number: Int) : NavRoot
+internal class SimpleRoot(val number: Int) : NavRoot, Parcelable
 
 @Poko
 @Parcelize

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/TestNavigationExecutor.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/TestNavigationExecutor.kt
@@ -16,15 +16,15 @@ internal class TestNavigationExecutor : NavigationExecutor {
     val received = Turbine<NavEvent>()
     val savedStateHandle = SavedStateHandle()
 
-    override fun navigate(route: NavRoute) {
+    override fun navigateTo(route: NavRoute) {
         received.add(NavEvent.NavigateToEvent(route))
     }
 
-    override fun navigate(root: NavRoot, restoreRootState: Boolean) {
+    override fun navigateToRoot(root: NavRoot, restoreRootState: Boolean) {
         received.add(NavEvent.NavigateToRootEvent(root, restoreRootState))
     }
 
-    override fun navigate(route: ActivityRoute) {
+    override fun navigateTo(route: ActivityRoute) {
         received.add(NavEvent.NavigateToActivityEvent(route))
     }
 
@@ -36,11 +36,11 @@ internal class TestNavigationExecutor : NavigationExecutor {
         received.add(NavEvent.BackEvent)
     }
 
-    override fun <T : BaseRoute> navigateBackTo(
-        destinationId: DestinationId<T>,
-        isInclusive: Boolean,
+    override fun <T : BaseRoute> navigateBackToInternal(
+        popUpTo: DestinationId<T>,
+        inclusive: Boolean,
     ) {
-        received.add(NavEvent.BackToEvent(destinationId, isInclusive))
+        received.add(NavEvent.BackToEvent(popUpTo, inclusive))
     }
 
     override fun resetToRoot(root: NavRoot) {


### PR DESCRIPTION
Extracts `Navigator`, `ResultNavigator`, `ActivityResultNavigator` and `BackInterceptor` out of `NavEventNavigator`. With this the whole public API of `NavEventNavigator`, except for the multi nav event method, is represented by these interfaces. For now this gives us 2 things:
- `NavigationExecutor` also implements `Navigator` to mirror the parts of the API for which it consumes `NavEvent`
- `NavEventCollector` is also just an implementation of `Navigator` which means the type doesn't need to be publicly exposed anymore.

For the longer term future this will allow us to move the event based navigation to a state based approach. For example `NavEventNavigator` (or a replacement for it) could just delegate to a shared implementation of `Navigator` instead of sending events which are then passed to a `Navigator` like right now.

One side effect of this is that `<reified T : NavRoute> navigateBackTo(inclusive: Boolean = false)` is now an extension function.