### PR TITLE
chore(Stack): use `ImmutableListAdapter` instead of `toImmutableList` to avoid unnecessary copying

### DIFF
--- a/navigation-experimental/src/main/kotlin/com/freeletics/khonshu/navigation/internal/Stack.kt
+++ b/navigation-experimental/src/main/kotlin/com/freeletics/khonshu/navigation/internal/Stack.kt
@@ -9,6 +9,7 @@ import com.freeletics.khonshu.navigation.NavRoute
 import com.freeletics.khonshu.navigation.ScreenDestination
 import java.util.UUID
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.adapters.ImmutableListAdapter
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 
@@ -33,7 +34,7 @@ internal class Stack private constructor(
 
     fun computeVisibleEntries(): ImmutableList<StackEntry<*>> {
         if (stack.size == 1) {
-            return persistentListOf(stack.single())
+            return ImmutableListAdapter(listOf(stack.single()))
         }
 
         // go through the stack from the top until reaching the first ScreenDestination
@@ -46,7 +47,7 @@ internal class Stack private constructor(
                     while (iterator.hasNext()) {
                         add(iterator.next())
                     }
-                }.toImmutableList()
+                }.let(::ImmutableListAdapter)
             }
         }
 

--- a/navigation-experimental/src/main/kotlin/com/freeletics/khonshu/navigation/internal/Stack.kt
+++ b/navigation-experimental/src/main/kotlin/com/freeletics/khonshu/navigation/internal/Stack.kt
@@ -10,7 +10,6 @@ import com.freeletics.khonshu.navigation.ScreenDestination
 import java.util.UUID
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.adapters.ImmutableListAdapter
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 
 internal class Stack private constructor(

--- a/navigation-experimental/src/main/kotlin/com/freeletics/khonshu/navigation/internal/Stack.kt
+++ b/navigation-experimental/src/main/kotlin/com/freeletics/khonshu/navigation/internal/Stack.kt
@@ -10,7 +10,6 @@ import com.freeletics.khonshu.navigation.ScreenDestination
 import java.util.UUID
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.adapters.ImmutableListAdapter
-import kotlinx.collections.immutable.toImmutableList
 
 internal class Stack private constructor(
     initialStack: List<StackEntry<*>>,


### PR DESCRIPTION
Although the returned `ArrayList` is mutable, but we can not mutate it -> `ImmutableListAdapter ` can be used in this case