### PR TITLE
replace onEntryRemoved callback with closing entries

### DIFF
--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStack.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStack.kt
@@ -16,7 +16,6 @@ internal class MultiStack(
     private var startStack: Stack,
     private var currentStack: Stack,
     private val createEntry: (BaseRoute) -> StackEntry<*>,
-    private val onStackEntryRemoved: (StackEntry.Id) -> Unit,
     private val inputRoot: NavRoot,
 ) {
 
@@ -47,7 +46,7 @@ internal class MultiStack(
     }
 
     private fun createBackStack(root: NavRoot): Stack {
-        val newStack = Stack.createWith(root, createEntry, onStackEntryRemoved)
+        val newStack = Stack.createWith(root, createEntry)
         allStacks.add(newStack)
         return newStack
     }
@@ -55,7 +54,7 @@ internal class MultiStack(
     private fun removeBackStack(stack: Stack) {
         stack.clear()
         allStacks.remove(stack)
-        onStackEntryRemoved(stack.rootEntry.id)
+        stack.rootEntry.close()
     }
 
     private fun updateVisibleDestinations() {
@@ -163,15 +162,13 @@ internal class MultiStack(
         fun createWith(
             root: NavRoot,
             createEntry: (BaseRoute) -> StackEntry<*>,
-            onStackEntryRemoved: (StackEntry.Id) -> Unit,
         ): MultiStack {
-            val startStack = Stack.createWith(root, createEntry, onStackEntryRemoved)
+            val startStack = Stack.createWith(root, createEntry)
             return MultiStack(
                 allStacks = arrayListOf(startStack),
                 startStack = startStack,
                 currentStack = startStack,
                 createEntry = createEntry,
-                onStackEntryRemoved = onStackEntryRemoved,
                 inputRoot = root,
             )
         }
@@ -182,7 +179,6 @@ internal class MultiStack(
             bundle: Bundle,
             createEntry: (BaseRoute) -> StackEntry<*>,
             createRestoredEntry: (BaseRoute, StackEntry.Id, SavedStateHandle) -> StackEntry<*>,
-            onStackEntryRemoved: (StackEntry.Id) -> Unit,
         ): MultiStack {
             val inputRoot = bundle.getParcelable<NavRoot>(SAVED_INPUT_ROOT)!!
 
@@ -190,7 +186,6 @@ internal class MultiStack(
                 return createWith(
                     root = root,
                     createEntry = createEntry,
-                    onStackEntryRemoved = onStackEntryRemoved,
                 )
             }
 
@@ -199,7 +194,7 @@ internal class MultiStack(
             val startDestinationId = bundle.getSerializable(SAVED_STATE_START_STACK)!!
 
             val allStacks = allStackBundles.mapTo(ArrayList(allStackBundles.size)) {
-                Stack.fromState(it, createEntry, createRestoredEntry, onStackEntryRemoved)
+                Stack.fromState(it, createEntry, createRestoredEntry)
             }
             val startStack = allStacks.first { it.id.route.java == startDestinationId }
             val currentStack = allStacks.first { it.id.route.java == currentStackId }
@@ -209,7 +204,6 @@ internal class MultiStack(
                 startStack = startStack,
                 currentStack = currentStack,
                 createEntry = createEntry,
-                onStackEntryRemoved = onStackEntryRemoved,
                 inputRoot = inputRoot,
             )
         }

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackNavigationExecutor.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackNavigationExecutor.kt
@@ -11,8 +11,8 @@ import kotlin.reflect.KClass
 
 internal class MultiStackNavigationExecutor(
     private val stack: MultiStack,
-    private val viewModel: StackEntryStoreViewModel,
     private val activityStarter: (ActivityRoute) -> Unit,
+    viewModel: StackEntryStoreViewModel,
     deepLinkRoutes: List<Parcelable>,
 ) : NavigationExecutor {
 

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackNavigationExecutorBuilder.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackNavigationExecutorBuilder.kt
@@ -46,7 +46,6 @@ internal fun rememberNavigationExecutor(
             MultiStack.createWith(
                 root = startRoot,
                 createEntry = factory::create,
-                onStackEntryRemoved = viewModel::removeEntry,
             )
         } else {
             MultiStack.fromState(
@@ -54,7 +53,6 @@ internal fun rememberNavigationExecutor(
                 bundle = navState,
                 createEntry = factory::create,
                 createRestoredEntry = factory::create,
-                onStackEntryRemoved = viewModel::removeEntry,
             )
         }
     }
@@ -72,8 +70,8 @@ internal fun rememberNavigationExecutor(
     return remember(stack, viewModel, starter, deepLinkRoutes) {
         MultiStackNavigationExecutor(
             stack = stack,
-            viewModel = viewModel,
             activityStarter = starter::start,
+            viewModel = viewModel,
             deepLinkRoutes = deepLinkRoutes,
         )
     }

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/Stack.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/Stack.kt
@@ -20,10 +20,6 @@ internal class Stack private constructor(
     val rootEntry: StackEntry<*> get() = stack.first()
     val isAtRoot: Boolean get() = !stack.last().removable
 
-    fun findEntry(id: StackEntry.Id): StackEntry<*>? {
-        return stack.findLast { it.id == id }
-    }
-
     @Suppress("UNCHECKED_CAST")
     fun <T : BaseRoute> entryFor(destinationId: DestinationId<T>): StackEntry<T>? {
         return stack.findLast { it.destinationId == destinationId } as StackEntry<T>?

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/Stack.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/Stack.kt
@@ -11,7 +11,6 @@ import com.freeletics.khonshu.navigation.NavRoute
 internal class Stack private constructor(
     initialStack: List<StackEntry<*>>,
     private val createEntry: (BaseRoute) -> StackEntry<*>,
-    private val onStackEntryRemoved: (StackEntry.Id) -> Unit,
 ) {
     private val stack = ArrayDeque<StackEntry<*>>(20).also {
         it.addAll(initialStack)
@@ -20,6 +19,10 @@ internal class Stack private constructor(
     val id: DestinationId<*> get() = rootEntry.destinationId
     val rootEntry: StackEntry<*> get() = stack.first()
     val isAtRoot: Boolean get() = !stack.last().removable
+
+    fun findEntry(id: StackEntry.Id): StackEntry<*>? {
+        return stack.findLast { it.id == id }
+    }
 
     @Suppress("UNCHECKED_CAST")
     fun <T : BaseRoute> entryFor(destinationId: DestinationId<T>): StackEntry<T>? {
@@ -41,7 +44,7 @@ internal class Stack private constructor(
 
     private fun popInternal() {
         val entry = stack.removeLast()
-        onStackEntryRemoved(entry.id)
+        entry.close()
     }
 
     fun popUpTo(destinationId: DestinationId<*>, isInclusive: Boolean) {
@@ -83,10 +86,9 @@ internal class Stack private constructor(
         fun createWith(
             root: NavRoot,
             createEntry: (BaseRoute) -> StackEntry<*>,
-            onStackEntryRemoved: (StackEntry.Id) -> Unit,
         ): Stack {
             val rootEntry = createEntry(root)
-            return Stack(listOf(rootEntry), createEntry, onStackEntryRemoved)
+            return Stack(listOf(rootEntry), createEntry)
         }
 
         @SuppressLint("RestrictedApi")
@@ -94,7 +96,6 @@ internal class Stack private constructor(
             bundle: Bundle,
             createEntry: (BaseRoute) -> StackEntry<*>,
             createRestoredEntry: (BaseRoute, StackEntry.Id, SavedStateHandle) -> StackEntry<*>,
-            onStackEntryRemoved: (StackEntry.Id) -> Unit,
         ): Stack {
             val ids = bundle.getStringArrayList(SAVED_STATE_IDS)!!
 
@@ -110,7 +111,7 @@ internal class Stack private constructor(
                     SavedStateHandle.createHandle(states[index], null),
                 )
             }
-            return Stack(entries, createEntry, onStackEntryRemoved)
+            return Stack(entries, createEntry)
         }
 
         private const val SAVED_STATE_IDS = "com.freeletics.khonshu.navigation.stack.ids"

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackEntry.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackEntry.kt
@@ -28,6 +28,10 @@ internal class StackEntry<T : BaseRoute>(
             is NavRoot -> false
         }
 
+    fun close() {
+        store.close()
+    }
+
     @JvmInline
     value class Id(val value: String)
 }

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackEntryStore.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackEntryStore.kt
@@ -5,7 +5,7 @@ import kotlin.reflect.KClass
 
 @InternalNavigationCodegenApi
 public class StackEntryStore(
-    private val onClose: () -> Unit
+    private val onClose: () -> Unit,
 ) : Closeable {
     private val storedObjects = mutableMapOf<KClass<*>, Any>()
 

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackEntryStore.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackEntryStore.kt
@@ -4,7 +4,9 @@ import java.io.Closeable
 import kotlin.reflect.KClass
 
 @InternalNavigationCodegenApi
-public class StackEntryStore : Closeable {
+public class StackEntryStore(
+    private val onClose: () -> Unit
+) : Closeable {
     private val storedObjects = mutableMapOf<KClass<*>, Any>()
 
     public fun <T : Any> getOrCreate(key: KClass<T>, factory: () -> T): T {
@@ -18,6 +20,7 @@ public class StackEntryStore : Closeable {
     }
 
     override fun close() {
+        onClose()
         storedObjects.forEach { (_, storedObject) ->
             if (storedObject is Closeable) {
                 storedObject.close()

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackEntryStoreViewModel.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackEntryStoreViewModel.kt
@@ -9,12 +9,13 @@ internal class StackEntryStoreViewModel(
     private val stores = mutableMapOf<StackEntry.Id, StackEntryStore>()
 
     fun provideStore(id: StackEntry.Id): StackEntryStore {
-        return stores.getOrPut(id) { StackEntryStore() }
+        return stores.getOrPut(id) {
+            StackEntryStore { stores.remove(id) }
+        }
     }
 
-    fun removeEntry(id: StackEntry.Id) {
-        val store = stores.remove(id)
-        store?.close()
+    private fun removeStore(id: StackEntry.Id) {
+        stores.remove(id)
     }
 
     public override fun onCleared() {

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackNavigationExecutorTest.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackNavigationExecutorTest.kt
@@ -20,18 +20,13 @@ import org.junit.Test
 
 internal class MultiStackNavigationExecutorTest {
 
-    private var nextId = 100
-    private val idGenerator = { StackEntry.Id((nextId++).toString()) }
-
-    private val removed = mutableListOf<StackEntry.Id>()
-    private val removedCallback: (StackEntry.Id) -> Unit = { removed.add(it) }
-
     private val started = mutableListOf<ActivityRoute>()
     private val starter: (ActivityRoute) -> Unit = { route ->
         started.add(route)
     }
 
     private val factory = TestStackEntryFactory()
+    private val removed get() = factory.closedEntries
 
     private val viewModel = StackEntryStoreViewModel(SavedStateHandle())
 
@@ -39,9 +34,9 @@ internal class MultiStackNavigationExecutorTest {
         deepLinkRoutes: List<Parcelable> = emptyList(),
     ): MultiStackNavigationExecutor {
         return MultiStackNavigationExecutor(
+            stack = MultiStack.createWith(SimpleRoot(1), factory::create),
             activityStarter = starter,
             viewModel = viewModel,
-            stack = MultiStack.createWith(SimpleRoot(1), factory::create, removedCallback),
             deepLinkRoutes = deepLinkRoutes,
         )
     }

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackTest.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackTest.kt
@@ -17,18 +17,13 @@ import org.junit.Test
 
 internal class MultiStackTest {
 
-    private var nextId = 100
-    private val idGenerator = { StackEntry.Id((nextId++).toString()) }
-
-    private val removed = mutableListOf<StackEntry.Id>()
-    private val removedCallback: (StackEntry.Id) -> Unit = { removed.add(it) }
-
     private val defaultStack get() = stack(SimpleRoot(1))
 
     private val factory = TestStackEntryFactory()
+    private val removed get() = factory.closedEntries
 
     private fun stack(root: NavRoot): Stack {
-        return Stack.createWith(root, factory::create, removedCallback)
+        return Stack.createWith(root, factory::create)
     }
 
     private fun underTest(
@@ -39,7 +34,6 @@ internal class MultiStackTest {
             startStack = startStack,
             currentStack = startStack,
             createEntry = factory::create,
-            onStackEntryRemoved = removedCallback,
             inputRoot = startStack.rootEntry.route as NavRoot,
         )
     }

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/NavgationExecutorStoreTest.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/NavgationExecutorStoreTest.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 
 internal class NavgationExecutorStoreTest {
 
-    private val underTest = StackEntryStore()
+    private val underTest = StackEntryStore {}
 
     @Test
     fun `store returns value from factory`() {

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/StackEntryStoreViewModelTest.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/StackEntryStoreViewModelTest.kt
@@ -25,36 +25,38 @@ internal class StackEntryStoreViewModelTest {
     }
 
     @Test
-    fun `StoreViewModel returns different store for same id after removeEntry`() {
+    fun `StoreViewModel returns different store for same id after store was closed`() {
         val valueA = underTest.provideStore(StackEntry.Id("1"))
-        underTest.removeEntry(StackEntry.Id("1"))
+        valueA.close()
         val valueB = underTest.provideStore(StackEntry.Id("1"))
         assertThat(valueA).isNotSameInstanceAs(valueB)
     }
 
     @Test
-    fun `StoreViewModel closes store after removeEntry`() {
+    fun `StoreViewModel closes store after store was closed`() {
         val closeable = FakeCloseable()
         val valueA = underTest.provideStore(StackEntry.Id("1"))
         valueA.getOrCreate(FakeCloseable::class) { closeable }
-        underTest.removeEntry(StackEntry.Id("1"))
+        valueA.close()
         assertThat(closeable.closed).isTrue()
     }
 
     @Test
-    fun `StoreViewModel returns same store for same id after removeEntry for different id`() {
+    fun `StoreViewModel returns same store for same id after store was closed for same id`() {
         val valueA = underTest.provideStore(StackEntry.Id("1"))
-        underTest.removeEntry(StackEntry.Id("2"))
-        val valueB = underTest.provideStore(StackEntry.Id("1"))
-        assertThat(valueA).isSameInstanceAs(valueB)
+        val valueB = underTest.provideStore(StackEntry.Id("2"))
+        valueB.close()
+        val valueC = underTest.provideStore(StackEntry.Id("1"))
+        assertThat(valueA).isSameInstanceAs(valueC)
     }
 
     @Test
-    fun `StoreViewModel does not close store after removeEntry for different id`() {
+    fun `StoreViewModel does not close store after closing store for different id`() {
         val closeable = FakeCloseable()
         val valueA = underTest.provideStore(StackEntry.Id("1"))
         valueA.getOrCreate(FakeCloseable::class) { closeable }
-        underTest.removeEntry(StackEntry.Id("2"))
+        val valueB = underTest.provideStore(StackEntry.Id("2"))
+        valueB.close()
         assertThat(closeable.closed).isFalse()
     }
 

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/StackTest.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/StackTest.kt
@@ -15,21 +15,19 @@ import org.junit.Test
 
 internal class StackTest {
 
-    private val removed = mutableListOf<StackEntry.Id>()
-    private val removedCallback: (StackEntry.Id) -> Unit = { removed.add(it) }
-
     private val factory = TestStackEntryFactory()
+    private val removed get() = factory.closedEntries
 
     @Test
     fun id() {
-        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create)
 
         assertThat(stack.id).isEqualTo(simpleRootDestination.id)
     }
 
     @Test
     fun rootEntry() {
-        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create)
 
         assertThat(stack.rootEntry)
             .isEqualTo(factory.create(StackEntry.Id("100"), SimpleRoot(1)))
@@ -37,21 +35,21 @@ internal class StackTest {
 
     @Test
     fun `isAtRoot after construction`() {
-        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create)
 
         assertThat(stack.isAtRoot).isTrue()
     }
 
     @Test
     fun `removed after construction`() {
-        Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
+        Stack.createWith(SimpleRoot(1), factory::create)
 
         assertThat(removed).isEmpty()
     }
 
     @Test
     fun `computeVisibleEntries after construction`() {
-        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create)
 
         assertThat(stack.snapshot(stack.id).visibleEntries)
             .containsExactly(
@@ -62,7 +60,7 @@ internal class StackTest {
 
     @Test
     fun `push with a screen destination`() {
-        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create)
         stack.push(SimpleRoute(2))
 
         assertThat(stack.snapshot(stack.id).visibleEntries)
@@ -76,7 +74,7 @@ internal class StackTest {
 
     @Test
     fun `push with a dialog destination`() {
-        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create)
         stack.push(OtherRoute(3))
 
         assertThat(stack.snapshot(stack.id).visibleEntries)
@@ -91,7 +89,7 @@ internal class StackTest {
 
     @Test
     fun `push with a bottom sheet destination`() {
-        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create)
         stack.push(ThirdRoute(4))
 
         assertThat(stack.snapshot(stack.id).visibleEntries)
@@ -106,7 +104,7 @@ internal class StackTest {
 
     @Test
     fun `computeVisibleEntries with multiple screens, dialogs and bottom sheets`() {
-        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create)
         stack.push(SimpleRoute(2))
         stack.push(SimpleRoute(3))
         stack.push(SimpleRoute(4))
@@ -133,7 +131,7 @@ internal class StackTest {
 
     @Test
     fun `computeVisibleEntries with multiple screens, dialogs and bottom sheets 2`() {
-        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create)
         stack.push(SimpleRoute(2))
         stack.push(SimpleRoute(3))
         stack.push(SimpleRoute(4))
@@ -158,7 +156,7 @@ internal class StackTest {
 
     @Test
     fun `pop from the root`() {
-        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create)
         val exception = assertThrows(IllegalStateException::class.java) {
             stack.pop()
         }
@@ -169,7 +167,7 @@ internal class StackTest {
 
     @Test
     fun `pop from a screen`() {
-        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create)
         stack.push(SimpleRoute(2))
         assertThat(stack.snapshot(stack.id).visibleEntries)
             .containsExactly(
@@ -190,7 +188,7 @@ internal class StackTest {
 
     @Test
     fun `pop from a screen and then opening that screen again`() {
-        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create)
         stack.push(SimpleRoute(2))
 
         assertThat(stack.snapshot(stack.id).visibleEntries)
@@ -213,7 +211,7 @@ internal class StackTest {
 
     @Test
     fun `popUpTo with inclusive false`() {
-        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create)
         stack.push(SimpleRoute(2))
         stack.push(SimpleRoute(3))
         stack.push(SimpleRoute(4))
@@ -245,7 +243,7 @@ internal class StackTest {
 
     @Test
     fun `popUpTo with inclusive true`() {
-        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create)
         stack.push(SimpleRoute(2))
         stack.push(SimpleRoute(3))
         stack.push(SimpleRoute(4))
@@ -278,7 +276,7 @@ internal class StackTest {
 
     @Test
     fun `popUpTo with root and inclusive false`() {
-        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create)
         stack.push(SimpleRoute(2))
         stack.push(SimpleRoute(3))
         stack.push(SimpleRoute(4))
@@ -314,7 +312,7 @@ internal class StackTest {
 
     @Test
     fun `popUpTo with root and inclusive true`() {
-        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create)
         stack.push(SimpleRoute(2))
         stack.push(SimpleRoute(3))
         stack.push(SimpleRoute(4))
@@ -347,7 +345,7 @@ internal class StackTest {
 
     @Test
     fun `popUpTo with route not present on the stack`() {
-        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create)
         stack.push(SimpleRoute(2))
         stack.push(SimpleRoute(3))
         stack.push(SimpleRoute(4))
@@ -378,7 +376,7 @@ internal class StackTest {
 
     @Test
     fun `clear removes everything except for the root`() {
-        val stack = Stack.createWith(SimpleRoot(1), factory::create, removedCallback)
+        val stack = Stack.createWith(SimpleRoot(1), factory::create)
         stack.push(SimpleRoute(2))
         stack.push(SimpleRoute(3))
         stack.push(SimpleRoute(4))

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/TestStackEntryFactory.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/TestStackEntryFactory.kt
@@ -13,6 +13,8 @@ internal class TestStackEntryFactory {
     private val handles = mutableMapOf<StackEntry.Id, SavedStateHandle>()
     private val stores = mutableMapOf<StackEntry.Id, StackEntryStore>()
 
+    val closedEntries = mutableListOf<StackEntry.Id>()
+
     fun <T : BaseRoute> create(route: T): StackEntry<T> {
         return create(StackEntry.Id((nextId++).toString()), route)
     }
@@ -21,7 +23,7 @@ internal class TestStackEntryFactory {
     fun <T : BaseRoute> create(id: StackEntry.Id, route: T): StackEntry<T> {
         val destination = destinations.find { it.id == route.destinationId } as ContentDestination<T>
         val handle = handles.getOrPut(id) { SavedStateHandle() }
-        val store = stores.getOrPut(id) { StackEntryStore() }
+        val store = stores.getOrPut(id) { StackEntryStore { closedEntries.add(id) } }
         return StackEntry(id, route, destination, handle, store)
     }
 }


### PR DESCRIPTION
This makes it a little bit more direct. We can't avoid referencing the store in 2 places: we want it in the entry because that's how we access it but the the `ViewModel` needs to hold it as well so that it stays alive during configuration changes. Instead of passing down the `onEntryRemoved` callback everywhere, the store will now remove itself from the `ViewModel` when it's closed and we close the store through the entry on removal of the entry.