### PR TITLE
remove Experimental prefix

### DIFF
--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavHostActivityCodegenTest.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavHostActivityCodegenTest.kt
@@ -1447,7 +1447,7 @@ internal class NavHostActivityCodegenTest {
               scope = TestScreen::class,
               parentScope = TestParentScope::class,
             )
-            public interface KhonshuExperimentalTestComponent : Closeable {
+            public interface KhonshuTestComponent : Closeable {
               public val testStateMachine: TestStateMachine
 
               @get:ForScope(TestScreen::class)
@@ -1475,30 +1475,30 @@ internal class NavHostActivityCodegenTest {
               public interface Factory {
                 public fun create(@BindsInstance @ForScope(TestScreen::class)
                     savedStateHandle: SavedStateHandle, @BindsInstance @ForScope(TestScreen::class)
-                    arguments: Bundle): KhonshuExperimentalTestComponent
+                    arguments: Bundle): KhonshuTestComponent
               }
 
               @ContributesTo(TestParentScope::class)
               public interface ParentComponent {
-                public fun khonshuExperimentalTestComponentFactory(): Factory
+                public fun khonshuTestComponentFactory(): Factory
               }
             }
 
             @OptIn(InternalCodegenApi::class)
-            public class KhonshuExperimentalTestComponentProvider(
+            public class KhonshuTestComponentProvider(
               private final val activity: ComponentActivity,
             ) : ActivityComponentProvider {
               override fun <C> provide(scope: KClass<*>): C = component(activity, scope, TestScreen::class,
-                  TestParentScope::class) { parentComponent: KhonshuExperimentalTestComponent.ParentComponent,
+                  TestParentScope::class) { parentComponent: KhonshuTestComponent.ParentComponent,
                   savedStateHandle ->
-                parentComponent.khonshuExperimentalTestComponentFactory().create(savedStateHandle,
+                parentComponent.khonshuTestComponentFactory().create(savedStateHandle,
                     activity.intent.extras ?: Bundle.EMPTY)
               }
             }
 
             @Module
             @ContributesTo(TestScreen::class)
-            public interface KhonshuExperimentalTestModule {
+            public interface KhonshuTestModule {
               @Multibinds
               @ForScope(TestScreen::class)
               public fun bindCloseables(): Set<Closeable>
@@ -1506,7 +1506,7 @@ internal class NavHostActivityCodegenTest {
 
             @Module
             @ContributesTo(TestScreen::class)
-            public interface KhonshuExperimentalTestActivityModule {
+            public interface KhonshuTestActivityModule {
               @Multibinds
               public fun bindDeepLinkHandler(): Set<DeepLinkHandler>
 
@@ -1530,17 +1530,17 @@ internal class NavHostActivityCodegenTest {
             }
 
             @OptIn(InternalCodegenApi::class)
-            public class KhonshuExperimentalTestActivity : ComponentActivity() {
+            public class KhonshuTestActivity : ComponentActivity() {
               override fun onCreate(savedInstanceState: Bundle?) {
                 super.onCreate(savedInstanceState)
                 setContent {
                   val componentProvider = remember {
-                    KhonshuExperimentalTestComponentProvider(this)
+                    KhonshuTestComponentProvider(this)
                   }
                   val component = remember(componentProvider) {
-                    componentProvider.provide<KhonshuExperimentalTestComponent>(TestScreen::class)
+                    componentProvider.provide<KhonshuTestComponent>(TestScreen::class)
                   }
-                  KhonshuExperimentalTest(component) { startRoute, modifier, destinationChangedCallback ->
+                  KhonshuTest(component) { startRoute, modifier, destinationChangedCallback ->
                     CompositionLocalProvider(LocalActivityComponentProvider provides componentProvider) {
                       val useExperimentalNavigation = remember(component) {
                         component.useExperimentalNavigation
@@ -1575,7 +1575,7 @@ internal class NavHostActivityCodegenTest {
 
             @Composable
             @OptIn(InternalCodegenApi::class)
-            private fun KhonshuExperimentalTest(component: KhonshuExperimentalTestComponent,
+            private fun KhonshuTest(component: KhonshuTestComponent,
                 navHost: SimpleNavHost) {
               val stateMachine = remember { component.testStateMachine }
               val scope = rememberCoroutineScope()
@@ -1595,6 +1595,6 @@ internal class NavHostActivityCodegenTest {
 
         """.trimIndent()
 
-        test(withExperimentalNavigation, "com/test/ExperimentalTest.kt", source, expected)
+        test(withExperimentalNavigation, "com/test/Test.kt", source, expected)
     }
 }

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavHostActivityCodegenTest.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavHostActivityCodegenTest.kt
@@ -20,7 +20,7 @@ import org.junit.Test
 internal class NavHostActivityCodegenTest {
 
     private val data = NavHostActivityData(
-        originalName = "Test",
+        baseName = "Test",
         packageName = "com.test",
         scope = ClassName("com.test", "TestScreen"),
         parentScope = ClassName("com.test.parent", "TestParentScope"),
@@ -470,7 +470,7 @@ internal class NavHostActivityCodegenTest {
     @Test
     fun `generates code for NavHostActivityData with Composable Dependencies`() {
         val withInjectedParameters = data.copy(
-            originalName = "Test2",
+            baseName = "Test2",
             composableParameter = listOf(
                 ComposableParameter(
                     name = "testClass",
@@ -1491,8 +1491,8 @@ internal class NavHostActivityCodegenTest {
               override fun <C> provide(scope: KClass<*>): C = component(activity, scope, TestScreen::class,
                   TestParentScope::class) { parentComponent: KhonshuTestComponent.ParentComponent,
                   savedStateHandle ->
-                parentComponent.khonshuTestComponentFactory().create(savedStateHandle,
-                    activity.intent.extras ?: Bundle.EMPTY)
+                parentComponent.khonshuTestComponentFactory().create(savedStateHandle, activity.intent.extras ?:
+                    Bundle.EMPTY)
               }
             }
 
@@ -1575,8 +1575,7 @@ internal class NavHostActivityCodegenTest {
 
             @Composable
             @OptIn(InternalCodegenApi::class)
-            private fun KhonshuTest(component: KhonshuTestComponent,
-                navHost: SimpleNavHost) {
+            private fun KhonshuTest(component: KhonshuTestComponent, navHost: SimpleNavHost) {
               val stateMachine = remember { component.testStateMachine }
               val scope = rememberCoroutineScope()
               val sendAction: (TestAction) -> Unit = remember(stateMachine, scope) {

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/Data.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/Data.kt
@@ -5,7 +5,6 @@ import com.freeletics.khonshu.codegen.util.getComponentFromRoute
 import com.freeletics.khonshu.codegen.util.navigationDestination
 import com.freeletics.khonshu.codegen.util.overlayDestination
 import com.freeletics.khonshu.codegen.util.screenDestination
-import com.squareup.anvil.compiler.internal.capitalize
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.TypeName
@@ -48,7 +47,7 @@ public data class NavDestinationData(
 ) : BaseData
 
 public data class NavHostActivityData(
-    private val originalName: String,
+    override val baseName: String,
     override val packageName: String,
 
     override val scope: ClassName,
@@ -65,11 +64,6 @@ public data class NavHostActivityData(
     override val composableParameter: List<ComposableParameter>,
 ) : BaseData {
     override val navigation: Navigation? = null
-
-    override val baseName: String = when (experimentalNavigation) {
-        false -> originalName
-        true -> "Experimental${originalName.capitalize()}"
-    }
 }
 
 public data class Navigation(

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/ComponentComposableGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/ComponentComposableGenerator.kt
@@ -65,7 +65,7 @@ internal class ComponentComposableGenerator(
             .addStatement("val state = stateMachine.%M()", asComposeState)
             .addStatement("val currentState = state.value")
             .beginControlFlow("if (currentState != null)")
-            .addStatement("%L(", data.baseName.removePrefix("Experimental"))
+            .addStatement("%L(", data.baseName)
             .apply {
                 data.composableParameter.forEach { parameter ->
                     addStatement("  %L = %L,", parameter.name, parameter.name)

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/AnvilParser.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/AnvilParser.kt
@@ -86,7 +86,7 @@ internal fun TopLevelFunctionReference.toNavHostActivityData(annotation: Annotat
     val navHostParameter = navHostParameter()
 
     return NavHostActivityData(
-        originalName = name,
+        baseName = name,
         packageName = packageName,
         scope = annotation.scope,
         parentScope = annotation.parentScope,

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/KspParser.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/KspParser.kt
@@ -69,7 +69,7 @@ internal fun KSFunctionDeclaration.toNavHostActivityData(
     val navHostParameter = navHostParameter(logger) ?: return null
 
     return NavHostActivityData(
-        originalName = simpleName.asString(),
+        baseName = simpleName.asString(),
         packageName = packageName.asString(),
         scope = annotation.scope,
         parentScope = annotation.parentScope,


### PR DESCRIPTION
Since we're switching between modes at runtime instead of generating 2 separate activities we don't need the `Experimental` prefix anymore on generated code.