### PR TITLE
start collecting StateMachine immediately the first time

### DIFF
--- a/codegen/src/androidMain/kotlin/com/freeletics/khonshu/codegen/internal/CollectAsState.kt
+++ b/codegen/src/androidMain/kotlin/com/freeletics/khonshu/codegen/internal/CollectAsState.kt
@@ -6,8 +6,12 @@ import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.withCreated
 import com.freeletics.khonshu.statemachine.StateMachine
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
 
 @Composable
 @InternalCodegenApi
@@ -15,7 +19,36 @@ public fun <S : Any> StateMachine<S, *>.asComposeState(): State<S?> {
     val lifecycleOwner = LocalLifecycleOwner.current
     val state = remember(this) { state }
     return produceState<S?>(initialValue = null, lifecycleOwner, state) {
+        // start state collection immediately and stop it on any downwards lifecycle event (e.g. pause/stop)
+        state.runUntilDownEvent(lifecycleOwner.lifecycle, Lifecycle.State.RESUMED)
+            .collect { value = it }
+
+        // after the initial collection was cancelled start collecting again whenever resuming
         state.flowWithLifecycle(lifecycleOwner.lifecycle, Lifecycle.State.RESUMED)
             .collect { value = it }
+    }
+}
+
+private fun <T> Flow<T>.runUntilDownEvent(
+    lifecycle: Lifecycle,
+    lifecycleState: Lifecycle.State,
+): Flow<T> = channelFlow {
+    val cancelWorkEvent = requireNotNull(Lifecycle.Event.downFrom(lifecycleState)) {
+        "Unsupported $lifecycleState"
+    }
+    val observer = LifecycleEventObserver { _, event ->
+        if (event >= cancelWorkEvent) {
+            close()
+        }
+    }
+
+    try {
+        // wait for the lifecycle to be at least created, this will
+        // also cancel the flow when the lifecycle is already DESTROYED
+        lifecycle.withCreated {}
+        lifecycle.addObserver(observer)
+        collect { send(it) }
+    } finally {
+        lifecycle.removeObserver(observer)
     }
 }


### PR DESCRIPTION
With #668 we limited the state machine collection to only happen while the app/destination is resumed. This results in a small but noticeable delay in the first state being received and therefore the UI being rendered. During that you see a blank screen. The issue that the lifecycle change fixes was only with continuing to collect/run the state machine after the app was paused. This means we can initially start the collection immediately, then stop it when the app gets paused (or another lifecycle down event happens) and from then on only continue it again when the app is resumed. Because the state machine is collected immediately again the visual delay is gone.