### PR TITLE
Codegen: make it possible to enabele experimental nav at runtime

### DIFF
--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavHostActivityCodegenTest.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavHostActivityCodegenTest.kt
@@ -1459,7 +1459,7 @@ internal class NavHostActivityCodegenTest {
 
               public val deepLinkPrefixes: ImmutableSet<DeepLinkHandler.Prefix>
 
-              @UseExperimentalNavigation
+              @get:UseExperimentalNavigation
               public val useExperimentalNavigation: Boolean
 
               @get:ForScope(TestScreen::class)

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavHostActivityCodegenTest.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavHostActivityCodegenTest.kt
@@ -1409,6 +1409,7 @@ internal class NavHostActivityCodegenTest {
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.lifecycle.SavedStateHandle
             import com.freeletics.khonshu.codegen.SimpleNavHost
+            import com.freeletics.khonshu.codegen.UseExperimentalNavigation
             import com.freeletics.khonshu.codegen.`internal`.ActivityComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
             import com.freeletics.khonshu.codegen.`internal`.LocalActivityComponentProvider
@@ -1416,7 +1417,7 @@ internal class NavHostActivityCodegenTest {
             import com.freeletics.khonshu.codegen.`internal`.component
             import com.freeletics.khonshu.navigation.NavDestination
             import com.freeletics.khonshu.navigation.NavEventNavigator
-            import com.freeletics.khonshu.navigation.NavHost
+            import com.freeletics.khonshu.navigation.androidx.NavHostTransitionAnimations
             import com.freeletics.khonshu.navigation.deeplinks.DeepLinkHandler
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
@@ -1428,6 +1429,7 @@ internal class NavHostActivityCodegenTest {
             import dagger.Provides
             import dagger.multibindings.Multibinds
             import java.io.Closeable
+            import kotlin.Boolean
             import kotlin.OptIn
             import kotlin.Unit
             import kotlin.collections.Set
@@ -1436,6 +1438,8 @@ internal class NavHostActivityCodegenTest {
             import kotlinx.collections.immutable.ImmutableSet
             import kotlinx.collections.immutable.toImmutableSet
             import kotlinx.coroutines.launch
+            import com.freeletics.khonshu.navigation.NavHost as navigationNavHost
+            import com.freeletics.khonshu.navigation.androidx.NavHost as androidxNavHost
 
             @OptIn(InternalCodegenApi::class)
             @SingleIn(TestScreen::class)
@@ -1454,6 +1458,9 @@ internal class NavHostActivityCodegenTest {
               public val deepLinkHandlers: ImmutableSet<DeepLinkHandler>
 
               public val deepLinkPrefixes: ImmutableSet<DeepLinkHandler.Prefix>
+
+              @UseExperimentalNavigation
+              public val useExperimentalNavigation: Boolean
 
               @get:ForScope(TestScreen::class)
               public val closeables: Set<Closeable>
@@ -1535,15 +1542,31 @@ internal class NavHostActivityCodegenTest {
                   }
                   KhonshuExperimentalTest(component) { startRoute, modifier, destinationChangedCallback ->
                     CompositionLocalProvider(LocalActivityComponentProvider provides componentProvider) {
-                      NavHost(
-                        startRoute = startRoute,
-                        destinations = component.destinations,
-                        modifier = modifier,
-                        deepLinkHandlers = component.deepLinkHandlers,
-                        deepLinkPrefixes = component.deepLinkPrefixes,
-                        navEventNavigator = component.navEventNavigator,
-                        destinationChangedCallback = destinationChangedCallback,
-                      )
+                      val useExperimentalNavigation = remember {
+                        component.useExperimentalNavigation
+                      }
+                      if (useExperimentalNavigation) {
+                        navigationNavHost(
+                          startRoute = startRoute,
+                          destinations = component.destinations,
+                          modifier = modifier,
+                          deepLinkHandlers = component.deepLinkHandlers,
+                          deepLinkPrefixes = component.deepLinkPrefixes,
+                          navEventNavigator = component.navEventNavigator,
+                          destinationChangedCallback = destinationChangedCallback,
+                        )
+                      } else {
+                        androidxNavHost(
+                          startRoute = startRoute,
+                          destinations = component.destinations,
+                          modifier = modifier,
+                          deepLinkHandlers = component.deepLinkHandlers,
+                          deepLinkPrefixes = component.deepLinkPrefixes,
+                          navEventNavigator = component.navEventNavigator,
+                          destinationChangedCallback = destinationChangedCallback,
+                          transitionAnimations = NavHostTransitionAnimations.noAnimations(),
+                        )
+                      }
                     }
                   }
                 }

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/Data.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/Data.kt
@@ -1,7 +1,5 @@
 package com.freeletics.khonshu.codegen
 
-import com.freeletics.khonshu.codegen.util.androidxNavHost
-import com.freeletics.khonshu.codegen.util.experimentalNavHost
 import com.freeletics.khonshu.codegen.util.getComponent
 import com.freeletics.khonshu.codegen.util.getComponentFromRoute
 import com.freeletics.khonshu.codegen.util.navigationDestination

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/Data.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/Data.kt
@@ -72,11 +72,6 @@ public data class NavHostActivityData(
         false -> originalName
         true -> "Experimental${originalName.capitalize()}"
     }
-
-    val navHost: MemberName = when (experimentalNavigation) {
-        false -> androidxNavHost
-        true -> experimentalNavHost
-    }
 }
 
 public data class Navigation(

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/ComponentGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/ComponentGenerator.kt
@@ -2,6 +2,7 @@ package com.freeletics.khonshu.codegen.codegen
 
 import com.freeletics.khonshu.codegen.BaseData
 import com.freeletics.khonshu.codegen.NavHostActivityData
+import com.freeletics.khonshu.codegen.UseExperimentalNavigation
 import com.freeletics.khonshu.codegen.util.asParameter
 import com.freeletics.khonshu.codegen.util.bindsInstanceParameter
 import com.freeletics.khonshu.codegen.util.contributesToAnnotation
@@ -19,6 +20,7 @@ import com.freeletics.khonshu.codegen.util.subcomponentAnnotation
 import com.freeletics.khonshu.codegen.util.subcomponentFactoryAnnotation
 import com.squareup.anvil.compiler.internal.decapitalize
 import com.squareup.kotlinpoet.AnnotationSpec.UseSiteTarget.GET
+import com.squareup.kotlinpoet.BOOLEAN
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier.ABSTRACT
 import com.squareup.kotlinpoet.KModifier.OVERRIDE
@@ -80,6 +82,11 @@ internal class ComponentGenerator(
                 PropertySpec.builder("deepLinkHandlers", immutableSet.parameterizedBy(deepLinkHandler)).build(),
                 PropertySpec.builder("deepLinkPrefixes", immutableSet.parameterizedBy(deepLinkPrefix)).build(),
             )
+            if (data.experimentalNavigation) {
+                properties += PropertySpec.builder("useExperimentalNavigation", BOOLEAN)
+                    .addAnnotation(UseExperimentalNavigation::class)
+                    .build()
+            }
         }
         properties += PropertySpec.builder(closeableSetPropertyName, SET.parameterizedBy(Closeable::class.asTypeName()))
             .addAnnotation(forScope(data.scope, GET))

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/ComponentGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/ComponentGenerator.kt
@@ -19,6 +19,7 @@ import com.freeletics.khonshu.codegen.util.simplePropertySpec
 import com.freeletics.khonshu.codegen.util.subcomponentAnnotation
 import com.freeletics.khonshu.codegen.util.subcomponentFactoryAnnotation
 import com.squareup.anvil.compiler.internal.decapitalize
+import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.AnnotationSpec.UseSiteTarget.GET
 import com.squareup.kotlinpoet.BOOLEAN
 import com.squareup.kotlinpoet.FunSpec
@@ -84,7 +85,7 @@ internal class ComponentGenerator(
             )
             if (data.experimentalNavigation) {
                 properties += PropertySpec.builder("useExperimentalNavigation", BOOLEAN)
-                    .addAnnotation(UseExperimentalNavigation::class)
+                    .addAnnotation(AnnotationSpec.builder(UseExperimentalNavigation::class).useSiteTarget(GET).build())
                     .build()
             }
         }

--- a/codegen/api/android/codegen.api
+++ b/codegen/api/android/codegen.api
@@ -22,6 +22,9 @@ public abstract interface annotation class com/freeletics/khonshu/codegen/NavHos
 public abstract interface class com/freeletics/khonshu/codegen/Overlay {
 }
 
+public abstract interface annotation class com/freeletics/khonshu/codegen/UseExperimentalNavigation : java/lang/annotation/Annotation {
+}
+
 public final class com/freeletics/khonshu/codegen/internal/ActivityComponentLookupKt {
 	public static final fun findComponentByScope (Landroid/content/Context;Lkotlin/reflect/KClass;)Ljava/lang/Object;
 }

--- a/codegen/api/jvm/codegen.api
+++ b/codegen/api/jvm/codegen.api
@@ -22,6 +22,9 @@ public abstract interface annotation class com/freeletics/khonshu/codegen/NavHos
 public abstract interface class com/freeletics/khonshu/codegen/Overlay {
 }
 
+public abstract interface annotation class com/freeletics/khonshu/codegen/UseExperimentalNavigation : java/lang/annotation/Annotation {
+}
+
 public abstract interface annotation class com/freeletics/khonshu/codegen/internal/InternalCodegenApi : java/lang/annotation/Annotation {
 }
 

--- a/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/UseExperimentalNavigation.kt
+++ b/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/UseExperimentalNavigation.kt
@@ -7,4 +7,5 @@ import javax.inject.Qualifier
  * enabled or not. Only considered if [NavHostActivity.experimentalNavigation] is `true`.
  */
 @Qualifier
+@Retention(AnnotationRetention.RUNTIME)
 public annotation class UseExperimentalNavigation

--- a/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/UseExperimentalNavigation.kt
+++ b/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/UseExperimentalNavigation.kt
@@ -1,0 +1,10 @@
+package com.freeletics.khonshu.codegen
+
+import javax.inject.Qualifier
+
+/**
+ * Qualifier used to provide a boolean that indicated whether experimental navigation should be
+ * enabled or not. Only considered if [NavHostActivity.experimentalNavigation] is `true`.
+ */
+@Qualifier
+public annotation class UseExperimentalNavigation

--- a/sample/simple/feature/bottom-sheet/implementation/feature-bottom-sheet-implementation.gradle.kts
+++ b/sample/simple/feature/bottom-sheet/implementation/feature-bottom-sheet-implementation.gradle.kts
@@ -13,7 +13,6 @@ dependencies {
     api(libs.androidx.lifecycle.viewmodel.savedstate)
     api(libs.coroutines)
     api(libs.khonshu.navigator)
-    api(libs.khonshu.navigator.compose)
     api(libs.khonshu.statemachine)
     api(libs.khonshu.codegen)
     api(projects.feature.bottomSheet.nav)

--- a/sample/simple/feature/dialog/implementation/feature-dialog-implementation.gradle.kts
+++ b/sample/simple/feature/dialog/implementation/feature-dialog-implementation.gradle.kts
@@ -13,7 +13,6 @@ dependencies {
     api(libs.androidx.lifecycle.viewmodel.savedstate)
     api(libs.coroutines)
     api(libs.khonshu.navigator)
-    api(libs.khonshu.navigator.compose)
     api(libs.khonshu.statemachine)
     api(libs.khonshu.codegen)
     api(projects.feature.dialog.nav)

--- a/sample/simple/feature/main/feature-main.gradle.kts
+++ b/sample/simple/feature/main/feature-main.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     api(libs.androidx.lifecycle.viewmodel.savedstate)
     api(libs.coroutines)
     api(libs.khonshu.navigator.compose)
+    api(libs.khonshu.navigator.experimental)
     api(libs.khonshu.statemachine)
 
     implementation(libs.androidx.activity.compose)

--- a/sample/simple/feature/main/src/main/kotlin/com/freeletics/khonshu/sample/feature/main/MainModule.kt
+++ b/sample/simple/feature/main/src/main/kotlin/com/freeletics/khonshu/sample/feature/main/MainModule.kt
@@ -1,0 +1,15 @@
+package com.freeletics.khonshu.sample.feature.main
+
+import com.freeletics.khonshu.codegen.ActivityScope
+import com.freeletics.khonshu.codegen.UseExperimentalNavigation
+import com.squareup.anvil.annotations.ContributesTo
+import dagger.Module
+import dagger.Provides
+
+@Module
+@ContributesTo(ActivityScope::class)
+object MainModule {
+    @Provides
+    @UseExperimentalNavigation
+    fun provideUseExperimentalNavigation(): Boolean = true
+}

--- a/sample/simple/feature/new-root/implementation/feature-new-root-implementation.gradle.kts
+++ b/sample/simple/feature/new-root/implementation/feature-new-root-implementation.gradle.kts
@@ -13,7 +13,6 @@ dependencies {
     api(libs.androidx.lifecycle.viewmodel.savedstate)
     api(libs.coroutines)
     api(libs.khonshu.navigator)
-    api(libs.khonshu.navigator.compose)
     api(libs.khonshu.statemachine)
     api(libs.khonshu.codegen)
     api(projects.feature.newRoot.nav)

--- a/sample/simple/feature/root/implementation/feature-root-implementation.gradle.kts
+++ b/sample/simple/feature/root/implementation/feature-root-implementation.gradle.kts
@@ -13,7 +13,6 @@ dependencies {
     api(libs.androidx.lifecycle.viewmodel.savedstate)
     api(libs.coroutines)
     api(libs.khonshu.navigator)
-    api(libs.khonshu.navigator.compose)
     api(libs.khonshu.statemachine)
     api(libs.khonshu.codegen)
     api(projects.feature.root.nav)

--- a/sample/simple/feature/screen/implementation/feature-screen-implementation.gradle.kts
+++ b/sample/simple/feature/screen/implementation/feature-screen-implementation.gradle.kts
@@ -13,7 +13,6 @@ dependencies {
     api(libs.androidx.lifecycle.viewmodel.savedstate)
     api(libs.coroutines)
     api(libs.khonshu.navigator)
-    api(libs.khonshu.navigator.compose)
     api(libs.khonshu.statemachine)
     api(libs.khonshu.codegen)
     api(projects.feature.screen.nav)

--- a/sample/simple/gradle/libs.versions.toml
+++ b/sample/simple/gradle/libs.versions.toml
@@ -49,6 +49,7 @@ dagger = { module = "com.google.dagger:dagger", version.ref = "dagger" }
 dagger-compiler = { module = "com.google.dagger:dagger-compiler", version.ref = "dagger" }
 inject = { module = "javax.inject:javax.inject", version.ref = "inject" }
 khonshu-navigator = { module = "com.freeletics.khonshu:navigation", version.ref = "khonshu" }
+khonshu-navigator-experimental = { module = "com.freeletics.khonshu:navigation-experimental", version.ref = "khonshu" }
 khonshu-navigator-compose = { module = "com.freeletics.khonshu:navigation-compose", version.ref = "khonshu" }
 khonshu-codegen-compiler = { module = "com.freeletics.khonshu:codegen-compiler", version.ref = "khonshu" }
 khonshu-codegen = { module = "com.freeletics.khonshu:codegen-runtime", version.ref = "khonshu" }

--- a/sample/simple/settings.gradle.kts
+++ b/sample/simple/settings.gradle.kts
@@ -13,5 +13,5 @@ plugins {
 rootProject.name = "simple-sample"
 
 configure<com.freeletics.gradle.plugin.SettingsExtension> {
-    includeKhonshu("../..", true)
+    includeKhonshu("../..")
 }


### PR DESCRIPTION
Previously when setting `experimentalNavigation = true` in `@NavHostActivity` it would only generate the experimental code. Since you can have the annotation twice it was already possible to use both at the same time, however it doesn't work well for launcher activities and activities launched through implicit intents, where you can't easily dynamically switch which is launched.

With this enabling `experimentalNavigation` will generate both the code for experimental and androidx navigation. The boolean to decide which one to use at runtime is injected from the Activity component. This allows providing a value based on a feature flag.