### PR TITLE
introduce StackEntryFactory

### DIFF
--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackNavigationExecutorBuilder.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackNavigationExecutorBuilder.kt
@@ -39,19 +39,21 @@ internal fun rememberNavigationExecutor(
 
     val stack = remember(destinations, viewModel, startRoot) {
         val contentDestinations = destinations.filterIsInstance<ContentDestination<*>>()
-        val navState = viewModel.globalSavedStateHandle.get<Bundle>(SAVED_STATE_STACK)
+        val factory = StackEntryFactory(contentDestinations)
 
+        val navState = viewModel.globalSavedStateHandle.get<Bundle>(SAVED_STATE_STACK)
         if (navState == null) {
             MultiStack.createWith(
                 root = startRoot,
-                destinations = contentDestinations,
+                createEntry = factory::create,
                 onStackEntryRemoved = viewModel::removeEntry,
             )
         } else {
             MultiStack.fromState(
                 root = startRoot,
                 bundle = navState,
-                destinations = contentDestinations,
+                createEntry = factory::create,
+                createRestoredEntry = factory::create,
                 onStackEntryRemoved = viewModel::removeEntry,
             )
         }

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackEntryFactory.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackEntryFactory.kt
@@ -1,0 +1,20 @@
+package com.freeletics.khonshu.navigation.internal
+
+import com.freeletics.khonshu.navigation.BaseRoute
+import com.freeletics.khonshu.navigation.ContentDestination
+import java.util.UUID
+
+internal class StackEntryFactory(
+    private val destinations: List<ContentDestination<*>>,
+    private val idGenerator: () -> StackEntry.Id = { StackEntry.Id(UUID.randomUUID().toString()) },
+) {
+    fun <T : BaseRoute> create(route: T): StackEntry<T> {
+        return create(route, idGenerator())
+    }
+
+    fun <T : BaseRoute> create(route: T, id: StackEntry.Id): StackEntry<T> {
+        @Suppress("UNCHECKED_CAST")
+        val destination = destinations.find { it.id == route.destinationId } as ContentDestination<T>
+        return StackEntry(id, route, destination)
+    }
+}

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackNavigationExecutorTest.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackNavigationExecutorTest.kt
@@ -24,7 +24,7 @@ import org.junit.Test
 internal class MultiStackNavigationExecutorTest {
 
     private var nextId = 100
-    private val idGenerator = { (nextId++).toString() }
+    private val idGenerator = { StackEntry.Id((nextId++).toString()) }
 
     private val removed = mutableListOf<StackEntry.Id>()
     private val removedCallback: (StackEntry.Id) -> Unit = { removed.add(it) }
@@ -34,6 +34,8 @@ internal class MultiStackNavigationExecutorTest {
         started.add(route)
     }
 
+    private val factory = StackEntryFactory(destinations, idGenerator)
+
     private val viewModel = StoreViewModel(SavedStateHandle())
 
     private fun underTest(
@@ -42,7 +44,7 @@ internal class MultiStackNavigationExecutorTest {
         return MultiStackNavigationExecutor(
             activityStarter = starter,
             viewModel = viewModel,
-            stack = MultiStack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator),
+            stack = MultiStack.createWith(SimpleRoot(1), factory::create, removedCallback),
             deepLinkRoutes = deepLinkRoutes,
         )
     }

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackTest.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackTest.kt
@@ -21,15 +21,17 @@ import org.junit.Test
 internal class MultiStackTest {
 
     private var nextId = 100
-    private val idGenerator = { (nextId++).toString() }
+    private val idGenerator = { StackEntry.Id((nextId++).toString()) }
 
     private val removed = mutableListOf<StackEntry.Id>()
     private val removedCallback: (StackEntry.Id) -> Unit = { removed.add(it) }
 
     private val defaultStack get() = stack(SimpleRoot(1))
 
+    private val factory = StackEntryFactory(destinations, idGenerator)
+
     private fun stack(root: NavRoot): Stack {
-        return Stack.createWith(root, destinations, removedCallback, idGenerator)
+        return Stack.createWith(root, factory::create, removedCallback)
     }
 
     private fun underTest(
@@ -39,8 +41,7 @@ internal class MultiStackTest {
             allStacks = arrayListOf(startStack),
             startStack = startStack,
             currentStack = startStack,
-            destinations = destinations,
-            idGenerator = idGenerator,
+            createEntry = factory::create,
             onStackEntryRemoved = removedCallback,
             inputRoot = startStack.rootEntry.route as NavRoot,
         )

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/StackTest.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/StackTest.kt
@@ -17,21 +17,23 @@ import org.junit.Test
 internal class StackTest {
 
     private var nextId = 100
-    private val idGenerator = { (nextId++).toString() }
+    private val idGenerator = { StackEntry.Id((nextId++).toString()) }
 
     private val removed = mutableListOf<StackEntry.Id>()
     private val removedCallback: (StackEntry.Id) -> Unit = { removed.add(it) }
 
+    private val factory = StackEntryFactory(destinations, idGenerator)
+
     @Test
     fun id() {
-        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
 
         assertThat(stack.id).isEqualTo(simpleRootDestination.id)
     }
 
     @Test
     fun rootEntry() {
-        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
 
         assertThat(stack.rootEntry)
             .isEqualTo(StackEntry(StackEntry.Id("100"), SimpleRoot(1), simpleRootDestination))
@@ -39,21 +41,21 @@ internal class StackTest {
 
     @Test
     fun `isAtRoot after construction`() {
-        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
 
         assertThat(stack.isAtRoot).isTrue()
     }
 
     @Test
     fun `removed after construction`() {
-        Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+        Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
 
         assertThat(removed).isEmpty()
     }
 
     @Test
     fun `computeVisibleEntries after construction`() {
-        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
 
         assertThat(stack.computeVisibleEntries())
             .containsExactly(
@@ -64,7 +66,7 @@ internal class StackTest {
 
     @Test
     fun `push with a screen destination`() {
-        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
         stack.push(SimpleRoute(2))
 
         assertThat(stack.computeVisibleEntries())
@@ -78,7 +80,7 @@ internal class StackTest {
 
     @Test
     fun `push with a dialog destination`() {
-        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
         stack.push(OtherRoute(3))
 
         assertThat(stack.computeVisibleEntries())
@@ -93,7 +95,7 @@ internal class StackTest {
 
     @Test
     fun `push with a bottom sheet destination`() {
-        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
         stack.push(ThirdRoute(4))
 
         assertThat(stack.computeVisibleEntries())
@@ -108,7 +110,7 @@ internal class StackTest {
 
     @Test
     fun `computeVisibleEntries with multiple screens, dialogs and bottom sheets`() {
-        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
         stack.push(SimpleRoute(2))
         stack.push(SimpleRoute(3))
         stack.push(SimpleRoute(4))
@@ -135,7 +137,7 @@ internal class StackTest {
 
     @Test
     fun `computeVisibleEntries with multiple screens, dialogs and bottom sheets 2`() {
-        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
         stack.push(SimpleRoute(2))
         stack.push(SimpleRoute(3))
         stack.push(SimpleRoute(4))
@@ -160,7 +162,7 @@ internal class StackTest {
 
     @Test
     fun `pop from the root`() {
-        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
         val exception = assertThrows(IllegalStateException::class.java) {
             stack.pop()
         }
@@ -171,7 +173,7 @@ internal class StackTest {
 
     @Test
     fun `pop from a screen`() {
-        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
         stack.push(SimpleRoute(2))
         assertThat(stack.computeVisibleEntries())
             .containsExactly(
@@ -192,7 +194,7 @@ internal class StackTest {
 
     @Test
     fun `pop from a screen and then opening that screen again`() {
-        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
         stack.push(SimpleRoute(2))
 
         assertThat(stack.computeVisibleEntries())
@@ -215,7 +217,7 @@ internal class StackTest {
 
     @Test
     fun `popUpTo with inclusive false`() {
-        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
         stack.push(SimpleRoute(2))
         stack.push(SimpleRoute(3))
         stack.push(SimpleRoute(4))
@@ -247,7 +249,7 @@ internal class StackTest {
 
     @Test
     fun `popUpTo with inclusive true`() {
-        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
         stack.push(SimpleRoute(2))
         stack.push(SimpleRoute(3))
         stack.push(SimpleRoute(4))
@@ -280,7 +282,7 @@ internal class StackTest {
 
     @Test
     fun `popUpTo with root and inclusive false`() {
-        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
         stack.push(SimpleRoute(2))
         stack.push(SimpleRoute(3))
         stack.push(SimpleRoute(4))
@@ -316,7 +318,7 @@ internal class StackTest {
 
     @Test
     fun `popUpTo with root and inclusive true`() {
-        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
         stack.push(SimpleRoute(2))
         stack.push(SimpleRoute(3))
         stack.push(SimpleRoute(4))
@@ -349,7 +351,7 @@ internal class StackTest {
 
     @Test
     fun `popUpTo with route not present on the stack`() {
-        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
         stack.push(SimpleRoute(2))
         stack.push(SimpleRoute(3))
         stack.push(SimpleRoute(4))
@@ -380,7 +382,7 @@ internal class StackTest {
 
     @Test
     fun `clear removes everything except for the root`() {
-        val stack = Stack.createWith(SimpleRoot(1), destinations, removedCallback, idGenerator)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
         stack.push(SimpleRoute(2))
         stack.push(SimpleRoute(3))
         stack.push(SimpleRoute(4))


### PR DESCRIPTION
Preparation for adding `SavedStateHandle` and `Store` directly to `StackEntry` so that they can be accessed from the `StackSnapshot`. The reasons for having the factory are
- already in the existing code we don't need to pass down `destinations` and `idGenerator` anymore
- we won't need to pass down the view model that holds stores to add the mentioned functionality
- in tests we can do something more reproducible for store and handle