### PR TITLE
add remember for the sendAction lambda

### DIFF
--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationCodegenTest.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationCodegenTest.kt
@@ -105,6 +105,7 @@ internal class NavDestinationCodegenTest {
             import dagger.multibindings.Multibinds
             import java.io.Closeable
             import kotlin.OptIn
+            import kotlin.Unit
             import kotlin.collections.Set
             import kotlinx.coroutines.launch
 
@@ -181,13 +182,16 @@ internal class NavDestinationCodegenTest {
             @OptIn(InternalCodegenApi::class)
             private fun KhonshuTest(component: KhonshuTestComponent) {
               val stateMachine = remember { component.testStateMachine }
+              val scope = rememberCoroutineScope()
+              val sendAction: (TestAction) -> Unit = remember(stateMachine, scope) {
+                { scope.launch { stateMachine.dispatch(it) } }
+              }
               val state = stateMachine.asComposeState()
               val currentState = state.value
               if (currentState != null) {
-                val scope = rememberCoroutineScope()
                 Test(
                   state = currentState,
-                  sendAction = { scope.launch { stateMachine.dispatch(it) } },
+                  sendAction = sendAction,
                 )
               }
             }
@@ -275,6 +279,7 @@ internal class NavDestinationCodegenTest {
             import dagger.multibindings.Multibinds
             import java.io.Closeable
             import kotlin.OptIn
+            import kotlin.Unit
             import kotlin.collections.Set
             import kotlinx.coroutines.launch
 
@@ -351,13 +356,16 @@ internal class NavDestinationCodegenTest {
             @OptIn(InternalCodegenApi::class)
             private fun KhonshuTest(component: KhonshuTestComponent) {
               val stateMachine = remember { component.testStateMachine }
+              val scope = rememberCoroutineScope()
+              val sendAction: (TestAction) -> Unit = remember(stateMachine, scope) {
+                { scope.launch { stateMachine.dispatch(it) } }
+              }
               val state = stateMachine.asComposeState()
               val currentState = state.value
               if (currentState != null) {
-                val scope = rememberCoroutineScope()
                 Test(
                   state = currentState,
-                  sendAction = { scope.launch { stateMachine.dispatch(it) } },
+                  sendAction = sendAction,
                 )
               }
             }
@@ -449,6 +457,7 @@ internal class NavDestinationCodegenTest {
             import dagger.multibindings.Multibinds
             import java.io.Closeable
             import kotlin.OptIn
+            import kotlin.Unit
             import kotlin.collections.Set
             import kotlinx.coroutines.launch
 
@@ -527,13 +536,16 @@ internal class NavDestinationCodegenTest {
             @OptIn(InternalCodegenApi::class)
             private fun KhonshuTest(component: KhonshuTestComponent) {
               val stateMachine = remember { component.testStateMachine }
+              val scope = rememberCoroutineScope()
+              val sendAction: (TestAction) -> Unit = remember(stateMachine, scope) {
+                { scope.launch { stateMachine.dispatch(it) } }
+              }
               val state = stateMachine.asComposeState()
               val currentState = state.value
               if (currentState != null) {
-                val scope = rememberCoroutineScope()
                 Test(
                   state = currentState,
-                  sendAction = { scope.launch { stateMachine.dispatch(it) } },
+                  sendAction = sendAction,
                 )
               }
             }
@@ -646,6 +658,7 @@ internal class NavDestinationCodegenTest {
             import kotlin.Int
             import kotlin.OptIn
             import kotlin.String
+            import kotlin.Unit
             import kotlin.collections.Map
             import kotlin.collections.Set
             import kotlinx.coroutines.launch
@@ -735,17 +748,20 @@ internal class NavDestinationCodegenTest {
               val testSet = remember { component.testSet }
               val testMap = remember { component.testMap }
               val stateMachine = remember { component.testStateMachine }
+              val scope = rememberCoroutineScope()
+              val sendAction: (TestAction) -> Unit = remember(stateMachine, scope) {
+                { scope.launch { stateMachine.dispatch(it) } }
+              }
               val state = stateMachine.asComposeState()
               val currentState = state.value
               if (currentState != null) {
-                val scope = rememberCoroutineScope()
                 Test2(
                   testClass = testClass,
                   test = test,
                   testSet = testSet,
                   testMap = testMap,
                   state = currentState,
-                  sendAction = { scope.launch { stateMachine.dispatch(it) } },
+                  sendAction = sendAction,
                 )
               }
             }
@@ -995,6 +1011,7 @@ internal class NavDestinationCodegenTest {
             import dagger.multibindings.Multibinds
             import java.io.Closeable
             import kotlin.OptIn
+            import kotlin.Unit
             import kotlin.collections.Set
             import kotlinx.coroutines.launch
 
@@ -1071,12 +1088,15 @@ internal class NavDestinationCodegenTest {
             @OptIn(InternalCodegenApi::class)
             private fun KhonshuTest(component: KhonshuTestComponent) {
               val stateMachine = remember { component.testStateMachine }
+              val scope = rememberCoroutineScope()
+              val sendAction: (TestAction) -> Unit = remember(stateMachine, scope) {
+                { scope.launch { stateMachine.dispatch(it) } }
+              }
               val state = stateMachine.asComposeState()
               val currentState = state.value
               if (currentState != null) {
-                val scope = rememberCoroutineScope()
                 Test(
-                  sendAction = { scope.launch { stateMachine.dispatch(it) } },
+                  sendAction = sendAction,
                 )
               }
             }

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavHostActivityCodegenTest.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavHostActivityCodegenTest.kt
@@ -106,6 +106,7 @@ internal class NavHostActivityCodegenTest {
             import dagger.multibindings.Multibinds
             import java.io.Closeable
             import kotlin.OptIn
+            import kotlin.Unit
             import kotlin.collections.Set
             import kotlin.jvm.JvmSuppressWildcards
             import kotlin.reflect.KClass
@@ -230,13 +231,16 @@ internal class NavHostActivityCodegenTest {
             @OptIn(InternalCodegenApi::class)
             private fun KhonshuTest(component: KhonshuTestComponent, navHost: SimpleNavHost) {
               val stateMachine = remember { component.testStateMachine }
+              val scope = rememberCoroutineScope()
+              val sendAction: (TestAction) -> Unit = remember(stateMachine, scope) {
+                { scope.launch { stateMachine.dispatch(it) } }
+              }
               val state = stateMachine.asComposeState()
               val currentState = state.value
               if (currentState != null) {
-                val scope = rememberCoroutineScope()
                 Test(
                   state = currentState,
-                  sendAction = { scope.launch { stateMachine.dispatch(it) } },
+                  sendAction = sendAction,
                   navHost = navHost,
                 )
               }
@@ -315,6 +319,7 @@ internal class NavHostActivityCodegenTest {
             import dagger.multibindings.Multibinds
             import java.io.Closeable
             import kotlin.OptIn
+            import kotlin.Unit
             import kotlin.collections.Set
             import kotlin.jvm.JvmSuppressWildcards
             import kotlin.reflect.KClass
@@ -438,13 +443,16 @@ internal class NavHostActivityCodegenTest {
             @OptIn(InternalCodegenApi::class)
             private fun KhonshuTest(component: KhonshuTestComponent, navHost: SimpleNavHost) {
               val stateMachine = remember { component.testStateMachine }
+              val scope = rememberCoroutineScope()
+              val sendAction: (TestAction) -> Unit = remember(stateMachine, scope) {
+                { scope.launch { stateMachine.dispatch(it) } }
+              }
               val state = stateMachine.asComposeState()
               val currentState = state.value
               if (currentState != null) {
-                val scope = rememberCoroutineScope()
                 Test(
                   state = currentState,
-                  sendAction = { scope.launch { stateMachine.dispatch(it) } },
+                  sendAction = sendAction,
                   navHost = navHost,
                 )
               }
@@ -549,6 +557,7 @@ internal class NavHostActivityCodegenTest {
             import kotlin.Int
             import kotlin.OptIn
             import kotlin.String
+            import kotlin.Unit
             import kotlin.collections.Map
             import kotlin.collections.Set
             import kotlin.jvm.JvmSuppressWildcards
@@ -686,17 +695,20 @@ internal class NavHostActivityCodegenTest {
               val testSet = remember { component.testSet }
               val testMap = remember { component.testMap }
               val stateMachine = remember { component.testStateMachine }
+              val scope = rememberCoroutineScope()
+              val sendAction: (TestAction) -> Unit = remember(stateMachine, scope) {
+                { scope.launch { stateMachine.dispatch(it) } }
+              }
               val state = stateMachine.asComposeState()
               val currentState = state.value
               if (currentState != null) {
-                val scope = rememberCoroutineScope()
                 Test2(
                   testClass = testClass,
                   test = test,
                   testSet = testSet,
                   testMap = testMap,
                   state = currentState,
-                  sendAction = { scope.launch { stateMachine.dispatch(it) } },
+                  sendAction = sendAction,
                   navHost = navHost,
                 )
               }
@@ -978,6 +990,7 @@ internal class NavHostActivityCodegenTest {
             import dagger.multibindings.Multibinds
             import java.io.Closeable
             import kotlin.OptIn
+            import kotlin.Unit
             import kotlin.collections.Set
             import kotlin.jvm.JvmSuppressWildcards
             import kotlin.reflect.KClass
@@ -1102,12 +1115,15 @@ internal class NavHostActivityCodegenTest {
             @OptIn(InternalCodegenApi::class)
             private fun KhonshuTest(component: KhonshuTestComponent, navHost: SimpleNavHost) {
               val stateMachine = remember { component.testStateMachine }
+              val scope = rememberCoroutineScope()
+              val sendAction: (TestAction) -> Unit = remember(stateMachine, scope) {
+                { scope.launch { stateMachine.dispatch(it) } }
+              }
               val state = stateMachine.asComposeState()
               val currentState = state.value
               if (currentState != null) {
-                val scope = rememberCoroutineScope()
                 Test(
-                  sendAction = { scope.launch { stateMachine.dispatch(it) } },
+                  sendAction = sendAction,
                   navHost = navHost,
                 )
               }
@@ -1186,6 +1202,7 @@ internal class NavHostActivityCodegenTest {
             import dagger.multibindings.Multibinds
             import java.io.Closeable
             import kotlin.OptIn
+            import kotlin.Unit
             import kotlin.collections.Set
             import kotlin.jvm.JvmSuppressWildcards
             import kotlin.reflect.KClass
@@ -1310,13 +1327,16 @@ internal class NavHostActivityCodegenTest {
             @OptIn(InternalCodegenApi::class)
             private fun KhonshuTest(component: KhonshuTestComponent, navHost: SimpleNavHost) {
               val stateMachine = remember { component.testStateMachine }
+              val scope = rememberCoroutineScope()
+              val sendAction: (TestAction) -> Unit = remember(stateMachine, scope) {
+                { scope.launch { stateMachine.dispatch(it) } }
+              }
               val state = stateMachine.asComposeState()
               val currentState = state.value
               if (currentState != null) {
-                val scope = rememberCoroutineScope()
                 Test(
                   state = currentState,
-                  sendAction = { scope.launch { stateMachine.dispatch(it) } },
+                  sendAction = sendAction,
                   navHost = navHost,
                 )
               }
@@ -1397,6 +1417,7 @@ internal class NavHostActivityCodegenTest {
             import dagger.multibindings.Multibinds
             import java.io.Closeable
             import kotlin.OptIn
+            import kotlin.Unit
             import kotlin.collections.Set
             import kotlin.jvm.JvmSuppressWildcards
             import kotlin.reflect.KClass
@@ -1522,13 +1543,16 @@ internal class NavHostActivityCodegenTest {
             private fun KhonshuExperimentalTest(component: KhonshuExperimentalTestComponent,
                 navHost: SimpleNavHost) {
               val stateMachine = remember { component.testStateMachine }
+              val scope = rememberCoroutineScope()
+              val sendAction: (TestAction) -> Unit = remember(stateMachine, scope) {
+                { scope.launch { stateMachine.dispatch(it) } }
+              }
               val state = stateMachine.asComposeState()
               val currentState = state.value
               if (currentState != null) {
-                val scope = rememberCoroutineScope()
                 Test(
                   state = currentState,
-                  sendAction = { scope.launch { stateMachine.dispatch(it) } },
+                  sendAction = sendAction,
                   navHost = navHost,
                 )
               }


### PR DESCRIPTION
Currently each state change will create a new `sendAction` lambda. On the top level this isn't much of a problem since the state changed anyways but further downstream it can cause unnecessary re-compositions (in addition to the unnecessary allocation). For example if you have a list of items in the state and one of the items changed, all items will be re-composed because the `sendAction` also changed. This remembers the lambda so that it's only recreated if the state machine or coroutine scope for some reason change.