### PR TITLE
bring back legacy state machine module

### DIFF
--- a/state-machine-legacy/api/state-machine-legacy.api
+++ b/state-machine-legacy/api/state-machine-legacy.api
@@ -1,0 +1,5 @@
+public abstract interface class com/freeletics/mad/statemachine/StateMachine : com/freeletics/khonshu/statemachine/StateMachine {
+	public abstract fun dispatch (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getState ()Lkotlinx/coroutines/flow/Flow;
+}
+

--- a/state-machine-legacy/gradle.properties
+++ b/state-machine-legacy/gradle.properties
@@ -1,0 +1,4 @@
+GROUP=com.freeletics.mad
+POM_ARTIFACT_ID=state-machine
+POM_NAME=MAD StateMachine
+POM_DESCRIPTION=MAD StateMachine

--- a/state-machine-legacy/src/commonMain/kotlin/com/freeletics/mad/statemachine/StateMachine.kt
+++ b/state-machine-legacy/src/commonMain/kotlin/com/freeletics/mad/statemachine/StateMachine.kt
@@ -1,0 +1,22 @@
+package com.freeletics.mad.statemachine
+
+import com.freeletics.khonshu.statemachine.StateMachine as KhonshuStateMachine
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * A state machine that emits [State] objects through the [Flow] returned by [state]. The state
+ * can be mutated through actions passed to [dispatch].
+ */
+public interface StateMachine<State : Any, Action : Any> : KhonshuStateMachine<State, Action> {
+
+    /**
+     * A [Flow] that emits the current state as well as all changes to the state.
+     */
+    public override val state: Flow<State>
+
+    /**
+     * An an [Action] to the [KhonshuStateMachine]. The implementation can mutate the [State] based on
+     * these actions or trigger side effects.
+     */
+    public override suspend fun dispatch(action: Action)
+}

--- a/state-machine-legacy/state-machine-legacy.gradle.kts
+++ b/state-machine-legacy/state-machine-legacy.gradle.kts
@@ -4,8 +4,9 @@ plugins {
 }
 
 freeletics {
-    explicitApi()
-    addCommonTargets()
+    multiplatform {
+        addCommonTargets()
+    }
 }
 
 dependencies {

--- a/state-machine-legacy/state-machine-legacy.gradle.kts
+++ b/state-machine-legacy/state-machine-legacy.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    alias(libs.plugins.fgp.multiplatform)
+    alias(libs.plugins.fgp.publish)
+}
+
+freeletics {
+    explicitApi()
+    addCommonTargets()
+}
+
+dependencies {
+    "commonMainApi"(libs.coroutines.core)
+    "commonMainApi"(projects.stateMachine)
+}


### PR DESCRIPTION
Just so that we have a version with the wasmJs target so that FlowRedux can also add the target. (wasmJs is automatically included in `addCommonTargets`).

Reverts #477