### PR TITLE
cleanup DeepLink internal APIs

### DIFF
--- a/navigation/src/commonMain/kotlin/com/freeletics/khonshu/navigation/deeplinks/DeepLinkParser.kt
+++ b/navigation/src/commonMain/kotlin/com/freeletics/khonshu/navigation/deeplinks/DeepLinkParser.kt
@@ -26,7 +26,6 @@ public fun Set<DeepLinkHandler>.createDeepLinkIfMatching(
     return null
 }
 
-
 @VisibleForTesting
 internal fun DeepLinkHandler.Pattern.extractPathParameters(uri: Uri): MutableMap<String, String> {
     // create a Uri with the pattern so that we can get the placeholder names and their indices


### PR DESCRIPTION
Removes the unused internal `createDeepLinkIfMatching` that is called on a single `DeepLinkHandler`. Also marks `extractPathParameters` with `@VisibleForTesting` to show why it is internal and makes `queryParameters` private.