### PR TITLE
expose current NavRoot in destination change callback

### DIFF
--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavHostActivityCodegenTest.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavHostActivityCodegenTest.kt
@@ -68,7 +68,7 @@ internal class NavHostActivityCodegenTest {
               sendAction: (TestAction) -> Unit,
               navHost: SimpleNavHost,
             ) {
-                navHost(TestRoot(), Modifier) {}
+                navHost(TestRoot(), Modifier) { _, _ -> }
             }
         """.trimIndent()
 
@@ -280,7 +280,7 @@ internal class NavHostActivityCodegenTest {
               sendAction: (TestAction) -> Unit,
               navHost: SimpleNavHost,
             ) {
-                navHost(TestRoot(), Modifier) {}
+                navHost(TestRoot(), Modifier) { _, _ -> }
             }
         """.trimIndent()
 
@@ -516,7 +516,7 @@ internal class NavHostActivityCodegenTest {
                 testMap: Map<String, Int>,
                 navHost: SimpleNavHost,
             ) {
-                navHost(TestRoot(), Modifier) {}
+                navHost(TestRoot(), Modifier) { _, _ -> }
             }
         """.trimIndent()
 
@@ -748,7 +748,7 @@ internal class NavHostActivityCodegenTest {
               state: TestState,
               navHost: SimpleNavHost,
             ) {
-                navHost(TestRoot(), Modifier) {}
+                navHost(TestRoot(), Modifier) { _, _ -> }
             }
         """.trimIndent()
 
@@ -952,7 +952,7 @@ internal class NavHostActivityCodegenTest {
               sendAction: (TestAction) -> Unit,
               navHost: SimpleNavHost,
             ) {
-                navHost(TestRoot(), Modifier) {}
+                navHost(TestRoot(), Modifier) { _, _ -> }
             }
         """.trimIndent()
 
@@ -1162,9 +1162,9 @@ internal class NavHostActivityCodegenTest {
             public fun Test(
               state: TestState,
               sendAction: (TestAction) -> Unit,
-              navHost: @Composable (NavRoot, Modifier, ((BaseRoute) -> Unit)?) -> Unit,
+              navHost: @Composable (NavRoot, Modifier, ((NavRoot, BaseRoute) -> Unit)?) -> Unit,
             ) {
-                navHost(TestRoot(), Modifier) {}
+                navHost(TestRoot(), Modifier) { _, _ -> }
             }
         """.trimIndent()
 

--- a/codegen-compiler/codegen-compiler.gradle.kts
+++ b/codegen-compiler/codegen-compiler.gradle.kts
@@ -23,7 +23,6 @@ dependencies {
     implementation(libs.anvil.compiler.utils)
     implementation(libs.kotlinpoet.ksp)
     implementation(projects.codegen)
-    implementation(projects.navigation)
 
     compileOnly(libs.auto.service.annotations)
     ksp(libs.auto.service.compiler)

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/util/External.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/util/External.kt
@@ -32,6 +32,7 @@ internal val localActivityComponentProvider =
 // Navigator
 internal val baseRoute = ClassName("com.freeletics.khonshu.navigation", "BaseRoute")
 internal val baseRouteFqName = FqName(baseRoute.canonicalName)
+internal val navRoot = ClassName("com.freeletics.khonshu.navigation", "NavRoot")
 internal val navEventNavigator = ClassName("com.freeletics.khonshu.navigation", "NavEventNavigator")
 internal val navigationExecutor = ClassName("com.freeletics.khonshu.navigation.internal", "NavigationExecutor")
 internal val navHost = MemberName("com.freeletics.khonshu.navigation", "NavHost")
@@ -49,9 +50,9 @@ internal val internalNavigatorApi =
 internal val simpleNavHost = ClassName("com.freeletics.khonshu.codegen", "SimpleNavHost")
 internal val simpleNavHostLambda = LambdaTypeName.get(
     null,
-    NavRoot::class.asClassName(),
+    navRoot,
     ClassName("androidx.compose.ui", "Modifier"),
-    LambdaTypeName.get(null, baseRoute, returnType = UNIT).copy(nullable = true),
+    LambdaTypeName.get(null, navRoot, baseRoute, returnType = UNIT).copy(nullable = true),
     returnType = UNIT,
 )
 

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/util/External.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/util/External.kt
@@ -1,11 +1,9 @@
 package com.freeletics.khonshu.codegen.util
 
-import com.freeletics.khonshu.navigation.NavRoot
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.UNIT
-import com.squareup.kotlinpoet.asClassName
 import org.jetbrains.kotlin.name.FqName
 
 // Codegen Public API

--- a/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/NavHostActivity.kt
+++ b/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/NavHostActivity.kt
@@ -35,4 +35,4 @@ public annotation class NavHostActivity(
  * - [Modifier]: passed to `NavHost`
  * - an optional destination changed callback
  */
-public typealias SimpleNavHost = @Composable (NavRoot, Modifier, ((BaseRoute) -> Unit)?) -> Unit
+public typealias SimpleNavHost = @Composable (NavRoot, Modifier, ((NavRoot, BaseRoute) -> Unit)?) -> Unit

--- a/navigation/api/android/navigation.api
+++ b/navigation/api/android/navigation.api
@@ -83,7 +83,7 @@ public class com/freeletics/khonshu/navigation/NavEventNavigator : com/freeletic
 }
 
 public final class com/freeletics/khonshu/navigation/NavHostKt {
-	public static final fun NavHost (Lcom/freeletics/khonshu/navigation/NavRoot;Lkotlinx/collections/immutable/ImmutableSet;Landroidx/compose/ui/Modifier;Lkotlinx/collections/immutable/ImmutableSet;Lkotlinx/collections/immutable/ImmutableSet;Lcom/freeletics/khonshu/navigation/NavEventNavigator;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public static final fun NavHost (Lcom/freeletics/khonshu/navigation/NavRoot;Lkotlinx/collections/immutable/ImmutableSet;Landroidx/compose/ui/Modifier;Lkotlinx/collections/immutable/ImmutableSet;Lkotlinx/collections/immutable/ImmutableSet;Lcom/freeletics/khonshu/navigation/NavEventNavigator;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 }
 
 public abstract interface class com/freeletics/khonshu/navigation/NavRoot : com/freeletics/khonshu/navigation/BaseRoute {

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavHost.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavHost.kt
@@ -139,7 +139,7 @@ private fun DestinationChangedCallback(
     if (destinationChangedCallback != null) {
         val root = snapshot.root
         val current = snapshot.current
-        DisposableEffect(root, current) {
+        DisposableEffect(destinationChangedCallback, root, current) {
             destinationChangedCallback(root.route as NavRoot, current.route)
             onDispose {}
         }

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavHost.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavHost.kt
@@ -47,7 +47,7 @@ public fun NavHost(
     deepLinkHandlers: ImmutableSet<DeepLinkHandler> = persistentSetOf(),
     deepLinkPrefixes: ImmutableSet<DeepLinkHandler.Prefix> = persistentSetOf(),
     navEventNavigator: NavEventNavigator? = null,
-    destinationChangedCallback: ((BaseRoute) -> Unit)? = null,
+    destinationChangedCallback: ((NavRoot, BaseRoute) -> Unit)? = null,
 ) {
     val executor = rememberNavigationExecutor(startRoute, destinations, deepLinkHandlers, deepLinkPrefixes)
     val snapshot by executor.snapshot
@@ -134,12 +134,13 @@ private fun SystemBackHandling(snapshot: StackSnapshot, executor: MultiStackNavi
 @Composable
 private fun DestinationChangedCallback(
     snapshot: StackSnapshot,
-    destinationChangedCallback: ((BaseRoute) -> Unit)?,
+    destinationChangedCallback: ((NavRoot, BaseRoute) -> Unit)?,
 ) {
     if (destinationChangedCallback != null) {
+        val root = snapshot.root
         val current = snapshot.current
-        DisposableEffect(current) {
-            destinationChangedCallback(current.route)
+        DisposableEffect(root, current) {
+            destinationChangedCallback(root.route as NavRoot, current.route)
             onDispose {}
         }
     }

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackSnapshot.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackSnapshot.kt
@@ -13,6 +13,9 @@ public class StackSnapshot internal constructor(
 ) {
     private var firstVisibleIndex: Int = -1
 
+    internal val root: StackEntry<*>
+        get() = entries.first()
+
     internal val current: StackEntry<*>
         get() = entries.last()
 

--- a/sample/simple/feature/main/src/main/kotlin/com/freeletics/khonshu/sample/feature/main/MainScreen.kt
+++ b/sample/simple/feature/main/src/main/kotlin/com/freeletics/khonshu/sample/feature/main/MainScreen.kt
@@ -16,5 +16,5 @@ import com.freeletics.khonshu.sample.feature.root.nav.RootRoute
 internal fun MainScreen(
     navHost: SimpleNavHost,
 ) {
-    navHost(RootRoute, Modifier.fillMaxSize()) {}
+    navHost(RootRoute, Modifier.fillMaxSize()) { _, _ -> }
 }


### PR DESCRIPTION
Primary use case for this is updating the selected state of something like bottom tabs or a navigation rail. When switching between destinations that are within a stack. 