### PR TITLE
introduce StackSnapshot

### DIFF
--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStack.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStack.kt
@@ -10,7 +10,6 @@ import com.freeletics.khonshu.navigation.ContentDestination
 import com.freeletics.khonshu.navigation.NavRoot
 import com.freeletics.khonshu.navigation.NavRoute
 import java.util.UUID
-import kotlinx.collections.immutable.ImmutableList
 
 internal class MultiStack(
     // Use ArrayList to make sure it is a RandomAccess
@@ -23,15 +22,10 @@ internal class MultiStack(
     private val inputRoot: NavRoot,
 ) {
 
-    private val visibleEntryState: MutableState<ImmutableList<StackEntry<*>>> =
-        mutableStateOf(currentStack.computeVisibleEntries())
-    val visibleEntries: State<ImmutableList<StackEntry<*>>>
-        get() = visibleEntryState
-
-    private val canNavigateBackState: MutableState<Boolean> =
-        mutableStateOf(canNavigateBack())
-    val canNavigateBack: State<Boolean>
-        get() = canNavigateBackState
+    private val snapshotState: MutableState<StackSnapshot> =
+        mutableStateOf(currentStack.snapshot(startStack.id))
+    val snapshot: State<StackSnapshot>
+        get() = snapshotState
 
     val startRoot = startStack.rootEntry.route as NavRoot
 
@@ -67,12 +61,7 @@ internal class MultiStack(
     }
 
     private fun updateVisibleDestinations() {
-        visibleEntryState.value = currentStack.computeVisibleEntries()
-        canNavigateBackState.value = canNavigateBack()
-    }
-
-    private fun canNavigateBack(): Boolean {
-        return currentStack.id != startStack.id || !currentStack.isAtRoot
+        snapshotState.value = currentStack.snapshot(startStack.id)
     }
 
     fun push(route: NavRoute) {

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackNavigationExecutor.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackNavigationExecutor.kt
@@ -8,7 +8,6 @@ import com.freeletics.khonshu.navigation.BaseRoute
 import com.freeletics.khonshu.navigation.NavRoot
 import com.freeletics.khonshu.navigation.NavRoute
 import kotlin.reflect.KClass
-import kotlinx.collections.immutable.ImmutableList
 
 internal class MultiStackNavigationExecutor(
     private val stack: MultiStack,
@@ -17,11 +16,8 @@ internal class MultiStackNavigationExecutor(
     deepLinkRoutes: List<Parcelable>,
 ) : NavigationExecutor {
 
-    val visibleEntries: State<ImmutableList<StackEntry<*>>>
-        get() = stack.visibleEntries
-
-    val canNavigateBack: State<Boolean>
-        get() = stack.canNavigateBack
+    val snapshot: State<StackSnapshot>
+        get() = stack.snapshot
 
     init {
         if (deepLinkRoutes.isNotEmpty()) {

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/Stack.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/Stack.kt
@@ -6,10 +6,7 @@ import com.freeletics.khonshu.navigation.BaseRoute
 import com.freeletics.khonshu.navigation.ContentDestination
 import com.freeletics.khonshu.navigation.NavRoot
 import com.freeletics.khonshu.navigation.NavRoute
-import com.freeletics.khonshu.navigation.ScreenDestination
 import java.util.UUID
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.adapters.ImmutableListAdapter
 
 internal class Stack private constructor(
     initialStack: List<StackEntry<*>>,
@@ -30,26 +27,8 @@ internal class Stack private constructor(
         return stack.findLast { it.destinationId == destinationId } as StackEntry<T>?
     }
 
-    fun computeVisibleEntries(): ImmutableList<StackEntry<*>> {
-        if (stack.size == 1) {
-            return ImmutableListAdapter(listOf(stack.single()))
-        }
-
-        // go through the stack from the top until reaching the first ScreenDestination
-        // then create a List of the elements starting from there
-        val iterator = stack.listIterator(stack.size)
-        while (iterator.hasPrevious()) {
-            if (iterator.previous().destination is ScreenDestination<*>) {
-                val expectedSize = stack.size - iterator.nextIndex()
-                return ArrayList<StackEntry<*>>(expectedSize).apply {
-                    while (iterator.hasNext()) {
-                        add(iterator.next())
-                    }
-                }.let(::ImmutableListAdapter)
-            }
-        }
-
-        error("Stack did not contain a ScreenDestination $stack")
+    fun snapshot(startStackId: DestinationId<*>): StackSnapshot {
+        return StackSnapshot(stack.toList(), startStackId == id)
     }
 
     fun push(route: NavRoute) {

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackSnapshot.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackSnapshot.kt
@@ -30,7 +30,7 @@ public class StackSnapshot internal constructor(
     }
 
     private fun computeFirstVisibleDestination() {
-        entries.indexOfLast {
+        firstVisibleIndex = entries.indexOfLast {
             it.destination !is OverlayDestination<*>
         }
     }

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackSnapshot.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackSnapshot.kt
@@ -1,0 +1,40 @@
+package com.freeletics.khonshu.navigation.internal
+
+import androidx.compose.runtime.Immutable
+import com.freeletics.khonshu.navigation.OverlayDestination
+import dev.drewhamilton.poko.Poko
+
+@Poko
+@Immutable
+@InternalNavigationCodegenApi
+public class StackSnapshot internal constructor(
+    private val entries: List<StackEntry<*>>,
+    private val startStack: Boolean,
+) {
+    private var firstVisibleIndex: Int = -1
+
+    internal val current: StackEntry<*>
+        get() = entries.last()
+
+    internal val canNavigateBack
+        get() = !startStack || entries.last().removable
+
+    internal inline fun forEachVisibleDestination(block: (StackEntry<*>) -> Unit) {
+        if (firstVisibleIndex < 0) {
+            computeFirstVisibleDestination()
+        }
+
+        for (i in firstVisibleIndex..<entries.size) {
+            block(entries[i])
+        }
+    }
+
+    private fun computeFirstVisibleDestination() {
+        for (i in entries.indices.reversed()) {
+            if (entries[i].destination !is OverlayDestination<*>) {
+                firstVisibleIndex = i
+                return
+            }
+        }
+    }
+}

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackSnapshot.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackSnapshot.kt
@@ -30,11 +30,8 @@ public class StackSnapshot internal constructor(
     }
 
     private fun computeFirstVisibleDestination() {
-        for (i in entries.indices.reversed()) {
-            if (entries[i].destination !is OverlayDestination<*>) {
-                firstVisibleIndex = i
-                return
-            }
+        entries.indexOfLast {
+            it.destination !is OverlayDestination<*>
         }
     }
 }

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackNavigationExecutorTest.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackNavigationExecutorTest.kt
@@ -9,12 +9,14 @@ import com.freeletics.khonshu.navigation.test.SimpleActivity
 import com.freeletics.khonshu.navigation.test.SimpleRoot
 import com.freeletics.khonshu.navigation.test.SimpleRoute
 import com.freeletics.khonshu.navigation.test.ThirdRoute
+import com.freeletics.khonshu.navigation.test.canNavigateBack
 import com.freeletics.khonshu.navigation.test.destinations
 import com.freeletics.khonshu.navigation.test.otherRootDestination
 import com.freeletics.khonshu.navigation.test.otherRouteDestination
 import com.freeletics.khonshu.navigation.test.simpleRootDestination
 import com.freeletics.khonshu.navigation.test.simpleRouteDestination
 import com.freeletics.khonshu.navigation.test.thirdRouteDestination
+import com.freeletics.khonshu.navigation.test.visibleEntries
 import com.google.common.truth.Truth.assertThat
 import org.junit.Assert.assertThrows
 import org.junit.Test

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackTest.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackTest.kt
@@ -6,12 +6,14 @@ import com.freeletics.khonshu.navigation.test.OtherRoute
 import com.freeletics.khonshu.navigation.test.SimpleRoot
 import com.freeletics.khonshu.navigation.test.SimpleRoute
 import com.freeletics.khonshu.navigation.test.ThirdRoute
+import com.freeletics.khonshu.navigation.test.canNavigateBack
 import com.freeletics.khonshu.navigation.test.destinations
 import com.freeletics.khonshu.navigation.test.otherRootDestination
 import com.freeletics.khonshu.navigation.test.otherRouteDestination
 import com.freeletics.khonshu.navigation.test.simpleRootDestination
 import com.freeletics.khonshu.navigation.test.simpleRouteDestination
 import com.freeletics.khonshu.navigation.test.thirdRouteDestination
+import com.freeletics.khonshu.navigation.test.visibleEntries
 import com.google.common.truth.Truth.assertThat
 import org.junit.Assert.assertThrows
 import org.junit.Test

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/StackSnapshotTest.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/StackSnapshotTest.kt
@@ -1,0 +1,158 @@
+package com.freeletics.khonshu.navigation.internal
+
+import com.freeletics.khonshu.navigation.test.OtherRoute
+import com.freeletics.khonshu.navigation.test.SimpleRoot
+import com.freeletics.khonshu.navigation.test.SimpleRoute
+import com.freeletics.khonshu.navigation.test.ThirdRoute
+import com.freeletics.khonshu.navigation.test.otherRouteDestination
+import com.freeletics.khonshu.navigation.test.simpleRootDestination
+import com.freeletics.khonshu.navigation.test.simpleRouteDestination
+import com.freeletics.khonshu.navigation.test.thirdRouteDestination
+import com.freeletics.khonshu.navigation.test.visibleEntries
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+internal class StackSnapshotTest {
+
+    @Test
+    fun `forEachVisibleDestination with just a root`() {
+        val stackSnapshot = StackSnapshot(
+            listOf(
+                StackEntry(StackEntry.Id("a"), SimpleRoot(0), simpleRootDestination),
+            ),
+            startStack = false,
+        )
+
+        assertThat(stackSnapshot.visibleEntries()).containsExactly(
+            StackEntry(StackEntry.Id("a"), SimpleRoot(0), simpleRootDestination),
+        )
+        assertThat(stackSnapshot.canNavigateBack).isTrue()
+    }
+
+    @Test
+    fun `forEachVisibleDestination with just a root but is start stack`() {
+        val stackSnapshot = StackSnapshot(
+            listOf(
+                StackEntry(StackEntry.Id("a"), SimpleRoot(0), simpleRootDestination),
+            ),
+            startStack = true,
+        )
+
+        assertThat(stackSnapshot.visibleEntries()).containsExactly(
+            StackEntry(StackEntry.Id("a"), SimpleRoot(0), simpleRootDestination),
+        )
+        assertThat(stackSnapshot.canNavigateBack).isFalse()
+    }
+
+    @Test
+    fun `forEachVisibleDestination with just a route on top of root`() {
+        val stackSnapshot = StackSnapshot(
+            listOf(
+                StackEntry(StackEntry.Id("a"), SimpleRoot(0), simpleRootDestination),
+                StackEntry(StackEntry.Id("b"), SimpleRoute(0), simpleRouteDestination),
+            ),
+            startStack = false,
+        )
+
+        assertThat(stackSnapshot.visibleEntries()).containsExactly(
+            StackEntry(StackEntry.Id("b"), SimpleRoute(0), simpleRouteDestination),
+        )
+        assertThat(stackSnapshot.canNavigateBack).isTrue()
+    }
+
+    @Test
+    fun `forEachVisibleDestination with just multiple routes on top of root`() {
+        val stackSnapshot = StackSnapshot(
+            listOf(
+                StackEntry(StackEntry.Id("a"), SimpleRoot(0), simpleRootDestination),
+                StackEntry(StackEntry.Id("b"), SimpleRoute(0), simpleRouteDestination),
+                StackEntry(StackEntry.Id("c"), SimpleRoute(1), simpleRouteDestination),
+                StackEntry(StackEntry.Id("d"), SimpleRoute(2), simpleRouteDestination),
+            ),
+            startStack = false,
+        )
+
+        assertThat(stackSnapshot.visibleEntries()).containsExactly(
+            StackEntry(StackEntry.Id("d"), SimpleRoute(2), simpleRouteDestination),
+        )
+        assertThat(stackSnapshot.canNavigateBack).isTrue()
+    }
+
+    @Test
+    fun `forEachVisibleDestination with overlay on top of root`() {
+        val stackSnapshot = StackSnapshot(
+            listOf(
+                StackEntry(StackEntry.Id("a"), SimpleRoot(0), simpleRootDestination),
+                StackEntry(StackEntry.Id("b"), OtherRoute(0), otherRouteDestination),
+            ),
+            startStack = false,
+        )
+
+        assertThat(stackSnapshot.visibleEntries()).containsExactly(
+            StackEntry(StackEntry.Id("a"), SimpleRoot(0), simpleRootDestination),
+            StackEntry(StackEntry.Id("b"), OtherRoute(0), otherRouteDestination),
+        )
+        assertThat(stackSnapshot.canNavigateBack).isTrue()
+    }
+
+    @Test
+    fun `forEachVisibleDestination with multiple overlays on top of root`() {
+        val stackSnapshot = StackSnapshot(
+            listOf(
+                StackEntry(StackEntry.Id("a"), SimpleRoot(0), simpleRootDestination),
+                StackEntry(StackEntry.Id("b"), OtherRoute(0), otherRouteDestination),
+                StackEntry(StackEntry.Id("c"), ThirdRoute(0), thirdRouteDestination),
+                StackEntry(StackEntry.Id("d"), OtherRoute(1), otherRouteDestination),
+            ),
+            startStack = false,
+        )
+
+        assertThat(stackSnapshot.visibleEntries()).containsExactly(
+            StackEntry(StackEntry.Id("a"), SimpleRoot(0), simpleRootDestination),
+            StackEntry(StackEntry.Id("b"), OtherRoute(0), otherRouteDestination),
+            StackEntry(StackEntry.Id("c"), ThirdRoute(0), thirdRouteDestination),
+            StackEntry(StackEntry.Id("d"), OtherRoute(1), otherRouteDestination),
+        )
+        assertThat(stackSnapshot.canNavigateBack).isTrue()
+    }
+
+    @Test
+    fun `forEachVisibleDestination with overlay on top of route`() {
+        val stackSnapshot = StackSnapshot(
+            listOf(
+                StackEntry(StackEntry.Id("a"), SimpleRoot(0), simpleRootDestination),
+                StackEntry(StackEntry.Id("b"), SimpleRoute(0), simpleRouteDestination),
+                StackEntry(StackEntry.Id("c"), OtherRoute(0), otherRouteDestination),
+            ),
+            startStack = false,
+        )
+
+        assertThat(stackSnapshot.visibleEntries()).containsExactly(
+            StackEntry(StackEntry.Id("b"), SimpleRoute(0), simpleRouteDestination),
+            StackEntry(StackEntry.Id("c"), OtherRoute(0), otherRouteDestination),
+        )
+        assertThat(stackSnapshot.canNavigateBack).isTrue()
+    }
+
+    @Test
+    fun `forEachVisibleDestination with multiple overlays on top of route`() {
+        val stackSnapshot = StackSnapshot(
+            listOf(
+                StackEntry(StackEntry.Id("a"), SimpleRoot(0), simpleRootDestination),
+                StackEntry(StackEntry.Id("b"), SimpleRoute(0), simpleRouteDestination),
+                StackEntry(StackEntry.Id("c"), OtherRoute(0), otherRouteDestination),
+                StackEntry(StackEntry.Id("d"), ThirdRoute(0), thirdRouteDestination),
+                StackEntry(StackEntry.Id("e"), OtherRoute(1), otherRouteDestination),
+            ),
+            startStack = false,
+        )
+
+        assertThat(stackSnapshot.visibleEntries()).containsExactly(
+            StackEntry(StackEntry.Id("b"), SimpleRoute(0), simpleRouteDestination),
+            StackEntry(StackEntry.Id("c"), OtherRoute(0), otherRouteDestination),
+            StackEntry(StackEntry.Id("d"), ThirdRoute(0), thirdRouteDestination),
+            StackEntry(StackEntry.Id("e"), OtherRoute(1), otherRouteDestination),
+        )
+        assertThat(stackSnapshot.canNavigateBack).isTrue()
+    }
+}

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/StackTest.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/StackTest.kt
@@ -4,6 +4,7 @@ import com.freeletics.khonshu.navigation.test.OtherRoute
 import com.freeletics.khonshu.navigation.test.SimpleRoot
 import com.freeletics.khonshu.navigation.test.SimpleRoute
 import com.freeletics.khonshu.navigation.test.ThirdRoute
+import com.freeletics.khonshu.navigation.test.computeVisibleEntries
 import com.freeletics.khonshu.navigation.test.destinations
 import com.freeletics.khonshu.navigation.test.otherRouteDestination
 import com.freeletics.khonshu.navigation.test.simpleRootDestination

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/VisibleEntries.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/VisibleEntries.kt
@@ -1,0 +1,39 @@
+package com.freeletics.khonshu.navigation.test
+
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import com.freeletics.khonshu.navigation.internal.MultiStack
+import com.freeletics.khonshu.navigation.internal.MultiStackNavigationExecutor
+import com.freeletics.khonshu.navigation.internal.Stack
+import com.freeletics.khonshu.navigation.internal.StackEntry
+import com.freeletics.khonshu.navigation.internal.StackSnapshot
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+
+// TODO rename
+internal fun Stack.computeVisibleEntries(): ImmutableList<StackEntry<*>> {
+    return snapshot(id).visibleEntries()
+}
+
+// TODO remove state wrapper
+internal val MultiStack.visibleEntries: State<ImmutableList<StackEntry<*>>>
+    get() = mutableStateOf(snapshot.value.visibleEntries())
+
+// TODO remove state wrapper
+internal val MultiStack.canNavigateBack: State<Boolean>
+    get() = mutableStateOf(snapshot.value.canNavigateBack)
+
+// TODO remove state wrapper
+internal val MultiStackNavigationExecutor.visibleEntries: MutableState<ImmutableList<StackEntry<*>>>
+    get() = mutableStateOf(snapshot.value.visibleEntries())
+
+// TODO remove state wrapper
+internal val MultiStackNavigationExecutor.canNavigateBack: State<Boolean>
+    get() = mutableStateOf(snapshot.value.canNavigateBack)
+
+internal fun StackSnapshot.visibleEntries(): ImmutableList<StackEntry<*>> {
+    val entries = mutableListOf<StackEntry<*>>()
+    forEachVisibleDestination { entries.add(it) }
+    return entries.toImmutableList()
+}


### PR DESCRIPTION
This introduces `StackSnapshot` which as the name implies represents a snapshot of the current stack. Internally it hold the whole backstack. For now it only exposes the current stack entry, whether it's possible to navigate back and a way to iterate over visible entries. With this it already replaces the 2 states we were exposing from `MultiStack` and the executor. 

What this enables for the future:
- We can expose the current `NavRoot` in the change callback.
- With some additional changes to stack entries, we can use this to look up things like the `BaseRoute`, `Store` or `SavedStateHandle` of an entry. So we wouldn't need to look those up through the executor anymore and we wouldn't run into issues where the backstack was already updated but the composable for a removed destination wasn't removed from the composition yet (which would then crash during the lookup).
- Predictive back will need the stack entry below the current visible entry for the animation, this will make it possible to expose it.