### PR TITLE
use remember when pulling destinations and deeplinks from component

### DIFF
--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavHostActivityCodegenTest.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavHostActivityCodegenTest.kt
@@ -215,11 +215,11 @@ internal class NavHostActivityCodegenTest {
                     CompositionLocalProvider(LocalActivityComponentProvider provides componentProvider) {
                       NavHost(
                         startRoute = startRoute,
-                        destinations = component.destinations,
+                        destinations = remember(component) { component.destinations },
                         modifier = modifier,
-                        deepLinkHandlers = component.deepLinkHandlers,
-                        deepLinkPrefixes = component.deepLinkPrefixes,
-                        navEventNavigator = component.navEventNavigator,
+                        deepLinkHandlers = remember(component) { component.deepLinkHandlers },
+                        deepLinkPrefixes = remember(component) { component.deepLinkPrefixes },
+                        navEventNavigator = remember(component) { component.navEventNavigator },
                         destinationChangedCallback = destinationChangedCallback,
                         transitionAnimations = NavHostTransitionAnimations.noAnimations(),
                       )
@@ -429,11 +429,11 @@ internal class NavHostActivityCodegenTest {
                     CompositionLocalProvider(LocalActivityComponentProvider provides componentProvider) {
                       NavHost(
                         startRoute = startRoute,
-                        destinations = component.destinations,
+                        destinations = remember(component) { component.destinations },
                         modifier = modifier,
-                        deepLinkHandlers = component.deepLinkHandlers,
-                        deepLinkPrefixes = component.deepLinkPrefixes,
-                        navEventNavigator = component.navEventNavigator,
+                        deepLinkHandlers = remember(component) { component.deepLinkHandlers },
+                        deepLinkPrefixes = remember(component) { component.deepLinkPrefixes },
+                        navEventNavigator = remember(component) { component.navEventNavigator },
                         destinationChangedCallback = destinationChangedCallback,
                         transitionAnimations = NavHostTransitionAnimations.noAnimations(),
                       )
@@ -679,11 +679,11 @@ internal class NavHostActivityCodegenTest {
                     CompositionLocalProvider(LocalActivityComponentProvider provides componentProvider) {
                       NavHost(
                         startRoute = startRoute,
-                        destinations = component.destinations,
+                        destinations = remember(component) { component.destinations },
                         modifier = modifier,
-                        deepLinkHandlers = component.deepLinkHandlers,
-                        deepLinkPrefixes = component.deepLinkPrefixes,
-                        navEventNavigator = component.navEventNavigator,
+                        deepLinkHandlers = remember(component) { component.deepLinkHandlers },
+                        deepLinkPrefixes = remember(component) { component.deepLinkPrefixes },
+                        navEventNavigator = remember(component) { component.navEventNavigator },
                         destinationChangedCallback = destinationChangedCallback,
                         transitionAnimations = NavHostTransitionAnimations.noAnimations(),
                       )
@@ -898,11 +898,11 @@ internal class NavHostActivityCodegenTest {
                     CompositionLocalProvider(LocalActivityComponentProvider provides componentProvider) {
                       NavHost(
                         startRoute = startRoute,
-                        destinations = component.destinations,
+                        destinations = remember(component) { component.destinations },
                         modifier = modifier,
-                        deepLinkHandlers = component.deepLinkHandlers,
-                        deepLinkPrefixes = component.deepLinkPrefixes,
-                        navEventNavigator = component.navEventNavigator,
+                        deepLinkHandlers = remember(component) { component.deepLinkHandlers },
+                        deepLinkPrefixes = remember(component) { component.deepLinkPrefixes },
+                        navEventNavigator = remember(component) { component.navEventNavigator },
                         destinationChangedCallback = destinationChangedCallback,
                         transitionAnimations = NavHostTransitionAnimations.noAnimations(),
                       )
@@ -1107,11 +1107,11 @@ internal class NavHostActivityCodegenTest {
                     CompositionLocalProvider(LocalActivityComponentProvider provides componentProvider) {
                       NavHost(
                         startRoute = startRoute,
-                        destinations = component.destinations,
+                        destinations = remember(component) { component.destinations },
                         modifier = modifier,
-                        deepLinkHandlers = component.deepLinkHandlers,
-                        deepLinkPrefixes = component.deepLinkPrefixes,
-                        navEventNavigator = component.navEventNavigator,
+                        deepLinkHandlers = remember(component) { component.deepLinkHandlers },
+                        deepLinkPrefixes = remember(component) { component.deepLinkPrefixes },
+                        navEventNavigator = remember(component) { component.navEventNavigator },
                         destinationChangedCallback = destinationChangedCallback,
                         transitionAnimations = NavHostTransitionAnimations.noAnimations(),
                       )
@@ -1321,11 +1321,11 @@ internal class NavHostActivityCodegenTest {
                     CompositionLocalProvider(LocalActivityComponentProvider provides componentProvider) {
                       NavHost(
                         startRoute = startRoute,
-                        destinations = component.destinations,
+                        destinations = remember(component) { component.destinations },
                         modifier = modifier,
-                        deepLinkHandlers = component.deepLinkHandlers,
-                        deepLinkPrefixes = component.deepLinkPrefixes,
-                        navEventNavigator = component.navEventNavigator,
+                        deepLinkHandlers = remember(component) { component.deepLinkHandlers },
+                        deepLinkPrefixes = remember(component) { component.deepLinkPrefixes },
+                        navEventNavigator = remember(component) { component.navEventNavigator },
                         destinationChangedCallback = destinationChangedCallback,
                         transitionAnimations = NavHostTransitionAnimations.noAnimations(),
                       )
@@ -1542,27 +1542,27 @@ internal class NavHostActivityCodegenTest {
                   }
                   KhonshuExperimentalTest(component) { startRoute, modifier, destinationChangedCallback ->
                     CompositionLocalProvider(LocalActivityComponentProvider provides componentProvider) {
-                      val useExperimentalNavigation = remember {
+                      val useExperimentalNavigation = remember(component) {
                         component.useExperimentalNavigation
                       }
                       if (useExperimentalNavigation) {
                         navigationNavHost(
                           startRoute = startRoute,
-                          destinations = component.destinations,
+                          destinations = remember(component) { component.destinations },
                           modifier = modifier,
-                          deepLinkHandlers = component.deepLinkHandlers,
-                          deepLinkPrefixes = component.deepLinkPrefixes,
-                          navEventNavigator = component.navEventNavigator,
+                          deepLinkHandlers = remember(component) { component.deepLinkHandlers },
+                          deepLinkPrefixes = remember(component) { component.deepLinkPrefixes },
+                          navEventNavigator = remember(component) { component.navEventNavigator },
                           destinationChangedCallback = destinationChangedCallback,
                         )
                       } else {
                         androidxNavHost(
                           startRoute = startRoute,
-                          destinations = component.destinations,
+                          destinations = remember(component) { component.destinations },
                           modifier = modifier,
-                          deepLinkHandlers = component.deepLinkHandlers,
-                          deepLinkPrefixes = component.deepLinkPrefixes,
-                          navEventNavigator = component.navEventNavigator,
+                          deepLinkHandlers = remember(component) { component.deepLinkHandlers },
+                          deepLinkPrefixes = remember(component) { component.deepLinkPrefixes },
+                          navEventNavigator = remember(component) { component.navEventNavigator },
                           destinationChangedCallback = destinationChangedCallback,
                           transitionAnimations = NavHostTransitionAnimations.noAnimations(),
                         )

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/ActivityGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/ActivityGenerator.kt
@@ -51,7 +51,7 @@ internal class ActivityGenerator(
             )
             .apply {
                 if (data.experimentalNavigation) {
-                    beginControlFlow("val useExperimentalNavigation = %M", remember)
+                    beginControlFlow("val useExperimentalNavigation = %M(component)", remember)
                         .addStatement("component.useExperimentalNavigation")
                         .endControlFlow()
                         .beginControlFlow("if (useExperimentalNavigation)")
@@ -79,11 +79,11 @@ internal class ActivityGenerator(
                 }
             }
             .addStatement("  startRoute = startRoute,")
-            .addStatement("  destinations = component.destinations,")
+            .addStatement("  destinations = %M(component) { component.destinations },", remember)
             .addStatement("  modifier = modifier,")
-            .addStatement("  deepLinkHandlers = component.deepLinkHandlers,")
-            .addStatement("  deepLinkPrefixes = component.deepLinkPrefixes,")
-            .addStatement("  navEventNavigator = component.navEventNavigator,")
+            .addStatement("  deepLinkHandlers = %M(component) { component.deepLinkHandlers },", remember)
+            .addStatement("  deepLinkPrefixes = %M(component) { component.deepLinkPrefixes },", remember)
+            .addStatement("  navEventNavigator = %M(component) { component.navEventNavigator },", remember)
             .addStatement("  destinationChangedCallback = destinationChangedCallback,")
             .apply {
                 if (!experimental) {


### PR DESCRIPTION
Avoids re-compositions and unintentionally re-creating the `NavigationExecutor` on recompositions.