### PR TITLE
cleanup InternalNavigationApi usages

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,6 +50,8 @@ apiValidation {
 
     nonPublicMarkers += arrayOf(
         "com.freeletics.khonshu.navigation.internal.InternalNavigationApi",
+        "com.freeletics.khonshu.navigation.internal.InternalNavigationCodegenApi",
+        "com.freeletics.khonshu.navigation.internal.InternalNavigationTestingApi",
         "com.freeletics.khonshu.codegen.internal.InternalCodegenApi",
     )
 }

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationCodegenTest.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationCodegenTest.kt
@@ -89,7 +89,7 @@ internal class NavDestinationCodegenTest {
             import com.freeletics.khonshu.navigation.NavEventNavigator
             import com.freeletics.khonshu.navigation.NavigationSetup
             import com.freeletics.khonshu.navigation.ScreenDestination
-            import com.freeletics.khonshu.navigation.`internal`.InternalNavigationApi
+            import com.freeletics.khonshu.navigation.`internal`.InternalNavigationCodegenApi
             import com.freeletics.khonshu.navigation.`internal`.NavigationExecutor
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
@@ -143,7 +143,7 @@ internal class NavDestinationCodegenTest {
 
             @OptIn(InternalCodegenApi::class)
             public object KhonshuTestComponentProvider : ComponentProvider<TestRoute, KhonshuTestComponent> {
-              @OptIn(InternalNavigationApi::class)
+              @OptIn(InternalNavigationCodegenApi::class)
               override fun provide(
                 route: TestRoute,
                 executor: NavigationExecutor,
@@ -164,7 +164,7 @@ internal class NavDestinationCodegenTest {
             }
 
             @Composable
-            @OptIn(InternalCodegenApi::class, InternalNavigationApi::class)
+            @OptIn(InternalCodegenApi::class, InternalNavigationCodegenApi::class)
             public fun KhonshuTest(testRoute: TestRoute) {
               val executor = LocalNavigationExecutor.current
               val provider = LocalActivityComponentProvider.current
@@ -201,7 +201,7 @@ internal class NavDestinationCodegenTest {
             public object KhonshuTestNavDestinationModule {
               @Provides
               @IntoSet
-              @OptIn(InternalNavigationApi::class)
+              @OptIn(InternalNavigationCodegenApi::class)
               public fun provideNavDestination(): NavDestination =
                   ScreenDestination<TestRoute>(KhonshuTestComponentProvider) {
                 KhonshuTest(it)
@@ -264,7 +264,7 @@ internal class NavDestinationCodegenTest {
             import com.freeletics.khonshu.navigation.NavEventNavigator
             import com.freeletics.khonshu.navigation.NavigationSetup
             import com.freeletics.khonshu.navigation.ScreenDestination
-            import com.freeletics.khonshu.navigation.`internal`.InternalNavigationApi
+            import com.freeletics.khonshu.navigation.`internal`.InternalNavigationCodegenApi
             import com.freeletics.khonshu.navigation.`internal`.NavigationExecutor
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
@@ -316,7 +316,7 @@ internal class NavDestinationCodegenTest {
 
             @OptIn(InternalCodegenApi::class)
             public object KhonshuTestComponentProvider : ComponentProvider<TestRoute, KhonshuTestComponent> {
-              @OptIn(InternalNavigationApi::class)
+              @OptIn(InternalNavigationCodegenApi::class)
               override fun provide(
                 route: TestRoute,
                 executor: NavigationExecutor,
@@ -336,7 +336,7 @@ internal class NavDestinationCodegenTest {
             }
 
             @Composable
-            @OptIn(InternalCodegenApi::class, InternalNavigationApi::class)
+            @OptIn(InternalCodegenApi::class, InternalNavigationCodegenApi::class)
             public fun KhonshuTest(testRoute: TestRoute) {
               val executor = LocalNavigationExecutor.current
               val provider = LocalActivityComponentProvider.current
@@ -373,7 +373,7 @@ internal class NavDestinationCodegenTest {
             public object KhonshuTestNavDestinationModule {
               @Provides
               @IntoSet
-              @OptIn(InternalNavigationApi::class)
+              @OptIn(InternalNavigationCodegenApi::class)
               public fun provideNavDestination(): NavDestination =
                   ScreenDestination<TestRoute>(KhonshuTestComponentProvider) {
                 KhonshuTest(it)
@@ -438,7 +438,7 @@ internal class NavDestinationCodegenTest {
             import com.freeletics.khonshu.navigation.NavEventNavigator
             import com.freeletics.khonshu.navigation.NavigationSetup
             import com.freeletics.khonshu.navigation.OverlayDestination
-            import com.freeletics.khonshu.navigation.`internal`.InternalNavigationApi
+            import com.freeletics.khonshu.navigation.`internal`.InternalNavigationCodegenApi
             import com.freeletics.khonshu.navigation.`internal`.NavigationExecutor
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
@@ -494,7 +494,7 @@ internal class NavDestinationCodegenTest {
             @OptIn(InternalCodegenApi::class)
             public object KhonshuTestComponentProvider :
                 ComponentProvider<TestOverlayRoute, KhonshuTestComponent> {
-              @OptIn(InternalNavigationApi::class)
+              @OptIn(InternalNavigationCodegenApi::class)
               override fun provide(
                 route: TestOverlayRoute,
                 executor: NavigationExecutor,
@@ -515,7 +515,7 @@ internal class NavDestinationCodegenTest {
             }
 
             @Composable
-            @OptIn(InternalCodegenApi::class, InternalNavigationApi::class)
+            @OptIn(InternalCodegenApi::class, InternalNavigationCodegenApi::class)
             public fun KhonshuTest(testOverlayRoute: TestOverlayRoute) {
               val executor = LocalNavigationExecutor.current
               val provider = LocalActivityComponentProvider.current
@@ -552,7 +552,7 @@ internal class NavDestinationCodegenTest {
             public object KhonshuTestNavDestinationModule {
               @Provides
               @IntoSet
-              @OptIn(InternalNavigationApi::class)
+              @OptIn(InternalNavigationCodegenApi::class)
               public fun provideNavDestination(): NavDestination =
                   OverlayDestination<TestOverlayRoute>(KhonshuTestComponentProvider) {
                 KhonshuTest(it)
@@ -635,7 +635,7 @@ internal class NavDestinationCodegenTest {
             import com.freeletics.khonshu.navigation.NavEventNavigator
             import com.freeletics.khonshu.navigation.NavigationSetup
             import com.freeletics.khonshu.navigation.ScreenDestination
-            import com.freeletics.khonshu.navigation.`internal`.InternalNavigationApi
+            import com.freeletics.khonshu.navigation.`internal`.InternalNavigationCodegenApi
             import com.freeletics.khonshu.navigation.`internal`.NavigationExecutor
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
@@ -701,7 +701,7 @@ internal class NavDestinationCodegenTest {
 
             @OptIn(InternalCodegenApi::class)
             public object KhonshuTest2ComponentProvider : ComponentProvider<TestRoute, KhonshuTest2Component> {
-              @OptIn(InternalNavigationApi::class)
+              @OptIn(InternalNavigationCodegenApi::class)
               override fun provide(
                 route: TestRoute,
                 executor: NavigationExecutor,
@@ -722,7 +722,7 @@ internal class NavDestinationCodegenTest {
             }
 
             @Composable
-            @OptIn(InternalCodegenApi::class, InternalNavigationApi::class)
+            @OptIn(InternalCodegenApi::class, InternalNavigationCodegenApi::class)
             public fun KhonshuTest2(testRoute: TestRoute) {
               val executor = LocalNavigationExecutor.current
               val provider = LocalActivityComponentProvider.current
@@ -767,7 +767,7 @@ internal class NavDestinationCodegenTest {
             public object KhonshuTest2NavDestinationModule {
               @Provides
               @IntoSet
-              @OptIn(InternalNavigationApi::class)
+              @OptIn(InternalNavigationCodegenApi::class)
               public fun provideNavDestination(): NavDestination =
                   ScreenDestination<TestRoute>(KhonshuTest2ComponentProvider) {
                 KhonshuTest2(it)
@@ -825,7 +825,7 @@ internal class NavDestinationCodegenTest {
             import com.freeletics.khonshu.navigation.NavEventNavigator
             import com.freeletics.khonshu.navigation.NavigationSetup
             import com.freeletics.khonshu.navigation.ScreenDestination
-            import com.freeletics.khonshu.navigation.`internal`.InternalNavigationApi
+            import com.freeletics.khonshu.navigation.`internal`.InternalNavigationCodegenApi
             import com.freeletics.khonshu.navigation.`internal`.NavigationExecutor
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
@@ -877,7 +877,7 @@ internal class NavDestinationCodegenTest {
 
             @OptIn(InternalCodegenApi::class)
             public object KhonshuTestComponentProvider : ComponentProvider<TestRoute, KhonshuTestComponent> {
-              @OptIn(InternalNavigationApi::class)
+              @OptIn(InternalNavigationCodegenApi::class)
               override fun provide(
                 route: TestRoute,
                 executor: NavigationExecutor,
@@ -898,7 +898,7 @@ internal class NavDestinationCodegenTest {
             }
 
             @Composable
-            @OptIn(InternalCodegenApi::class, InternalNavigationApi::class)
+            @OptIn(InternalCodegenApi::class, InternalNavigationCodegenApi::class)
             public fun KhonshuTest(testRoute: TestRoute) {
               val executor = LocalNavigationExecutor.current
               val provider = LocalActivityComponentProvider.current
@@ -930,7 +930,7 @@ internal class NavDestinationCodegenTest {
             public object KhonshuTestNavDestinationModule {
               @Provides
               @IntoSet
-              @OptIn(InternalNavigationApi::class)
+              @OptIn(InternalNavigationCodegenApi::class)
               public fun provideNavDestination(): NavDestination =
                   ScreenDestination<TestRoute>(KhonshuTestComponentProvider) {
                 KhonshuTest(it)
@@ -989,7 +989,7 @@ internal class NavDestinationCodegenTest {
             import com.freeletics.khonshu.navigation.NavEventNavigator
             import com.freeletics.khonshu.navigation.NavigationSetup
             import com.freeletics.khonshu.navigation.ScreenDestination
-            import com.freeletics.khonshu.navigation.`internal`.InternalNavigationApi
+            import com.freeletics.khonshu.navigation.`internal`.InternalNavigationCodegenApi
             import com.freeletics.khonshu.navigation.`internal`.NavigationExecutor
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
@@ -1043,7 +1043,7 @@ internal class NavDestinationCodegenTest {
 
             @OptIn(InternalCodegenApi::class)
             public object KhonshuTestComponentProvider : ComponentProvider<TestRoute, KhonshuTestComponent> {
-              @OptIn(InternalNavigationApi::class)
+              @OptIn(InternalNavigationCodegenApi::class)
               override fun provide(
                 route: TestRoute,
                 executor: NavigationExecutor,
@@ -1064,7 +1064,7 @@ internal class NavDestinationCodegenTest {
             }
 
             @Composable
-            @OptIn(InternalCodegenApi::class, InternalNavigationApi::class)
+            @OptIn(InternalCodegenApi::class, InternalNavigationCodegenApi::class)
             public fun KhonshuTest(testRoute: TestRoute) {
               val executor = LocalNavigationExecutor.current
               val provider = LocalActivityComponentProvider.current
@@ -1100,7 +1100,7 @@ internal class NavDestinationCodegenTest {
             public object KhonshuTestNavDestinationModule {
               @Provides
               @IntoSet
-              @OptIn(InternalNavigationApi::class)
+              @OptIn(InternalNavigationCodegenApi::class)
               public fun provideNavDestination(): NavDestination =
                   ScreenDestination<TestRoute>(KhonshuTestComponentProvider) {
                 KhonshuTest(it)

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/util/External.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/util/External.kt
@@ -43,7 +43,8 @@ internal val localNavigationExecutor =
     MemberName("com.freeletics.khonshu.navigation", "LocalNavigationExecutor")
 internal val deepLinkHandler = ClassName("com.freeletics.khonshu.navigation.deeplinks", "DeepLinkHandler")
 internal val deepLinkPrefix = deepLinkHandler.nestedClass("Prefix")
-internal val internalNavigatorApi = ClassName("com.freeletics.khonshu.navigation.internal", "InternalNavigationApi")
+internal val internalNavigatorApi =
+    ClassName("com.freeletics.khonshu.navigation.internal", "InternalNavigationCodegenApi")
 
 internal val simpleNavHost = ClassName("com.freeletics.khonshu.codegen", "SimpleNavHost")
 internal val simpleNavHostLambda = LambdaTypeName.get(

--- a/codegen/codegen.gradle.kts
+++ b/codegen/codegen.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 freeletics {
     optIn(
-        "com.freeletics.khonshu.navigation.internal.InternalNavigationApi",
+        "com.freeletics.khonshu.navigation.internal.InternalNavigationCodegenApi",
         "com.freeletics.khonshu.codegen.internal.InternalCodegenApi",
     )
 

--- a/navigation-testing/api/android/navigation-testing.api
+++ b/navigation-testing/api/android/navigation-testing.api
@@ -36,7 +36,7 @@ public final class com/freeletics/khonshu/navigation/ResultOwnerTestingKt {
 
 public final class com/freeletics/khonshu/navigation/TestNavEventCollector {
 	public final fun awaitNavigateBack ()V
-	public final fun awaitNavigateBackTo-UamjCxQ (Lkotlin/reflect/KClass;Z)V
+	public final fun awaitNavigateBackTo (Lkotlin/reflect/KClass;Z)V
 	public final fun awaitNavigateTo (Lcom/freeletics/khonshu/navigation/NavRoute;)V
 	public final fun awaitNavigateToRoot (Lcom/freeletics/khonshu/navigation/NavRoot;Z)V
 	public final fun awaitNavigateUp ()V

--- a/navigation-testing/navigation-testing.gradle.kts
+++ b/navigation-testing/navigation-testing.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 freeletics {
-    optIn("com.freeletics.khonshu.navigation.internal.InternalNavigationApi")
+    optIn("com.freeletics.khonshu.navigation.internal.InternalNavigationTestingApi")
 
     multiplatform {
         addJvmTarget()

--- a/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavigatorTurbine.kt
+++ b/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavigatorTurbine.kt
@@ -4,7 +4,6 @@ import android.os.Parcelable
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.test
 import app.cash.turbine.testIn
-import com.freeletics.khonshu.navigation.internal.DestinationId
 import com.freeletics.khonshu.navigation.internal.NavEvent
 import com.google.common.truth.Truth
 import kotlin.reflect.KClass
@@ -257,7 +256,7 @@ internal class DefaultNavigatorTurbine(
         popUpTo: KClass<T>,
         inclusive: Boolean,
     ) {
-        val event = NavEvent.BackToEvent(DestinationId(popUpTo), inclusive)
+        val event = NavEvent.BackToEvent(popUpTo, inclusive)
         Truth.assertThat(turbine.awaitItem()).isEqualTo(event)
     }
 

--- a/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/ResultOwnerTesting.kt
+++ b/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/ResultOwnerTesting.kt
@@ -2,7 +2,6 @@ package com.freeletics.khonshu.navigation
 
 import android.os.Parcelable
 import com.freeletics.khonshu.navigation.PermissionsResultRequest.PermissionResult
-import com.freeletics.khonshu.navigation.internal.DestinationId
 
 /**
  * Send a fake result to collectors of this request. Can be used to test the result handling
@@ -52,5 +51,5 @@ public fun <R : Parcelable> NavigationResultRequest<R>.sendResult(result: R) {
  * [NavEventNavigator.registerForNavigationResult].
  */
 public inline fun <reified R : Parcelable> fakeNavigationResultKey(): NavigationResultRequest.Key<R> {
-    return NavigationResultRequest.Key(DestinationId(NavRoute::class), R::class.qualifiedName!!)
+    return NavigationResultRequest.Key(NavRoute::class, R::class.qualifiedName!!)
 }

--- a/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/TestNavEventCollector.kt
+++ b/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/TestNavEventCollector.kt
@@ -1,7 +1,7 @@
 package com.freeletics.khonshu.navigation
 
-import com.freeletics.khonshu.navigation.internal.DestinationId
 import com.freeletics.khonshu.navigation.internal.NavEvent
+import kotlin.reflect.KClass
 
 public class TestNavEventCollector internal constructor() {
 
@@ -29,11 +29,11 @@ public class TestNavEventCollector internal constructor() {
     }
 
     public inline fun <reified T : NavRoute> awaitNavigateBackTo(inclusive: Boolean) {
-        awaitNavigateBackTo(DestinationId(T::class), inclusive)
+        awaitNavigateBackTo(T::class, inclusive)
     }
 
     @PublishedApi
-    internal fun <T : NavRoute> awaitNavigateBackTo(destination: DestinationId<T>, inclusive: Boolean) {
+    internal fun <T : NavRoute> awaitNavigateBackTo(destination: KClass<T>, inclusive: Boolean) {
         val event = NavEvent.BackToEvent(destination, inclusive)
         _navEvents.add(event)
     }

--- a/navigation-testing/src/commonMain/kotlin/com/freeletics/khonshu/navigation/deeplinks/DeepLinkDefinitions.kt
+++ b/navigation-testing/src/commonMain/kotlin/com/freeletics/khonshu/navigation/deeplinks/DeepLinkDefinitions.kt
@@ -1,6 +1,5 @@
 package com.freeletics.khonshu.navigation.deeplinks
 
-import com.freeletics.khonshu.navigation.internal.InternalNavigationApi
 import com.freeletics.khonshu.navigation.internal.InternalNavigationTestingApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString

--- a/navigation-testing/src/commonMain/kotlin/com/freeletics/khonshu/navigation/deeplinks/DeepLinkDefinitions.kt
+++ b/navigation-testing/src/commonMain/kotlin/com/freeletics/khonshu/navigation/deeplinks/DeepLinkDefinitions.kt
@@ -1,6 +1,7 @@
 package com.freeletics.khonshu.navigation.deeplinks
 
 import com.freeletics.khonshu.navigation.internal.InternalNavigationApi
+import com.freeletics.khonshu.navigation.internal.InternalNavigationTestingApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import net.peanuuutz.tomlkt.Toml
@@ -36,7 +37,7 @@ public value class PatternDefinition(
         DeepLinkHandler.Pattern(value)
     }
 
-    @OptIn(InternalNavigationApi::class)
+    @OptIn(InternalNavigationTestingApi::class)
     public fun replacePlaceholders(replacement: (String) -> String): String {
         return DeepLinkHandler.Pattern(value).replacePlaceholders(replacement)
     }

--- a/navigation/api/android/navigation.api
+++ b/navigation/api/android/navigation.api
@@ -1,3 +1,10 @@
+public final class com/freeletics/khonshu/navigation/ActivityDestination : com/freeletics/khonshu/navigation/NavDestination {
+	public static final field $stable I
+	public synthetic fun <init> (Lkotlin/reflect/KClass;Landroid/content/Intent;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getId-okpw8p8 ()Lkotlin/reflect/KClass;
+	public final fun getIntent ()Landroid/content/Intent;
+}
+
 public abstract interface class com/freeletics/khonshu/navigation/ActivityResultNavigator {
 	public abstract fun navigateForResult (Lcom/freeletics/khonshu/navigation/ActivityResultRequest;)V
 	public abstract fun navigateForResult (Lcom/freeletics/khonshu/navigation/ActivityResultRequest;Ljava/lang/Object;)V
@@ -59,6 +66,7 @@ public class com/freeletics/khonshu/navigation/NavEventNavigator : com/freeletic
 	public fun deliverNavigationResult (Lcom/freeletics/khonshu/navigation/NavigationResultRequest$Key;Landroid/os/Parcelable;)V
 	public final fun navigate (Lkotlin/jvm/functions/Function1;)V
 	public fun navigateBack ()V
+	public fun navigateBackTo (Lkotlin/reflect/KClass;Z)V
 	public fun navigateForResult (Lcom/freeletics/khonshu/navigation/ActivityResultRequest;)V
 	public fun navigateForResult (Lcom/freeletics/khonshu/navigation/ActivityResultRequest;Ljava/lang/Object;)V
 	public fun navigateTo (Lcom/freeletics/khonshu/navigation/ActivityRoute;)V
@@ -114,6 +122,8 @@ public final class com/freeletics/khonshu/navigation/NavigationSetupKt {
 public abstract interface class com/freeletics/khonshu/navigation/Navigator {
 	public static final field Companion Lcom/freeletics/khonshu/navigation/Navigator$Companion;
 	public abstract fun navigateBack ()V
+	public abstract fun navigateBackTo (Lkotlin/reflect/KClass;Z)V
+	public static synthetic fun navigateBackTo$default (Lcom/freeletics/khonshu/navigation/Navigator;Lkotlin/reflect/KClass;ZILjava/lang/Object;)V
 	public abstract fun navigateTo (Lcom/freeletics/khonshu/navigation/ActivityRoute;)V
 	public abstract fun navigateTo (Lcom/freeletics/khonshu/navigation/NavRoute;)V
 	public abstract fun navigateToRoot (Lcom/freeletics/khonshu/navigation/NavRoot;Z)V
@@ -126,9 +136,15 @@ public abstract interface class com/freeletics/khonshu/navigation/Navigator {
 public final class com/freeletics/khonshu/navigation/Navigator$Companion {
 }
 
+public final class com/freeletics/khonshu/navigation/OverlayDestination {
+	public static final field $stable I
+	public static final field $stable I
+	public synthetic fun <init> (Lkotlin/reflect/KClass;Ljava/io/Serializable;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
 public final class com/freeletics/khonshu/navigation/PermissionsResultRequest : com/freeletics/khonshu/navigation/ContractResultOwner {
 	public static final field $stable I
-	public synthetic fun getContract ()Landroidx/activity/result/contract/ActivityResultContract;
+	public synthetic fun getContract$navigation ()Landroidx/activity/result/contract/ActivityResultContract;
 }
 
 public abstract interface class com/freeletics/khonshu/navigation/PermissionsResultRequest$PermissionResult {
@@ -158,6 +174,12 @@ public abstract interface class com/freeletics/khonshu/navigation/ResultNavigato
 public abstract class com/freeletics/khonshu/navigation/ResultOwner {
 	public static final field $stable I
 	public final fun getResults ()Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class com/freeletics/khonshu/navigation/ScreenDestination {
+	public static final field $stable I
+	public static final field $stable I
+	public synthetic fun <init> (Lkotlin/reflect/KClass;Ljava/io/Serializable;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/freeletics/khonshu/navigation/deeplinks/ActivityRouteDeepLinkKt {
@@ -223,5 +245,11 @@ public final class com/freeletics/khonshu/navigation/deeplinks/DeepLinkKt {
 }
 
 public abstract interface annotation class com/freeletics/khonshu/navigation/internal/InternalNavigationApi : java/lang/annotation/Annotation {
+}
+
+public abstract interface annotation class com/freeletics/khonshu/navigation/internal/InternalNavigationCodegenApi : java/lang/annotation/Annotation {
+}
+
+public abstract interface annotation class com/freeletics/khonshu/navigation/internal/InternalNavigationTestingApi : java/lang/annotation/Annotation {
 }
 

--- a/navigation/api/jvm/navigation.api
+++ b/navigation/api/jvm/navigation.api
@@ -56,6 +56,12 @@ public final class com/freeletics/khonshu/navigation/deeplinks/DeepLinkKt {
 public abstract interface annotation class com/freeletics/khonshu/navigation/internal/InternalNavigationApi : java/lang/annotation/Annotation {
 }
 
+public abstract interface annotation class com/freeletics/khonshu/navigation/internal/InternalNavigationCodegenApi : java/lang/annotation/Annotation {
+}
+
+public abstract interface annotation class com/freeletics/khonshu/navigation/internal/InternalNavigationTestingApi : java/lang/annotation/Annotation {
+}
+
 public abstract interface class com/freeletics/khonshu/navigation/internal/Parcelable {
 }
 

--- a/navigation/navigation.gradle.kts
+++ b/navigation/navigation.gradle.kts
@@ -8,7 +8,11 @@ plugins {
 }
 
 freeletics {
-    optIn("com.freeletics.khonshu.navigation.internal.InternalNavigationApi")
+    optIn(
+        "com.freeletics.khonshu.navigation.internal.InternalNavigationApi",
+        "com.freeletics.khonshu.navigation.internal.InternalNavigationCodegenApi",
+        "com.freeletics.khonshu.navigation.internal.InternalNavigationTestingApi",
+    )
 
     multiplatform {
         addJvmTarget()

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/ActivityRoute.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/ActivityRoute.kt
@@ -3,7 +3,6 @@ package com.freeletics.khonshu.navigation
 import android.app.Activity
 import android.content.Intent
 import android.os.Parcelable
-import com.freeletics.khonshu.navigation.internal.InternalNavigationApi
 
 /**
  * Represents the route to an `Activity`. Should be used through []
@@ -51,5 +50,4 @@ public fun <T : InternalActivityRoute> Activity.getRoute(): T? {
     return intent.extras?.getParcelable(EXTRA_ROUTE)
 }
 
-@InternalNavigationApi
-public const val EXTRA_ROUTE: String = "com.freeletics.khonshu.navigation.ROUTE"
+private const val EXTRA_ROUTE: String = "com.freeletics.khonshu.navigation.ROUTE"

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavDestination.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavDestination.kt
@@ -4,7 +4,7 @@ import android.content.Intent
 import androidx.compose.runtime.Composable
 import com.freeletics.khonshu.navigation.internal.ActivityDestinationId
 import com.freeletics.khonshu.navigation.internal.DestinationId
-import com.freeletics.khonshu.navigation.internal.InternalNavigationApi
+import com.freeletics.khonshu.navigation.internal.InternalNavigationCodegenApi
 import java.io.Serializable
 
 /**
@@ -12,16 +12,10 @@ import java.io.Serializable
  */
 public sealed interface NavDestination
 
-@InternalNavigationApi
-public sealed interface ContentDestination<T : BaseRoute> : NavDestination {
-    @InternalNavigationApi
-    public val id: DestinationId<T>
-
-    @InternalNavigationApi
-    public val extra: Serializable?
-
-    @InternalNavigationApi
-    public val content: @Composable (T) -> Unit
+internal sealed class ContentDestination<T : BaseRoute> : NavDestination {
+    internal abstract val id: DestinationId<T>
+    internal abstract val extra: Serializable?
+    internal abstract val content: @Composable (T) -> Unit
 }
 
 /**
@@ -34,19 +28,19 @@ public inline fun <reified T : BaseRoute> ScreenDestination(
     noinline content: @Composable (T) -> Unit,
 ): NavDestination = ScreenDestination(DestinationId(T::class), null, content)
 
-@InternalNavigationApi
+@InternalNavigationCodegenApi
 @Suppress("FunctionName")
 public inline fun <reified T : BaseRoute> ScreenDestination(
     extra: Serializable,
     noinline content: @Composable (T) -> Unit,
 ): NavDestination = ScreenDestination(DestinationId(T::class), extra, content)
 
-@InternalNavigationApi
-public class ScreenDestination<T : BaseRoute>(
+@PublishedApi
+internal class ScreenDestination<T : BaseRoute>(
     override val id: DestinationId<T>,
     override val extra: Serializable?,
     override val content: @Composable (T) -> Unit,
-) : ContentDestination<T>
+) : ContentDestination<T>()
 
 /**
  * Creates a new [NavDestination] that is shown on top a [ScreenDestination], for example a dialog or bottom sheet. The
@@ -58,19 +52,19 @@ public inline fun <reified T : NavRoute> OverlayDestination(
     noinline content: @Composable (T) -> Unit,
 ): NavDestination = OverlayDestination(DestinationId(T::class), null, content)
 
-@InternalNavigationApi
+@InternalNavigationCodegenApi
 @Suppress("FunctionName")
 public inline fun <reified T : NavRoute> OverlayDestination(
     extra: Serializable,
     noinline content: @Composable (T) -> Unit,
 ): NavDestination = OverlayDestination(DestinationId(T::class), extra, content)
 
-@InternalNavigationApi
-public class OverlayDestination<T : NavRoute>(
+@PublishedApi
+internal class OverlayDestination<T : NavRoute>(
     override val id: DestinationId<T>,
     override val extra: Serializable?,
     override val content: @Composable (T) -> Unit,
-) : ContentDestination<T>
+) : ContentDestination<T>()
 
 /**
  * Creates a new [NavDestination] that represents an `Activity`. The class of [T] will be used
@@ -82,10 +76,8 @@ public inline fun <reified T : ActivityRoute> ActivityDestination(
     intent: Intent,
 ): NavDestination = ActivityDestination(ActivityDestinationId(T::class), intent)
 
-@InternalNavigationApi
-public class ActivityDestination(
-    @property:InternalNavigationApi
-    public val id: ActivityDestinationId<out ActivityRoute>,
-    @property:InternalNavigationApi
-    public val intent: Intent,
+@PublishedApi
+internal class ActivityDestination(
+    val id: ActivityDestinationId<out ActivityRoute>,
+    val intent: Intent,
 ) : NavDestination

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavigationSetup.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavigationSetup.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.core.app.ActivityCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
-import com.freeletics.khonshu.navigation.internal.InternalNavigationApi
+import com.freeletics.khonshu.navigation.internal.InternalNavigationCodegenApi
 import com.freeletics.khonshu.navigation.internal.NavEvent
 import com.freeletics.khonshu.navigation.internal.NavigationExecutor
 import kotlinx.coroutines.Dispatchers
@@ -114,7 +114,7 @@ private fun NavigationExecutor.navigateTo(
             navigateBack()
         }
         is NavEvent.BackToEvent -> {
-            navigateBackToInternal(event.popUpTo, event.inclusive)
+            navigateBackTo(event.popUpTo, event.inclusive)
         }
         is NavEvent.ResetToRoot -> {
             resetToRoot(event.root)
@@ -185,13 +185,12 @@ internal suspend fun <R : Parcelable> NavigationExecutor.collectAndHandleNavigat
 @Parcelize
 private object InitialValue : Parcelable
 
-@InternalNavigationApi
+@InternalNavigationCodegenApi
 public val LocalNavigationExecutor: ProvidableCompositionLocal<NavigationExecutor> = staticCompositionLocalOf {
     throw IllegalStateException("Can't use NavEventNavigationHandler outside of a navigator NavHost")
 }
 
-@InternalNavigationApi
-public tailrec fun Context.findActivity(): Activity = when (this) {
+internal tailrec fun Context.findActivity(): Activity = when (this) {
     is Activity -> this
     is ContextWrapper -> baseContext.findActivity()
     else -> error("Could not find activity in Context chain.")

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/deeplinks/AndroidDeepLinkExtensions.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/deeplinks/AndroidDeepLinkExtensions.kt
@@ -7,7 +7,6 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import androidx.core.app.TaskStackBuilder
-import com.freeletics.khonshu.navigation.internal.InternalNavigationApi
 
 /**
  * Creates an [Intent] that can be used to launch this deep link.
@@ -46,8 +45,7 @@ public fun DeepLink.buildPendingIntent(
     return buildTaskStack(context).getPendingIntent(requestCode, flags)!!
 }
 
-@property:InternalNavigationApi
-public const val EXTRA_DEEPLINK_ROUTES: String = "com.freeletics.khonshu.navigation.DEEPLINK_ROUTES"
+internal const val EXTRA_DEEPLINK_ROUTES: String = "com.freeletics.khonshu.navigation.DEEPLINK_ROUTES"
 
 private fun defaultFlag(): Int {
     return if (Build.VERSION.SDK_INT >= 23) {

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/DestinationId.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/DestinationId.kt
@@ -4,14 +4,14 @@ import com.freeletics.khonshu.navigation.ActivityRoute
 import com.freeletics.khonshu.navigation.BaseRoute
 import kotlin.reflect.KClass
 
-@InternalNavigationApi
+@InternalNavigationCodegenApi
 @JvmInline
 public value class DestinationId<T : BaseRoute>(public val route: KClass<T>)
 
-@InternalNavigationApi
+@InternalNavigationCodegenApi
 public val <T : BaseRoute> T.destinationId: DestinationId<out T>
     get() = DestinationId(this::class)
 
-@InternalNavigationApi
+@InternalNavigationCodegenApi
 @JvmInline
 public value class ActivityDestinationId<T : ActivityRoute>(public val route: KClass<T>)

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackNavigationExecutor.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackNavigationExecutor.kt
@@ -8,6 +8,7 @@ import com.freeletics.khonshu.navigation.BaseRoute
 import com.freeletics.khonshu.navigation.NavRoot
 import com.freeletics.khonshu.navigation.NavRoute
 import java.io.Serializable
+import kotlin.reflect.KClass
 import kotlinx.collections.immutable.ImmutableList
 
 internal class MultiStackNavigationExecutor(
@@ -71,11 +72,11 @@ internal class MultiStackNavigationExecutor(
         stack.pop()
     }
 
-    override fun <T : BaseRoute> navigateBackToInternal(
-        popUpTo: DestinationId<T>,
+    override fun <T : BaseRoute> navigateBackTo(
+        popUpTo: KClass<T>,
         inclusive: Boolean,
     ) {
-        stack.popUpTo(popUpTo, inclusive)
+        stack.popUpTo(DestinationId(popUpTo), inclusive)
     }
 
     override fun resetToRoot(root: NavRoot) {

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/NavEvent.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/NavEvent.kt
@@ -8,69 +8,70 @@ import com.freeletics.khonshu.navigation.NavRoot
 import com.freeletics.khonshu.navigation.NavRoute
 import com.freeletics.khonshu.navigation.NavigationResultRequest
 import dev.drewhamilton.poko.Poko
+import kotlin.reflect.KClass
 
-@InternalNavigationApi
+@InternalNavigationTestingApi
 public sealed interface NavEvent {
 
-    @InternalNavigationApi
+    @InternalNavigationTestingApi
     @Poko
     public class NavigateToEvent(
         internal val route: NavRoute,
     ) : NavEvent
 
-    @InternalNavigationApi
+    @InternalNavigationTestingApi
     @Poko
     public class NavigateToRootEvent(
         internal val root: NavRoot,
         internal val restoreRootState: Boolean,
     ) : NavEvent
 
-    @InternalNavigationApi
+    @InternalNavigationTestingApi
     @Poko
     public class NavigateToActivityEvent(
         internal val route: ActivityRoute,
     ) : NavEvent
 
-    @InternalNavigationApi
+    @InternalNavigationTestingApi
     public data object UpEvent : NavEvent
 
-    @InternalNavigationApi
+    @InternalNavigationTestingApi
     public data object BackEvent : NavEvent
 
-    @InternalNavigationApi
+    @InternalNavigationTestingApi
     @Poko
     public class BackToEvent(
-        internal val popUpTo: DestinationId<out BaseRoute>,
+        internal val popUpTo: KClass<out BaseRoute>,
         internal val inclusive: Boolean,
     ) : NavEvent
 
-    @InternalNavigationApi
+    @InternalNavigationTestingApi
     @Poko
     public class ResetToRoot(
         internal val root: NavRoot,
     ) : NavEvent
 
-    @InternalNavigationApi
+    @InternalNavigationTestingApi
     @Poko
     public class ReplaceAll(
         internal val root: NavRoot,
     ) : NavEvent
 
-    @InternalNavigationApi
+    @InternalNavigationTestingApi
     @Poko
     public class ActivityResultEvent<I>(
         internal val request: ContractResultOwner<I, *, *>,
         internal val input: I,
     ) : NavEvent
 
-    @InternalNavigationApi
+    @InternalNavigationTestingApi
     @Poko
     public class DestinationResultEvent<O : Parcelable>(
         internal val key: NavigationResultRequest.Key<O>,
         internal val result: O,
     ) : NavEvent
 
-    @InternalNavigationApi
+    @InternalNavigationTestingApi
     @Poko
     public class MultiNavEvent(
         internal val navEvents: List<NavEvent>,

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/NavEventCollector.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/NavEventCollector.kt
@@ -5,6 +5,7 @@ import com.freeletics.khonshu.navigation.BaseRoute
 import com.freeletics.khonshu.navigation.NavRoot
 import com.freeletics.khonshu.navigation.NavRoute
 import com.freeletics.khonshu.navigation.Navigator
+import kotlin.reflect.KClass
 
 internal class NavEventCollector : Navigator {
 
@@ -36,8 +37,7 @@ internal class NavEventCollector : Navigator {
         _navEvents.add(event)
     }
 
-    @InternalNavigationApi
-    override fun <T : BaseRoute> navigateBackToInternal(popUpTo: DestinationId<T>, inclusive: Boolean) {
+    override fun <T : BaseRoute> navigateBackTo(popUpTo: KClass<T>, inclusive: Boolean) {
         val event = NavEvent.BackToEvent(popUpTo, inclusive)
         _navEvents.add(event)
     }

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/NavigationExecutor.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/NavigationExecutor.kt
@@ -6,14 +6,14 @@ import com.freeletics.khonshu.navigation.Navigator
 import java.io.Serializable
 import kotlin.reflect.KClass
 
-@InternalNavigationApi
+@InternalNavigationCodegenApi
 public interface NavigationExecutor : Navigator {
     public fun <T : BaseRoute> routeFor(destinationId: DestinationId<T>): T
     public fun <T : BaseRoute> savedStateHandleFor(destinationId: DestinationId<T>): SavedStateHandle
     public fun <T : BaseRoute> storeFor(destinationId: DestinationId<T>): Store
     public fun <T : BaseRoute> extra(destinationId: DestinationId<T>): Serializable
 
-    @InternalNavigationApi
+    @InternalNavigationCodegenApi
     public interface Store {
         public fun <T : Any> getOrCreate(key: KClass<T>, factory: () -> T): T
     }

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/NavigationExecutorStore.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/NavigationExecutorStore.kt
@@ -3,8 +3,7 @@ package com.freeletics.khonshu.navigation.internal
 import java.io.Closeable
 import kotlin.reflect.KClass
 
-@InternalNavigationApi
-public class NavigationExecutorStore : NavigationExecutor.Store, Closeable {
+internal class NavigationExecutorStore : NavigationExecutor.Store, Closeable {
     private val storedObjects = mutableMapOf<KClass<*>, Any>()
 
     override fun <T : Any> getOrCreate(key: KClass<T>, factory: () -> T): T {

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/RequestPermissionsContract.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/RequestPermissionsContract.kt
@@ -10,8 +10,7 @@ import androidx.activity.result.contract.ActivityResultContracts
  * as input instead of [Array]. The reason for this is that [Array.equals] does not compare
  * the contents which makes testing [NavEvent.ActivityResultEvent] painful.
  */
-@InternalNavigationApi
-public class RequestPermissionsContract :
+internal class RequestPermissionsContract :
     ActivityResultContract<List<String>, Map<String, Boolean>>() {
 
     private val contract = ActivityResultContracts.RequestMultiplePermissions()

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/NavEventNavigatorTest.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/NavEventNavigatorTest.kt
@@ -3,7 +3,6 @@ package com.freeletics.khonshu.navigation
 import androidx.activity.result.contract.ActivityResultContracts
 import app.cash.turbine.test
 import com.freeletics.khonshu.navigation.Navigator.Companion.navigateBackTo
-import com.freeletics.khonshu.navigation.internal.DestinationId
 import com.freeletics.khonshu.navigation.internal.NavEvent
 import com.freeletics.khonshu.navigation.internal.NavEvent.NavigateToActivityEvent
 import com.freeletics.khonshu.navigation.internal.NavEvent.NavigateToEvent
@@ -119,7 +118,7 @@ internal class NavEventNavigatorTest {
             navigator.navigateBackTo<SimpleRoute>(true)
 
             assertThat(awaitItem()).isEqualTo(
-                NavEvent.BackToEvent(DestinationId(SimpleRoute::class), true),
+                NavEvent.BackToEvent(SimpleRoute::class, true),
             )
 
             cancel()
@@ -223,7 +222,7 @@ internal class NavEventNavigatorTest {
             assertThat(awaitItem()).isEqualTo(
                 NavEvent.MultiNavEvent(
                     listOf(
-                        NavEvent.BackToEvent(DestinationId(SimpleRoute::class), true),
+                        NavEvent.BackToEvent(SimpleRoute::class, true),
                         NavigateToEvent(SimpleRoute(1)),
                         NavEvent.BackEvent,
                     ),

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/NavigationSetupTest.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/NavigationSetupTest.kt
@@ -9,7 +9,6 @@ import androidx.lifecycle.testing.TestLifecycleOwner
 import app.cash.turbine.test
 import com.freeletics.khonshu.navigation.Navigator.Companion.navigateBackTo
 import com.freeletics.khonshu.navigation.PermissionsResultRequest.PermissionResult
-import com.freeletics.khonshu.navigation.internal.DestinationId
 import com.freeletics.khonshu.navigation.internal.NavEvent
 import com.freeletics.khonshu.navigation.test.SimpleActivity
 import com.freeletics.khonshu.navigation.test.SimpleRoot
@@ -162,7 +161,7 @@ internal class NavigationSetupTest {
 
         navigator.navigateBackTo<SimpleRoute>(inclusive = true)
         assertThat(executor.received.awaitItem())
-            .isEqualTo(NavEvent.BackToEvent(DestinationId(SimpleRoute::class), inclusive = true))
+            .isEqualTo(NavEvent.BackToEvent(SimpleRoute::class, inclusive = true))
     }
 
     @Test
@@ -194,7 +193,7 @@ internal class NavigationSetupTest {
         }
 
         assertThat(executor.received.awaitItem())
-            .isEqualTo(NavEvent.BackToEvent(DestinationId(SimpleRoute::class), inclusive = true))
+            .isEqualTo(NavEvent.BackToEvent(SimpleRoute::class, inclusive = true))
 
         assertThat(executor.received.awaitItem())
             .isEqualTo(NavEvent.NavigateToEvent(SimpleRoute(1)))

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackNavigationExecutorTest.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackNavigationExecutorTest.kt
@@ -831,7 +831,7 @@ internal class MultiStackNavigationExecutorTest {
 
         assertThat(executor.visibleEntries.value).hasSize(6)
 
-        executor.navigateBackToInternal(simpleRouteDestination.id, inclusive = false)
+        executor.navigateBackTo(simpleRouteDestination.id.route, inclusive = false)
 
         assertThat(executor.visibleEntries.value)
             .containsExactly(
@@ -864,7 +864,7 @@ internal class MultiStackNavigationExecutorTest {
 
         assertThat(executor.visibleEntries.value).hasSize(6)
 
-        executor.navigateBackToInternal(simpleRouteDestination.id, inclusive = true)
+        executor.navigateBackTo(simpleRouteDestination.id.route, inclusive = true)
 
         assertThat(executor.visibleEntries.value)
             .containsExactly(
@@ -898,7 +898,7 @@ internal class MultiStackNavigationExecutorTest {
 
         assertThat(executor.visibleEntries.value).hasSize(6)
 
-        executor.navigateBackToInternal(simpleRootDestination.id, inclusive = false)
+        executor.navigateBackTo(simpleRootDestination.id.route, inclusive = false)
 
         assertThat(executor.visibleEntries.value)
             .containsExactly(
@@ -936,7 +936,7 @@ internal class MultiStackNavigationExecutorTest {
         assertThat(executor.visibleEntries.value).hasSize(6)
 
         val exception = assertThrows(IllegalStateException::class.java) {
-            executor.navigateBackToInternal(simpleRootDestination.id, inclusive = true)
+            executor.navigateBackTo(simpleRootDestination.id.route, inclusive = true)
         }
         assertThat(exception).hasMessageThat().isEqualTo("Can't pop the root of the back stack")
 
@@ -966,7 +966,7 @@ internal class MultiStackNavigationExecutorTest {
         assertThat(executor.visibleEntries.value).hasSize(3)
 
         val exception = assertThrows(IllegalStateException::class.java) {
-            executor.navigateBackToInternal(otherRouteDestination.id, inclusive = false)
+            executor.navigateBackTo(otherRouteDestination.id.route, inclusive = false)
         }
         assertThat(exception).hasMessageThat()
             .isEqualTo(

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/TestNavigationExecutor.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/TestNavigationExecutor.kt
@@ -10,6 +10,7 @@ import com.freeletics.khonshu.navigation.internal.DestinationId
 import com.freeletics.khonshu.navigation.internal.NavEvent
 import com.freeletics.khonshu.navigation.internal.NavigationExecutor
 import java.io.Serializable
+import kotlin.reflect.KClass
 
 internal class TestNavigationExecutor : NavigationExecutor {
 
@@ -36,8 +37,8 @@ internal class TestNavigationExecutor : NavigationExecutor {
         received.add(NavEvent.BackEvent)
     }
 
-    override fun <T : BaseRoute> navigateBackToInternal(
-        popUpTo: DestinationId<T>,
+    override fun <T : BaseRoute> navigateBackTo(
+        popUpTo: KClass<T>,
         inclusive: Boolean,
     ) {
         received.add(NavEvent.BackToEvent(popUpTo, inclusive))

--- a/navigation/src/commonMain/kotlin/com/freeletics/khonshu/navigation/deeplinks/DeepLinkParser.kt
+++ b/navigation/src/commonMain/kotlin/com/freeletics/khonshu/navigation/deeplinks/DeepLinkParser.kt
@@ -4,6 +4,7 @@ import com.eygraber.uri.Uri
 import com.freeletics.khonshu.navigation.deeplinks.DeepLinkHandler.Pattern
 import com.freeletics.khonshu.navigation.deeplinks.DeepLinkHandler.Prefix
 import com.freeletics.khonshu.navigation.internal.InternalNavigationApi
+import com.freeletics.khonshu.navigation.internal.InternalNavigationTestingApi
 import org.jetbrains.annotations.VisibleForTesting
 
 /**
@@ -63,7 +64,7 @@ private fun Pattern.replacePlaceholders(replacement: String = PARAM_VALUE): Stri
     return value.replace(PARAM_REGEX, "$1$replacement$3")
 }
 
-@InternalNavigationApi
+@InternalNavigationTestingApi
 public fun Pattern.replacePlaceholders(replacement: (String) -> String): String {
     // $1 and $3 will add the optional leading and trailing slashes if needed
     return value.replace(PARAM_REGEX) { "${it.groupValues[1]}${replacement(it.groupValues[2])}${it.groupValues[3]}" }

--- a/navigation/src/commonMain/kotlin/com/freeletics/khonshu/navigation/internal/InternalNavigationApi.kt
+++ b/navigation/src/commonMain/kotlin/com/freeletics/khonshu/navigation/internal/InternalNavigationApi.kt
@@ -7,3 +7,19 @@ package com.freeletics.khonshu.navigation.internal
 @RequiresOptIn
 @Retention(AnnotationRetention.BINARY)
 public annotation class InternalNavigationApi
+
+/**
+ * Code marked with [InternalNavigationCodegenApi] has no guarantees about API stability and can be changed
+ * at any time.
+ */
+@RequiresOptIn
+@Retention(AnnotationRetention.BINARY)
+public annotation class InternalNavigationCodegenApi
+
+/**
+ * Code marked with [InternalNavigationTestingApi] has no guarantees about API stability and can be changed
+ * at any time.
+ */
+@RequiresOptIn
+@Retention(AnnotationRetention.BINARY)
+public annotation class InternalNavigationTestingApi


### PR DESCRIPTION
Previously since we had the AndroidX and experimental navigation modules many things in the main `navigation` module needed to be public so that those modules could access them. Now that we're down to 1 module this isn't needed anymore in many cases. 

For things that still need to public because of the `navigaton-testing` module or usages in codegen I've introduced new separate `@InternalNavigationCodegenApi` and `@InternalNavigationTestingApi` annotations to make it clearer why they are exposed.