### PR TITLE
introduce ActivityComponentProvider

### DIFF
--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/ActivityComponentProviderGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/ActivityComponentProviderGenerator.kt
@@ -1,0 +1,71 @@
+package com.freeletics.khonshu.codegen.codegen
+
+import com.freeletics.khonshu.codegen.NavHostActivityData
+import com.freeletics.khonshu.codegen.util.activityComponentProvider
+import com.freeletics.khonshu.codegen.util.bundle
+import com.freeletics.khonshu.codegen.util.componentActivity
+import com.freeletics.khonshu.codegen.util.getComponent
+import com.freeletics.khonshu.codegen.util.optInAnnotation
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier.FINAL
+import com.squareup.kotlinpoet.KModifier.OVERRIDE
+import com.squareup.kotlinpoet.KModifier.PRIVATE
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.STAR
+import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.TypeVariableName
+import com.squareup.kotlinpoet.asClassName
+import kotlin.reflect.KClass
+
+internal class ActivityComponentProviderGenerator(
+    override val data: NavHostActivityData,
+) : Generator<NavHostActivityData>() {
+
+    internal fun generate(): TypeSpec {
+        return TypeSpec.classBuilder(componentProviderClassName)
+            .addAnnotation(optInAnnotation())
+            .addSuperinterface(activityComponentProvider)
+            .primaryConstructor(constructor())
+            .addProperty(activityProperty())
+            .addFunction(provideFunction())
+            .build()
+    }
+
+    private fun constructor(): FunSpec {
+        return FunSpec.constructorBuilder()
+            .addParameter("activity", componentActivity)
+            .build()
+    }
+
+    private fun activityProperty(): PropertySpec {
+        return PropertySpec.builder("activity", componentActivity)
+            .addModifiers(PRIVATE, FINAL)
+            .initializer("activity")
+            .build()
+    }
+
+    private fun provideFunction(): FunSpec {
+        val typeVariable = TypeVariableName("C")
+        return FunSpec.builder("provide")
+            .addModifiers(OVERRIDE)
+            .addTypeVariable(typeVariable)
+            .addParameter("scope", KClass::class.asClassName().parameterizedBy(STAR))
+            .returns(typeVariable)
+            .beginControlFlow(
+                "return %M(activity, scope, %T::class, %T::class) { parentComponent: %T, savedStateHandle ->",
+                getComponent,
+                data.scope,
+                data.parentScope,
+                retainedParentComponentClassName,
+            )
+            .addStatement(
+                "parentComponent.%L().%L(savedStateHandle, activity.intent.extras ?: %T.EMPTY)",
+                retainedParentComponentGetterName,
+                retainedComponentFactoryCreateName,
+                bundle,
+            )
+            .endControlFlow()
+            .build()
+    }
+}

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/FileGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/FileGenerator.kt
@@ -34,6 +34,7 @@ public class FileGenerator {
 
     public fun generate(data: NavHostActivityData): FileSpec {
         val component = ComponentGenerator(data)
+        val componentProvider = ActivityComponentProviderGenerator(data)
         val module = ComponentModuleGenerator(data)
         val activityModule = ActivityModuleGenerator(data)
         val activity = ActivityGenerator(data)
@@ -41,6 +42,7 @@ public class FileGenerator {
 
         return FileSpec.builder(data.packageName, "Khonshu${data.baseName}")
             .addType(component.generate())
+            .addType(componentProvider.generate())
             .addType(module.generate())
             .addType(activityModule.generate())
             .addType(activity.generate())

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/util/External.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/util/External.kt
@@ -24,6 +24,10 @@ internal val InternalCodegenApi = ClassName("com.freeletics.khonshu.codegen.inte
 internal val getComponent = MemberName("com.freeletics.khonshu.codegen.internal", "component")
 internal val getComponentFromRoute = MemberName("com.freeletics.khonshu.codegen.internal", "componentFromParentRoute")
 internal val componentProvider = ClassName("com.freeletics.khonshu.codegen.internal", "ComponentProvider")
+internal val activityComponentProvider =
+    ClassName("com.freeletics.khonshu.codegen.internal", "ActivityComponentProvider")
+internal val localActivityComponentProvider =
+    MemberName("com.freeletics.khonshu.codegen.internal", "LocalActivityComponentProvider")
 
 // Navigator
 internal val baseRoute = ClassName("com.freeletics.khonshu.navigation", "BaseRoute")
@@ -76,6 +80,7 @@ internal val bindsInstance = ClassName("dagger", "BindsInstance")
 internal val module = ClassName("dagger", "Module")
 
 // AndroidX
+internal val componentActivity = ClassName("androidx.activity", "ComponentActivity")
 internal val setContent = MemberName("androidx.activity.compose", "setContent")
 internal val savedStateHandle = ClassName("androidx.lifecycle", "SavedStateHandle")
 
@@ -83,6 +88,7 @@ internal val savedStateHandle = ClassName("androidx.lifecycle", "SavedStateHandl
 internal val composable = ClassName("androidx.compose.runtime", "Composable")
 internal val getValue = MemberName("androidx.compose.runtime", "getValue")
 internal val remember = MemberName("androidx.compose.runtime", "remember")
+internal val compositionLocalProvider = MemberName("androidx.compose.runtime", "CompositionLocalProvider")
 internal val rememberCoroutineScope = MemberName("androidx.compose.runtime", "rememberCoroutineScope")
 internal val localContext = MemberName("androidx.compose.ui.platform", "LocalContext")
 


### PR DESCRIPTION
`ActivityComponentProvider` mostly matches what we already have with `ComponentProvider` for destinations. It isolates the creation/finding of the dagger component and makes it reusable. We are also providing the created `ActivityComponentProvider` as an internal composition local from the generated activity. This will enable the next step which is to change the destination codegen to use the provider for its parent lookup. The 2 advantages of this are that destination code doesn't need `Context` anymore and that the activity scope/component can be used as parent.