### PR TITLE
remove unused internal matchesPattern deep link methods

### DIFF
--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/deeplinks/DeepLinkMatcherTest.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/deeplinks/DeepLinkMatcherTest.kt
@@ -20,42 +20,42 @@ internal class DeepLinkMatcherTest {
     fun `when the pattern is home`() {
         val handler = TestDeepLinkHandler("home")
 
-        assertThat(handler).matchesPattern("https://a.com/home", prefixes).isTrue() // first prefix
-        assertThat(handler).matchesPattern("https://b.de/home", prefixes).isTrue() // second prefix
-        assertThat(handler).matchesPattern("app://b.de/home", prefixes).isTrue() // third prefix
+        assertThat(handler).createDeepLinkIfMatching("https://a.com/home", prefixes).isNotNull() // first prefix
+        assertThat(handler).createDeepLinkIfMatching("https://b.de/home", prefixes).isNotNull() // second prefix
+        assertThat(handler).createDeepLinkIfMatching("app://b.de/home", prefixes).isNotNull() // third prefix
         assertThat(handler)
-            .matchesPattern("https://a.com/home?param1=value1&param2=value2", prefixes)
-            .isTrue() // with query parameters
+            .createDeepLinkIfMatching("https://a.com/home?param1=value1&param2=value2", prefixes)
+            .isNotNull() // with query parameters
 
-        assertThat(handler).matchesPattern("https://a.com", prefixes).isFalse() // just the prefix 1
-        assertThat(handler).matchesPattern("https://a.com/", prefixes).isFalse() // just the prefix 2
+        assertThat(handler).createDeepLinkIfMatching("https://a.com", prefixes).isNull() // just the prefix 1
+        assertThat(handler).createDeepLinkIfMatching("https://a.com/", prefixes).isNull() // just the prefix 2
         assertThat(handler)
-            .matchesPattern("https://a.com/home/world", prefixes).isFalse() // different path
-        assertThat(handler).matchesPattern("https://a.com/home/", prefixes)
-            .isFalse() // trailing slash that is not in pattern
-        assertThat(handler).matchesPattern("https://c.com/home", prefixes).isFalse() // different domain
-        assertThat(handler).matchesPattern("https://a.abc/home", prefixes).isFalse() // different tld
-        assertThat(handler).matchesPattern("web://b.de/home", prefixes).isFalse() // different scheme
+            .createDeepLinkIfMatching("https://a.com/home/world", prefixes).isNull() // different path
+        assertThat(handler).createDeepLinkIfMatching("https://a.com/home/", prefixes)
+            .isNull() // trailing slash that is not in pattern
+        assertThat(handler).createDeepLinkIfMatching("https://c.com/home", prefixes).isNull() // different domain
+        assertThat(handler).createDeepLinkIfMatching("https://a.abc/home", prefixes).isNull() // different tld
+        assertThat(handler).createDeepLinkIfMatching("web://b.de/home", prefixes).isNull() // different scheme
     }
 
     @Test
     fun `when the pattern is empty`() {
         val handler = TestDeepLinkHandler("")
 
-        assertThat(handler).matchesPattern("https://a.com/", prefixes).isTrue() // first prefix
-        assertThat(handler).matchesPattern("https://b.de/", prefixes).isTrue() // second prefix
-        assertThat(handler).matchesPattern("app://b.de/", prefixes).isTrue() // third prefix
-        assertThat(handler).matchesPattern("https://a.com", prefixes).isTrue() // first prefix
-        assertThat(handler).matchesPattern("https://b.de", prefixes).isTrue() // second prefix
-        assertThat(handler).matchesPattern("app://b.de", prefixes).isTrue() // third prefix
+        assertThat(handler).createDeepLinkIfMatching("https://a.com/", prefixes).isNotNull() // first prefix
+        assertThat(handler).createDeepLinkIfMatching("https://b.de/", prefixes).isNotNull() // second prefix
+        assertThat(handler).createDeepLinkIfMatching("app://b.de/", prefixes).isNotNull() // third prefix
+        assertThat(handler).createDeepLinkIfMatching("https://a.com", prefixes).isNotNull() // first prefix
+        assertThat(handler).createDeepLinkIfMatching("https://b.de", prefixes).isNotNull() // second prefix
+        assertThat(handler).createDeepLinkIfMatching("app://b.de", prefixes).isNotNull() // third prefix
         assertThat(handler)
-            .matchesPattern("https://a.com?param1=value1&param2=value2", prefixes)
-            .isTrue() // with query parameters
+            .createDeepLinkIfMatching("https://a.com?param1=value1&param2=value2", prefixes)
+            .isNotNull() // with query parameters
         assertThat(handler)
-            .matchesPattern("https://a.com/?param1=value1&param2=value2", prefixes)
-            .isTrue() // with query parameters
+            .createDeepLinkIfMatching("https://a.com/?param1=value1&param2=value2", prefixes)
+            .isNotNull() // with query parameters
 
-        assertThat(handler).matchesPattern("https://a.com/home", prefixes).isFalse() // different path
+        assertThat(handler).createDeepLinkIfMatching("https://a.com/home", prefixes).isNull() // different path
     }
 
     @Test
@@ -63,25 +63,25 @@ internal class DeepLinkMatcherTest {
         val handler = TestDeepLinkHandler("foo/bar/{placeholder}")
 
         assertThat(handler)
-            .matchesPattern("https://a.com/foo/bar/abc", prefixes).isTrue() // lower case chars
+            .createDeepLinkIfMatching("https://a.com/foo/bar/abc", prefixes).isNotNull() // lower case chars
         assertThat(handler)
-            .matchesPattern("https://a.com/foo/bar/ABC", prefixes).isTrue() // upper case chars
+            .createDeepLinkIfMatching("https://a.com/foo/bar/ABC", prefixes).isNotNull() // upper case chars
         assertThat(handler)
-            .matchesPattern("https://a.com/foo/bar/123", prefixes).isTrue() // numbers
+            .createDeepLinkIfMatching("https://a.com/foo/bar/123", prefixes).isNotNull() // numbers
         assertThat(handler)
-            .matchesPattern("https://a.com/foo/bar/_'!+~=,-.@\$:", prefixes)
-            .isTrue() // all allowed special character
+            .createDeepLinkIfMatching("https://a.com/foo/bar/_'!+~=,-.@\$:", prefixes)
+            .isNotNull() // all allowed special character
         assertThat(handler)
-            .matchesPattern("https://a.com/foo/bar/aBC123_=", prefixes)
-            .isTrue() // combination of the above
+            .createDeepLinkIfMatching("https://a.com/foo/bar/aBC123_=", prefixes)
+            .isNotNull() // combination of the above
         assertThat(handler)
-            .matchesPattern("https://a.com/foo/bar/abc?param1=value1&param2=value2", prefixes)
-            .isTrue() // with query parameters
+            .createDeepLinkIfMatching("https://a.com/foo/bar/abc?param1=value1&param2=value2", prefixes)
+            .isNotNull() // with query parameters
 
-        assertThat(handler).matchesPattern("https://a.com/foo/bar/", prefixes).isFalse() // empty placeholder
+        assertThat(handler).createDeepLinkIfMatching("https://a.com/foo/bar/", prefixes).isNull() // empty placeholder
         assertThat(handler)
-            .matchesPattern("https://a.com/foo/bar/§&", prefixes)
-            .isFalse() // not allowed special characters
+            .createDeepLinkIfMatching("https://a.com/foo/bar/§&", prefixes)
+            .isNull() // not allowed special characters
     }
 
     @Test
@@ -89,25 +89,25 @@ internal class DeepLinkMatcherTest {
         val handler = TestDeepLinkHandler("{placeholder}/foo/bar")
 
         assertThat(handler)
-            .matchesPattern("https://a.com/abc/foo/bar", prefixes).isTrue() // lower case chars
+            .createDeepLinkIfMatching("https://a.com/abc/foo/bar", prefixes).isNotNull() // lower case chars
         assertThat(handler)
-            .matchesPattern("https://a.com/ABC/foo/bar", prefixes).isTrue() // upper case chars
+            .createDeepLinkIfMatching("https://a.com/ABC/foo/bar", prefixes).isNotNull() // upper case chars
         assertThat(handler)
-            .matchesPattern("https://a.com/123/foo/bar", prefixes).isTrue() // numbers
+            .createDeepLinkIfMatching("https://a.com/123/foo/bar", prefixes).isNotNull() // numbers
         assertThat(handler)
-            .matchesPattern("https://a.com/_'!+~=,-.@\$:/foo/bar", prefixes)
-            .isTrue() // all allowed special character
+            .createDeepLinkIfMatching("https://a.com/_'!+~=,-.@\$:/foo/bar", prefixes)
+            .isNotNull() // all allowed special character
         assertThat(handler)
-            .matchesPattern("https://a.com/aBC123_=/foo/bar", prefixes)
-            .isTrue() // combination of the above
+            .createDeepLinkIfMatching("https://a.com/aBC123_=/foo/bar", prefixes)
+            .isNotNull() // combination of the above
         assertThat(handler)
-            .matchesPattern("https://a.com/abc/foo/bar?param1=value1&param2=value2", prefixes)
-            .isTrue() // with query parameters
+            .createDeepLinkIfMatching("https://a.com/abc/foo/bar?param1=value1&param2=value2", prefixes)
+            .isNotNull() // with query parameters
 
-        assertThat(handler).matchesPattern("https://a.com//foo/bar", prefixes).isFalse() // empty placeholder
+        assertThat(handler).createDeepLinkIfMatching("https://a.com//foo/bar", prefixes).isNull() // empty placeholder
         assertThat(handler)
-            .matchesPattern("https://a.com/§&/foo/bar", prefixes)
-            .isFalse() // not allowed special characters
+            .createDeepLinkIfMatching("https://a.com/§&/foo/bar", prefixes)
+            .isNull() // not allowed special characters
     }
 
     @Test
@@ -115,25 +115,25 @@ internal class DeepLinkMatcherTest {
         val handler = TestDeepLinkHandler("foo/{placeholder}/bar")
 
         assertThat(handler)
-            .matchesPattern("https://a.com/foo/abc/bar", prefixes).isTrue() // lower case chars
+            .createDeepLinkIfMatching("https://a.com/foo/abc/bar", prefixes).isNotNull() // lower case chars
         assertThat(handler)
-            .matchesPattern("https://a.com/foo/ABC/bar", prefixes).isTrue() // upper case chars
+            .createDeepLinkIfMatching("https://a.com/foo/ABC/bar", prefixes).isNotNull() // upper case chars
         assertThat(handler)
-            .matchesPattern("https://a.com/foo/123/bar", prefixes).isTrue() // numbers
+            .createDeepLinkIfMatching("https://a.com/foo/123/bar", prefixes).isNotNull() // numbers
         assertThat(handler)
-            .matchesPattern("https://a.com/foo/_'!+~=,-.@\$:/bar", prefixes)
-            .isTrue() // all allowed special character
+            .createDeepLinkIfMatching("https://a.com/foo/_'!+~=,-.@\$:/bar", prefixes)
+            .isNotNull() // all allowed special character
         assertThat(handler)
-            .matchesPattern("https://a.com/foo/aBC123_=/bar", prefixes)
-            .isTrue() // combination of the above
+            .createDeepLinkIfMatching("https://a.com/foo/aBC123_=/bar", prefixes)
+            .isNotNull() // combination of the above
         assertThat(handler)
-            .matchesPattern("https://a.com/foo/abc/bar?param1=value1&param2=value2", prefixes)
-            .isTrue() // with query parameters
+            .createDeepLinkIfMatching("https://a.com/foo/abc/bar?param1=value1&param2=value2", prefixes)
+            .isNotNull() // with query parameters
 
-        assertThat(handler).matchesPattern("https://a.com/foo//bar", prefixes).isFalse() // empty placeholder
+        assertThat(handler).createDeepLinkIfMatching("https://a.com/foo//bar", prefixes).isNull() // empty placeholder
         assertThat(handler)
-            .matchesPattern("https://a.com/foo/§&/bar", prefixes)
-            .isFalse() // not allowed special characters
+            .createDeepLinkIfMatching("https://a.com/foo/§&/bar", prefixes)
+            .isNull() // not allowed special characters
     }
 
     @Test
@@ -141,7 +141,7 @@ internal class DeepLinkMatcherTest {
         val handler = TestDeepLinkHandler("foo/{placeholder1}/bar/{placeholder2}")
 
         assertThat(handler)
-            .matchesPattern("https://a.com/foo/abc/bar/aBC123_=", prefixes).isTrue()
+            .createDeepLinkIfMatching("https://a.com/foo/abc/bar/aBC123_=", prefixes).isNotNull()
     }
 
     @Test
@@ -149,7 +149,7 @@ internal class DeepLinkMatcherTest {
         val handler = TestDeepLinkHandler("foo/a{placeholder}/bar")
 
         val exception = Assert.assertThrows(PatternSyntaxException::class.java) {
-            handler.matchesPattern(Uri.parse("https://a.com/foo/abc/bar"), prefixes)
+            setOf(handler).createDeepLinkIfMatching(Uri.parse("https://a.com/foo/abc/bar"), prefixes)
         }
         assertThat(exception).hasMessageThat().startsWith("Illegal repetition near index ")
     }
@@ -161,14 +161,14 @@ internal class DeepLinkMatcherTest {
             prefixes = setOf(DeepLinkHandler.Prefix("https://test.com")),
         )
 
-        assertThat(handler.matchesPattern(Uri.parse("https://test.com/home"), prefixes)).isTrue()
+        assertThat(handler).createDeepLinkIfMatching(Uri.parse("https://test.com/home"), prefixes).isNotNull()
         assertThat(handler)
-            .matchesPattern("https://test.com/home?param1=value1&param2=value2", prefixes)
-            .isTrue() // with query parameters
+            .createDeepLinkIfMatching("https://test.com/home?param1=value1&param2=value2", prefixes)
+            .isNotNull() // with query parameters
 
-        assertThat(handler).matchesPattern("https://a.com/home", prefixes).isFalse() // first default prefix
-        assertThat(handler).matchesPattern("https://b.de/home", prefixes).isFalse() // second default prefix
-        assertThat(handler).matchesPattern("app://b.de/home", prefixes).isFalse() // third default prefix
+        assertThat(handler).createDeepLinkIfMatching("https://a.com/home", prefixes).isNull() // first default prefix
+        assertThat(handler).createDeepLinkIfMatching("https://b.de/home", prefixes).isNull() // second default prefix
+        assertThat(handler).createDeepLinkIfMatching("app://b.de/home", prefixes).isNull() // third default prefix
     }
 
     @Test
@@ -176,13 +176,12 @@ internal class DeepLinkMatcherTest {
         val handlers = setOf(
             TestDeepLinkHandler(
                 patterns = setOf(DeepLinkHandler.Pattern("home")),
-                deepLinkFactory = { _, _ -> DeepLink("test", listOf()) },
             ),
             TestDeepLinkHandler(""),
         )
 
         val uri = Uri.parse("https://a.com/home")
-        assertThat(handlers.matchesPattern(uri, prefixes)).isTrue()
+        assertThat(handlers.createDeepLinkIfMatching(uri, prefixes)).isNotNull()
     }
 
     @Test
@@ -195,6 +194,6 @@ internal class DeepLinkMatcherTest {
         )
 
         val uri = Uri.parse("https://a.com/foo")
-        assertThat(handlers.matchesPattern(uri, prefixes)).isFalse()
+        assertThat(handlers.createDeepLinkIfMatching(uri, prefixes)).isNull()
     }
 }

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/deeplinks/DeepLinkParseParametersTest.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/deeplinks/DeepLinkParseParametersTest.kt
@@ -7,7 +7,7 @@ import com.freeletics.khonshu.navigation.test.TestDeepLinkHandler
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
-internal class DeepLinkParserTest {
+internal class DeepLinkParseParametersTest {
     @Test
     fun `when the pattern is home`() {
         val pattern = DeepLinkHandler.Pattern("home")
@@ -100,14 +100,13 @@ internal class DeepLinkParserTest {
             TestDeepLinkHandler(
                 patterns = setOf(DeepLinkHandler.Pattern("home")),
                 prefixes = setOf(DeepLinkHandler.Prefix("https://a.com")),
-                deepLinkFactory = { _, _ -> DeepLink("test", listOf()) },
             ),
             TestDeepLinkHandler(""),
         )
 
         val uri = Uri.parse("https://a.com/home")
         assertThat(handlers.createDeepLinkIfMatching(uri, emptySet())).isEqualTo(
-            DeepLink("test", listOf()),
+            DeepLink("test", listOf(DeepLinkRoute(emptyMap(), emptyMap()))),
         )
     }
 
@@ -117,9 +116,6 @@ internal class DeepLinkParserTest {
             TestDeepLinkHandler(
                 patterns = setOf(DeepLinkHandler.Pattern("{path}")),
                 prefixes = setOf(DeepLinkHandler.Prefix("https://a.com")),
-                deepLinkFactory = { path, query ->
-                    DeepLink("test", listOf(DeepLinkRoute(path, query)))
-                },
             ),
             TestDeepLinkHandler(""),
         )

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/DeepLinkHandlerPatternSubject.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/DeepLinkHandlerPatternSubject.kt
@@ -10,8 +10,8 @@ import com.google.common.truth.Truth.assertAbout
 
 internal class DeepLinkHandlerPatternSubject private constructor(
     failureMetadata: FailureMetadata,
-    private val handler: DeepLinkHandler.Pattern,
-) : Subject(failureMetadata, handler) {
+    private val pattern: DeepLinkHandler.Pattern,
+) : Subject(failureMetadata, pattern) {
 
     companion object {
         private val SUBJECT_FACTORY: Factory<DeepLinkHandlerPatternSubject, DeepLinkHandler.Pattern> =
@@ -33,6 +33,6 @@ internal class DeepLinkHandlerPatternSubject private constructor(
     }
 
     fun extractPathParameters(uri: Uri): MapSubject {
-        return check("extractPathParameters()").that(handler.extractPathParameters(uri))
+        return check("extractPathParameters()").that(pattern.extractPathParameters(uri))
     }
 }

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/DeepLinkHandlerSubject.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/DeepLinkHandlerSubject.kt
@@ -3,37 +3,41 @@ package com.freeletics.khonshu.navigation.test
 import com.eygraber.uri.Uri
 import com.freeletics.khonshu.navigation.deeplinks.DeepLinkHandler
 import com.freeletics.khonshu.navigation.deeplinks.DeepLinkHandler.Prefix
-import com.freeletics.khonshu.navigation.deeplinks.matchesPattern
-import com.google.common.truth.BooleanSubject
+import com.freeletics.khonshu.navigation.deeplinks.createDeepLinkIfMatching
 import com.google.common.truth.FailureMetadata
 import com.google.common.truth.Subject
 import com.google.common.truth.Truth.assertAbout
 
 internal class DeepLinkHandlerSubject private constructor(
     failureMetadata: FailureMetadata,
-    private val handler: DeepLinkHandler,
-) : Subject(failureMetadata, handler) {
+    private val handlers: Set<DeepLinkHandler>,
+) : Subject(failureMetadata, handlers) {
 
     companion object {
-        private val SUBJECT_FACTORY: Factory<DeepLinkHandlerSubject, DeepLinkHandler> =
+        private val SUBJECT_FACTORY: Factory<DeepLinkHandlerSubject, Set<DeepLinkHandler>> =
             Factory { metadata, actual -> DeepLinkHandlerSubject(metadata, actual!!) }
 
         @JvmStatic
-        fun deepLinkHandler(): Factory<DeepLinkHandlerSubject, DeepLinkHandler> {
+        fun deepLinkHandler(): Factory<DeepLinkHandlerSubject, Set<DeepLinkHandler>> {
             return SUBJECT_FACTORY
         }
 
         @JvmStatic
         fun assertThat(actual: DeepLinkHandler): DeepLinkHandlerSubject {
+            return assertAbout(deepLinkHandler()).that(setOf(actual))
+        }
+
+        @JvmStatic
+        fun assertThat(actual: Set<DeepLinkHandler>): DeepLinkHandlerSubject {
             return assertAbout(deepLinkHandler()).that(actual)
         }
     }
 
-    fun matchesPattern(string: String, prefixes: Set<Prefix> = emptySet()): BooleanSubject {
-        return matchesPattern(Uri.parse(string), prefixes)
+    fun createDeepLinkIfMatching(string: String, prefixes: Set<Prefix> = emptySet()): Subject {
+        return createDeepLinkIfMatching(Uri.parse(string), prefixes)
     }
 
-    fun matchesPattern(uri: Uri, prefixes: Set<Prefix> = emptySet()): BooleanSubject {
-        return check("matchesPattern()").that(handler.matchesPattern(uri, prefixes))
+    fun createDeepLinkIfMatching(uri: Uri, prefixes: Set<Prefix> = emptySet()): Subject {
+        return check("createDeepLinkIfMatching()").that(handlers.createDeepLinkIfMatching(uri, prefixes))
     }
 }

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/TestDeepLinkHandler.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/TestDeepLinkHandler.kt
@@ -8,9 +8,6 @@ import com.freeletics.khonshu.navigation.deeplinks.DeepLinkHandler.Prefix
 internal class TestDeepLinkHandler(
     override val patterns: Set<Pattern>,
     override val prefixes: Set<Prefix> = emptySet(),
-    private val deepLinkFactory: (Map<String, String>, Map<String, String>) -> DeepLink = { _, _ ->
-        throw AssertionError("Should never be called")
-    },
 ) : DeepLinkHandler {
 
     constructor(vararg patterns: String) : this(patterns.map { Pattern(it) }.toSet())
@@ -19,6 +16,6 @@ internal class TestDeepLinkHandler(
         pathParameters: Map<String, String>,
         queryParameters: Map<String, String>,
     ): DeepLink {
-        return deepLinkFactory(pathParameters, queryParameters)
+        return DeepLink("test", listOf(DeepLinkRoute(pathParameters, queryParameters)))
     }
 }

--- a/navigation/src/commonMain/kotlin/com/freeletics/khonshu/navigation/deeplinks/DeepLinkMatcher.kt
+++ b/navigation/src/commonMain/kotlin/com/freeletics/khonshu/navigation/deeplinks/DeepLinkMatcher.kt
@@ -1,37 +1,8 @@
 package com.freeletics.khonshu.navigation.deeplinks
 
-import com.eygraber.uri.Uri
 import com.freeletics.khonshu.navigation.deeplinks.DeepLinkHandler.Pattern
 import com.freeletics.khonshu.navigation.deeplinks.DeepLinkHandler.Prefix
 import com.freeletics.khonshu.navigation.internal.InternalNavigationApi
-
-/**
- * Checks if any of the given [uri] matches one of [DeepLinkHandler.patterns] and returns `true`
- * if that is the case.
- *
- * [defaultPrefixes] will be used as base url if [DeepLinkHandler.prefixes] is empty.
- */
-@InternalNavigationApi
-public fun Set<DeepLinkHandler>.matchesPattern(
-    uri: Uri,
-    defaultPrefixes: Set<Prefix>,
-): Boolean {
-    return any { it.matchesPattern(uri, defaultPrefixes) }
-}
-
-/**
- * Checks if the given [uri] matches one of [DeepLinkHandler.patterns] and returns `true` if that
- * is the case.
- *
- * [defaultPrefixes] will be used as base url if [DeepLinkHandler.prefixes] is empty.
- */
-@InternalNavigationApi
-public fun DeepLinkHandler.matchesPattern(
-    uri: Uri,
-    defaultPrefixes: Set<Prefix>,
-): Boolean {
-    return findMatchingPattern(uri.toString(), defaultPrefixes) != null
-}
 
 internal fun DeepLinkHandler.findMatchingPattern(
     uriString: String,


### PR DESCRIPTION
We used these internally at some point but since then migrated away from them.