### PR TITLE
use ActivityComponentProvider to lookup parent components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Change Log
   have been moved to `com.freeletics.khonshu.codegen`.
 - **Added**: `NavHostActivity` has an `experimentalNavigation` boolean to generate code
   with a `navigation-experimental` `NavHost`.
+- **Added**: `ActivityScope` and custom `Activity` scopes can now be used as `parentScope` for
+  destinations.
 - **Removed**: `@ComposeFragmentDestination` and `Fragment` codegen support.
 
 

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationCodegenTest.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationCodegenTest.kt
@@ -74,14 +74,14 @@ internal class NavDestinationCodegenTest {
         val expected = """
             package com.test
 
-            import android.content.Context
             import androidx.compose.runtime.Composable
             import androidx.compose.runtime.remember
             import androidx.compose.runtime.rememberCoroutineScope
-            import androidx.compose.ui.platform.LocalContext
             import androidx.lifecycle.SavedStateHandle
+            import com.freeletics.khonshu.codegen.`internal`.ActivityComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.ComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
+            import com.freeletics.khonshu.codegen.`internal`.LocalActivityComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.asComposeState
             import com.freeletics.khonshu.codegen.`internal`.componentFromParentRoute
             import com.freeletics.khonshu.navigation.LocalNavigationExecutor
@@ -91,7 +91,6 @@ internal class NavDestinationCodegenTest {
             import com.freeletics.khonshu.navigation.ScreenDestination
             import com.freeletics.khonshu.navigation.`internal`.InternalNavigationApi
             import com.freeletics.khonshu.navigation.`internal`.NavigationExecutor
-            import com.freeletics.khonshu.navigation.`internal`.destinationId
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
             import com.squareup.anvil.annotations.optional.ForScope
@@ -147,8 +146,8 @@ internal class NavDestinationCodegenTest {
               override fun provide(
                 route: TestRoute,
                 executor: NavigationExecutor,
-                context: Context,
-              ): KhonshuTestComponent = componentFromParentRoute(route.destinationId, route, executor, context,
+                provider: ActivityComponentProvider,
+              ): KhonshuTestComponent = componentFromParentRoute(route, executor, provider,
                   TestParentRoute::class) { parentComponent: KhonshuTestComponent.ParentComponent,
                   savedStateHandle, testRoute ->
                 parentComponent.khonshuTestComponentFactory().create(savedStateHandle, testRoute)
@@ -166,10 +165,10 @@ internal class NavDestinationCodegenTest {
             @Composable
             @OptIn(InternalCodegenApi::class, InternalNavigationApi::class)
             public fun KhonshuTest(testRoute: TestRoute) {
-              val context = LocalContext.current
               val executor = LocalNavigationExecutor.current
-              val component = remember(context, executor, testRoute) {
-                KhonshuTestComponentProvider.provide(testRoute, executor, context)
+              val provider = LocalActivityComponentProvider.current
+              val component = remember(testRoute, executor, provider) {
+                KhonshuTestComponentProvider.provide(testRoute, executor, provider)
               }
 
               NavigationSetup(component.navEventNavigator)
@@ -245,15 +244,15 @@ internal class NavDestinationCodegenTest {
         val expected = """
             package com.test
 
-            import android.content.Context
             import androidx.compose.runtime.Composable
             import androidx.compose.runtime.remember
             import androidx.compose.runtime.rememberCoroutineScope
-            import androidx.compose.ui.platform.LocalContext
             import androidx.lifecycle.SavedStateHandle
             import com.freeletics.khonshu.codegen.AppScope
+            import com.freeletics.khonshu.codegen.`internal`.ActivityComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.ComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
+            import com.freeletics.khonshu.codegen.`internal`.LocalActivityComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.asComposeState
             import com.freeletics.khonshu.codegen.`internal`.component
             import com.freeletics.khonshu.navigation.LocalNavigationExecutor
@@ -263,7 +262,6 @@ internal class NavDestinationCodegenTest {
             import com.freeletics.khonshu.navigation.ScreenDestination
             import com.freeletics.khonshu.navigation.`internal`.InternalNavigationApi
             import com.freeletics.khonshu.navigation.`internal`.NavigationExecutor
-            import com.freeletics.khonshu.navigation.`internal`.destinationId
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
             import com.squareup.anvil.annotations.optional.ForScope
@@ -317,10 +315,9 @@ internal class NavDestinationCodegenTest {
               override fun provide(
                 route: TestRoute,
                 executor: NavigationExecutor,
-                context: Context,
-              ): KhonshuTestComponent = component(route.destinationId, route, executor, context,
-                  AppScope::class) { parentComponent: KhonshuTestComponent.ParentComponent, savedStateHandle,
-                  testRoute ->
+                provider: ActivityComponentProvider,
+              ): KhonshuTestComponent = component(route, executor, provider, AppScope::class) { parentComponent:
+                  KhonshuTestComponent.ParentComponent, savedStateHandle, testRoute ->
                 parentComponent.khonshuTestComponentFactory().create(savedStateHandle, testRoute)
               }
             }
@@ -336,10 +333,10 @@ internal class NavDestinationCodegenTest {
             @Composable
             @OptIn(InternalCodegenApi::class, InternalNavigationApi::class)
             public fun KhonshuTest(testRoute: TestRoute) {
-              val context = LocalContext.current
               val executor = LocalNavigationExecutor.current
-              val component = remember(context, executor, testRoute) {
-                KhonshuTestComponentProvider.provide(testRoute, executor, context)
+              val provider = LocalActivityComponentProvider.current
+              val component = remember(testRoute, executor, provider) {
+                KhonshuTestComponentProvider.provide(testRoute, executor, provider)
               }
 
               NavigationSetup(component.navEventNavigator)
@@ -418,14 +415,14 @@ internal class NavDestinationCodegenTest {
         val expected = """
             package com.test
 
-            import android.content.Context
             import androidx.compose.runtime.Composable
             import androidx.compose.runtime.remember
             import androidx.compose.runtime.rememberCoroutineScope
-            import androidx.compose.ui.platform.LocalContext
             import androidx.lifecycle.SavedStateHandle
+            import com.freeletics.khonshu.codegen.`internal`.ActivityComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.ComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
+            import com.freeletics.khonshu.codegen.`internal`.LocalActivityComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.asComposeState
             import com.freeletics.khonshu.codegen.`internal`.componentFromParentRoute
             import com.freeletics.khonshu.navigation.LocalNavigationExecutor
@@ -435,7 +432,6 @@ internal class NavDestinationCodegenTest {
             import com.freeletics.khonshu.navigation.OverlayDestination
             import com.freeletics.khonshu.navigation.`internal`.InternalNavigationApi
             import com.freeletics.khonshu.navigation.`internal`.NavigationExecutor
-            import com.freeletics.khonshu.navigation.`internal`.destinationId
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
             import com.squareup.anvil.annotations.optional.ForScope
@@ -493,8 +489,8 @@ internal class NavDestinationCodegenTest {
               override fun provide(
                 route: TestOverlayRoute,
                 executor: NavigationExecutor,
-                context: Context,
-              ): KhonshuTestComponent = componentFromParentRoute(route.destinationId, route, executor, context,
+                provider: ActivityComponentProvider,
+              ): KhonshuTestComponent = componentFromParentRoute(route, executor, provider,
                   TestParentRoute::class) { parentComponent: KhonshuTestComponent.ParentComponent,
                   savedStateHandle, testOverlayRoute ->
                 parentComponent.khonshuTestComponentFactory().create(savedStateHandle, testOverlayRoute)
@@ -512,10 +508,10 @@ internal class NavDestinationCodegenTest {
             @Composable
             @OptIn(InternalCodegenApi::class, InternalNavigationApi::class)
             public fun KhonshuTest(testOverlayRoute: TestOverlayRoute) {
-              val context = LocalContext.current
               val executor = LocalNavigationExecutor.current
-              val component = remember(context, executor, testOverlayRoute) {
-                KhonshuTestComponentProvider.provide(testOverlayRoute, executor, context)
+              val provider = LocalActivityComponentProvider.current
+              val component = remember(testOverlayRoute, executor, provider) {
+                KhonshuTestComponentProvider.provide(testOverlayRoute, executor, provider)
               }
 
               NavigationSetup(component.navEventNavigator)
@@ -612,14 +608,14 @@ internal class NavDestinationCodegenTest {
         val expected = """
             package com.test
 
-            import android.content.Context
             import androidx.compose.runtime.Composable
             import androidx.compose.runtime.remember
             import androidx.compose.runtime.rememberCoroutineScope
-            import androidx.compose.ui.platform.LocalContext
             import androidx.lifecycle.SavedStateHandle
+            import com.freeletics.khonshu.codegen.`internal`.ActivityComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.ComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
+            import com.freeletics.khonshu.codegen.`internal`.LocalActivityComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.asComposeState
             import com.freeletics.khonshu.codegen.`internal`.componentFromParentRoute
             import com.freeletics.khonshu.navigation.LocalNavigationExecutor
@@ -629,7 +625,6 @@ internal class NavDestinationCodegenTest {
             import com.freeletics.khonshu.navigation.ScreenDestination
             import com.freeletics.khonshu.navigation.`internal`.InternalNavigationApi
             import com.freeletics.khonshu.navigation.`internal`.NavigationExecutor
-            import com.freeletics.khonshu.navigation.`internal`.destinationId
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
             import com.squareup.anvil.annotations.optional.ForScope
@@ -697,8 +692,8 @@ internal class NavDestinationCodegenTest {
               override fun provide(
                 route: TestRoute,
                 executor: NavigationExecutor,
-                context: Context,
-              ): KhonshuTest2Component = componentFromParentRoute(route.destinationId, route, executor, context,
+                provider: ActivityComponentProvider,
+              ): KhonshuTest2Component = componentFromParentRoute(route, executor, provider,
                   TestParentRoute::class) { parentComponent: KhonshuTest2Component.ParentComponent,
                   savedStateHandle, testRoute ->
                 parentComponent.khonshuTest2ComponentFactory().create(savedStateHandle, testRoute)
@@ -716,10 +711,10 @@ internal class NavDestinationCodegenTest {
             @Composable
             @OptIn(InternalCodegenApi::class, InternalNavigationApi::class)
             public fun KhonshuTest2(testRoute: TestRoute) {
-              val context = LocalContext.current
               val executor = LocalNavigationExecutor.current
-              val component = remember(context, executor, testRoute) {
-                KhonshuTest2ComponentProvider.provide(testRoute, executor, context)
+              val provider = LocalActivityComponentProvider.current
+              val component = remember(testRoute, executor, provider) {
+                KhonshuTest2ComponentProvider.provide(testRoute, executor, provider)
               }
 
               NavigationSetup(component.navEventNavigator)
@@ -800,13 +795,13 @@ internal class NavDestinationCodegenTest {
         val expected = """
             package com.test
 
-            import android.content.Context
             import androidx.compose.runtime.Composable
             import androidx.compose.runtime.remember
-            import androidx.compose.ui.platform.LocalContext
             import androidx.lifecycle.SavedStateHandle
+            import com.freeletics.khonshu.codegen.`internal`.ActivityComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.ComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
+            import com.freeletics.khonshu.codegen.`internal`.LocalActivityComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.asComposeState
             import com.freeletics.khonshu.codegen.`internal`.componentFromParentRoute
             import com.freeletics.khonshu.navigation.LocalNavigationExecutor
@@ -816,7 +811,6 @@ internal class NavDestinationCodegenTest {
             import com.freeletics.khonshu.navigation.ScreenDestination
             import com.freeletics.khonshu.navigation.`internal`.InternalNavigationApi
             import com.freeletics.khonshu.navigation.`internal`.NavigationExecutor
-            import com.freeletics.khonshu.navigation.`internal`.destinationId
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
             import com.squareup.anvil.annotations.optional.ForScope
@@ -871,8 +865,8 @@ internal class NavDestinationCodegenTest {
               override fun provide(
                 route: TestRoute,
                 executor: NavigationExecutor,
-                context: Context,
-              ): KhonshuTestComponent = componentFromParentRoute(route.destinationId, route, executor, context,
+                provider: ActivityComponentProvider,
+              ): KhonshuTestComponent = componentFromParentRoute(route, executor, provider,
                   TestParentRoute::class) { parentComponent: KhonshuTestComponent.ParentComponent,
                   savedStateHandle, testRoute ->
                 parentComponent.khonshuTestComponentFactory().create(savedStateHandle, testRoute)
@@ -890,10 +884,10 @@ internal class NavDestinationCodegenTest {
             @Composable
             @OptIn(InternalCodegenApi::class, InternalNavigationApi::class)
             public fun KhonshuTest(testRoute: TestRoute) {
-              val context = LocalContext.current
               val executor = LocalNavigationExecutor.current
-              val component = remember(context, executor, testRoute) {
-                KhonshuTestComponentProvider.provide(testRoute, executor, context)
+              val provider = LocalActivityComponentProvider.current
+              val component = remember(testRoute, executor, provider) {
+                KhonshuTestComponentProvider.provide(testRoute, executor, provider)
               }
 
               NavigationSetup(component.navEventNavigator)
@@ -964,14 +958,14 @@ internal class NavDestinationCodegenTest {
         val expected = """
             package com.test
 
-            import android.content.Context
             import androidx.compose.runtime.Composable
             import androidx.compose.runtime.remember
             import androidx.compose.runtime.rememberCoroutineScope
-            import androidx.compose.ui.platform.LocalContext
             import androidx.lifecycle.SavedStateHandle
+            import com.freeletics.khonshu.codegen.`internal`.ActivityComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.ComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
+            import com.freeletics.khonshu.codegen.`internal`.LocalActivityComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.asComposeState
             import com.freeletics.khonshu.codegen.`internal`.componentFromParentRoute
             import com.freeletics.khonshu.navigation.LocalNavigationExecutor
@@ -981,7 +975,6 @@ internal class NavDestinationCodegenTest {
             import com.freeletics.khonshu.navigation.ScreenDestination
             import com.freeletics.khonshu.navigation.`internal`.InternalNavigationApi
             import com.freeletics.khonshu.navigation.`internal`.NavigationExecutor
-            import com.freeletics.khonshu.navigation.`internal`.destinationId
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
             import com.squareup.anvil.annotations.optional.ForScope
@@ -1037,8 +1030,8 @@ internal class NavDestinationCodegenTest {
               override fun provide(
                 route: TestRoute,
                 executor: NavigationExecutor,
-                context: Context,
-              ): KhonshuTestComponent = componentFromParentRoute(route.destinationId, route, executor, context,
+                provider: ActivityComponentProvider,
+              ): KhonshuTestComponent = componentFromParentRoute(route, executor, provider,
                   TestParentRoute::class) { parentComponent: KhonshuTestComponent.ParentComponent,
                   savedStateHandle, testRoute ->
                 parentComponent.khonshuTestComponentFactory().create(savedStateHandle, testRoute)
@@ -1056,10 +1049,10 @@ internal class NavDestinationCodegenTest {
             @Composable
             @OptIn(InternalCodegenApi::class, InternalNavigationApi::class)
             public fun KhonshuTest(testRoute: TestRoute) {
-              val context = LocalContext.current
               val executor = LocalNavigationExecutor.current
-              val component = remember(context, executor, testRoute) {
-                KhonshuTestComponentProvider.provide(testRoute, executor, context)
+              val provider = LocalActivityComponentProvider.current
+              val component = remember(testRoute, executor, provider) {
+                KhonshuTestComponentProvider.provide(testRoute, executor, provider)
               }
 
               NavigationSetup(component.navEventNavigator)

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/Data.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/Data.kt
@@ -2,6 +2,8 @@ package com.freeletics.khonshu.codegen
 
 import com.freeletics.khonshu.codegen.util.androidxNavHost
 import com.freeletics.khonshu.codegen.util.experimentalNavHost
+import com.freeletics.khonshu.codegen.util.getComponent
+import com.freeletics.khonshu.codegen.util.getComponentFromRoute
 import com.freeletics.khonshu.codegen.util.navigationDestination
 import com.freeletics.khonshu.codegen.util.overlayDestination
 import com.freeletics.khonshu.codegen.util.screenDestination
@@ -79,11 +81,16 @@ public data class NavHostActivityData(
 
 public data class Navigation(
     val route: ClassName,
-    val parentScopeIsRoute: Boolean,
+    private val parentScopeIsRoute: Boolean,
     private val overlay: Boolean,
     val destinationScope: ClassName,
 ) {
     val destinationClass: ClassName = navigationDestination
+
+    val parentComponentLookup: MemberName = when (parentScopeIsRoute) {
+        false -> getComponent
+        true -> getComponentFromRoute
+    }
 
     val destinationMethod: MemberName = when (overlay) {
         false -> screenDestination

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationComposableGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationComposableGenerator.kt
@@ -5,7 +5,7 @@ import com.freeletics.khonshu.codegen.util.InternalCodegenApi
 import com.freeletics.khonshu.codegen.util.asParameter
 import com.freeletics.khonshu.codegen.util.composable
 import com.freeletics.khonshu.codegen.util.internalNavigatorApi
-import com.freeletics.khonshu.codegen.util.localContext
+import com.freeletics.khonshu.codegen.util.localActivityComponentProvider
 import com.freeletics.khonshu.codegen.util.localNavigationExecutor
 import com.freeletics.khonshu.codegen.util.navEventNavigator
 import com.freeletics.khonshu.codegen.util.navigationSetup
@@ -29,10 +29,10 @@ internal class NavDestinationComposableGenerator(
             .addAnnotation(composable)
             .addAnnotation(optInAnnotation(InternalCodegenApi, internalNavigatorApi))
             .addParameter(parameter)
-            .addStatement("val context = %M.current", localContext)
             .addStatement("val executor = %M.current", localNavigationExecutor)
-            .beginControlFlow("val component = %M(context, executor, %N)", remember, parameter)
-            .addStatement("%T.provide(%N, executor, context)", componentProviderClassName, parameter)
+            .addStatement("val provider = %M.current", localActivityComponentProvider)
+            .beginControlFlow("val component = %M(%N, executor, provider)", remember, parameter)
+            .addStatement("%T.provide(%N, executor, provider)", componentProviderClassName, parameter)
             .endControlFlow()
             .addStatement("")
             .addStatement("%M(component.%L)", navigationSetup, navEventNavigator.propertyName)

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/util/External.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/util/External.kt
@@ -34,7 +34,6 @@ internal val baseRoute = ClassName("com.freeletics.khonshu.navigation", "BaseRou
 internal val baseRouteFqName = FqName(baseRoute.canonicalName)
 internal val navEventNavigator = ClassName("com.freeletics.khonshu.navigation", "NavEventNavigator")
 internal val navigationExecutor = ClassName("com.freeletics.khonshu.navigation.internal", "NavigationExecutor")
-internal val destinationId = MemberName("com.freeletics.khonshu.navigation.internal", "destinationId")
 internal val androidxNavHost = MemberName("com.freeletics.khonshu.navigation.androidx", "NavHost")
 internal val experimentalNavHost = MemberName("com.freeletics.khonshu.navigation", "NavHost")
 internal val navigationSetup = MemberName("com.freeletics.khonshu.navigation", "NavigationSetup")
@@ -90,8 +89,6 @@ internal val getValue = MemberName("androidx.compose.runtime", "getValue")
 internal val remember = MemberName("androidx.compose.runtime", "remember")
 internal val compositionLocalProvider = MemberName("androidx.compose.runtime", "CompositionLocalProvider")
 internal val rememberCoroutineScope = MemberName("androidx.compose.runtime", "rememberCoroutineScope")
-internal val localContext = MemberName("androidx.compose.ui.platform", "LocalContext")
 
 // Android
 internal val bundle = ClassName("android.os", "Bundle")
-internal val context = ClassName("android.content", "Context")


### PR DESCRIPTION
Builds on top of #664.

This updates the destination codegen and `DestinationComponentLookup` to use the new `ActivityComponentProvider`, which
- allows using the activity scope as parent scope
- removes the need for `Context` from the destination component lookup