### PR TITLE
remove Serializable from ComponentProvider

### DIFF
--- a/codegen/src/androidMain/kotlin/com/freeletics/khonshu/codegen/internal/DestinationComponentLookup.kt
+++ b/codegen/src/androidMain/kotlin/com/freeletics/khonshu/codegen/internal/DestinationComponentLookup.kt
@@ -6,11 +6,10 @@ import com.freeletics.khonshu.navigation.BaseRoute
 import com.freeletics.khonshu.navigation.internal.DestinationId
 import com.freeletics.khonshu.navigation.internal.NavigationExecutor
 import com.freeletics.khonshu.navigation.internal.destinationId
-import java.io.Serializable
 import kotlin.reflect.KClass
 
 @InternalCodegenApi
-public interface ComponentProvider<R : BaseRoute, T> : Serializable {
+public interface ComponentProvider<R : BaseRoute, T> {
     public fun provide(route: R, executor: NavigationExecutor, provider: ActivityComponentProvider): T
 }
 

--- a/navigation/api/android/navigation.api
+++ b/navigation/api/android/navigation.api
@@ -139,7 +139,7 @@ public final class com/freeletics/khonshu/navigation/Navigator$Companion {
 public final class com/freeletics/khonshu/navigation/OverlayDestination {
 	public static final field $stable I
 	public static final field $stable I
-	public synthetic fun <init> (Lkotlin/reflect/KClass;Ljava/io/Serializable;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lkotlin/reflect/KClass;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/freeletics/khonshu/navigation/PermissionsResultRequest : com/freeletics/khonshu/navigation/ContractResultOwner {
@@ -179,7 +179,7 @@ public abstract class com/freeletics/khonshu/navigation/ResultOwner {
 public final class com/freeletics/khonshu/navigation/ScreenDestination {
 	public static final field $stable I
 	public static final field $stable I
-	public synthetic fun <init> (Lkotlin/reflect/KClass;Ljava/io/Serializable;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lkotlin/reflect/KClass;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/freeletics/khonshu/navigation/deeplinks/ActivityRouteDeepLinkKt {

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavDestination.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavDestination.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.Composable
 import com.freeletics.khonshu.navigation.internal.ActivityDestinationId
 import com.freeletics.khonshu.navigation.internal.DestinationId
 import com.freeletics.khonshu.navigation.internal.InternalNavigationCodegenApi
-import java.io.Serializable
 
 /**
  * A destination that can be navigated to. See `NavHost` for how to configure a `NavGraph` with it.
@@ -14,7 +13,7 @@ public sealed interface NavDestination
 
 internal sealed class ContentDestination<T : BaseRoute> : NavDestination {
     internal abstract val id: DestinationId<T>
-    internal abstract val extra: Serializable?
+    internal abstract val extra: Any?
     internal abstract val content: @Composable (T) -> Unit
 }
 
@@ -31,14 +30,14 @@ public inline fun <reified T : BaseRoute> ScreenDestination(
 @InternalNavigationCodegenApi
 @Suppress("FunctionName")
 public inline fun <reified T : BaseRoute> ScreenDestination(
-    extra: Serializable,
+    extra: Any,
     noinline content: @Composable (T) -> Unit,
 ): NavDestination = ScreenDestination(DestinationId(T::class), extra, content)
 
 @PublishedApi
 internal class ScreenDestination<T : BaseRoute>(
     override val id: DestinationId<T>,
-    override val extra: Serializable?,
+    override val extra: Any?,
     override val content: @Composable (T) -> Unit,
 ) : ContentDestination<T>()
 
@@ -55,14 +54,14 @@ public inline fun <reified T : NavRoute> OverlayDestination(
 @InternalNavigationCodegenApi
 @Suppress("FunctionName")
 public inline fun <reified T : NavRoute> OverlayDestination(
-    extra: Serializable,
+    extra: Any,
     noinline content: @Composable (T) -> Unit,
 ): NavDestination = OverlayDestination(DestinationId(T::class), extra, content)
 
 @PublishedApi
 internal class OverlayDestination<T : NavRoute>(
     override val id: DestinationId<T>,
-    override val extra: Serializable?,
+    override val extra: Any?,
     override val content: @Composable (T) -> Unit,
 ) : ContentDestination<T>()
 

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackNavigationExecutor.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackNavigationExecutor.kt
@@ -7,7 +7,6 @@ import com.freeletics.khonshu.navigation.ActivityRoute
 import com.freeletics.khonshu.navigation.BaseRoute
 import com.freeletics.khonshu.navigation.NavRoot
 import com.freeletics.khonshu.navigation.NavRoute
-import java.io.Serializable
 import kotlin.reflect.KClass
 import kotlinx.collections.immutable.ImmutableList
 
@@ -101,7 +100,7 @@ internal class MultiStackNavigationExecutor(
         return storeFor(entry.id)
     }
 
-    override fun <T : BaseRoute> extra(destinationId: DestinationId<T>): Serializable {
+    override fun <T : BaseRoute> extra(destinationId: DestinationId<T>): Any {
         val entry = entryFor(destinationId)
         return entry.destination.extra!!
     }

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/NavigationExecutor.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/NavigationExecutor.kt
@@ -3,7 +3,6 @@ package com.freeletics.khonshu.navigation.internal
 import androidx.lifecycle.SavedStateHandle
 import com.freeletics.khonshu.navigation.BaseRoute
 import com.freeletics.khonshu.navigation.Navigator
-import java.io.Serializable
 import kotlin.reflect.KClass
 
 @InternalNavigationCodegenApi
@@ -11,7 +10,7 @@ public interface NavigationExecutor : Navigator {
     public fun <T : BaseRoute> routeFor(destinationId: DestinationId<T>): T
     public fun <T : BaseRoute> savedStateHandleFor(destinationId: DestinationId<T>): SavedStateHandle
     public fun <T : BaseRoute> storeFor(destinationId: DestinationId<T>): Store
-    public fun <T : BaseRoute> extra(destinationId: DestinationId<T>): Serializable
+    public fun <T : BaseRoute> extra(destinationId: DestinationId<T>): Any
 
     @InternalNavigationCodegenApi
     public interface Store {

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/TestNavigationExecutor.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/TestNavigationExecutor.kt
@@ -9,7 +9,6 @@ import com.freeletics.khonshu.navigation.NavRoute
 import com.freeletics.khonshu.navigation.internal.DestinationId
 import com.freeletics.khonshu.navigation.internal.NavEvent
 import com.freeletics.khonshu.navigation.internal.NavigationExecutor
-import java.io.Serializable
 import kotlin.reflect.KClass
 
 internal class TestNavigationExecutor : NavigationExecutor {
@@ -64,7 +63,7 @@ internal class TestNavigationExecutor : NavigationExecutor {
         throw UnsupportedOperationException()
     }
 
-    override fun <T : BaseRoute> extra(destinationId: DestinationId<T>): Serializable {
+    override fun <T : BaseRoute> extra(destinationId: DestinationId<T>): Any {
         throw UnsupportedOperationException()
     }
 }


### PR DESCRIPTION
Previously this was needed so that we can stuff it into a `Bundle` for AndroidX navigation, now we can just use `Any` on the navigation side.