### PR TITLE
pass StackSnapshot to content composable

### DIFF
--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationCodegenTest.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationCodegenTest.kt
@@ -84,13 +84,13 @@ internal class NavDestinationCodegenTest {
             import com.freeletics.khonshu.codegen.`internal`.LocalActivityComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.asComposeState
             import com.freeletics.khonshu.codegen.`internal`.componentFromParentRoute
-            import com.freeletics.khonshu.navigation.LocalNavigationExecutor
             import com.freeletics.khonshu.navigation.NavDestination
             import com.freeletics.khonshu.navigation.NavEventNavigator
             import com.freeletics.khonshu.navigation.NavigationSetup
             import com.freeletics.khonshu.navigation.ScreenDestination
             import com.freeletics.khonshu.navigation.`internal`.InternalNavigationCodegenApi
-            import com.freeletics.khonshu.navigation.`internal`.NavigationExecutor
+            import com.freeletics.khonshu.navigation.`internal`.StackEntry
+            import com.freeletics.khonshu.navigation.`internal`.StackSnapshot
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
             import com.squareup.anvil.annotations.optional.ForScope
@@ -145,13 +145,12 @@ internal class NavDestinationCodegenTest {
             public object KhonshuTestComponentProvider : ComponentProvider<TestRoute, KhonshuTestComponent> {
               @OptIn(InternalNavigationCodegenApi::class)
               override fun provide(
-                route: TestRoute,
-                executor: NavigationExecutor,
+                entry: StackEntry<TestRoute>,
+                snapshot: StackSnapshot,
                 provider: ActivityComponentProvider,
-              ): KhonshuTestComponent = componentFromParentRoute(route, executor, provider,
-                  TestParentRoute::class) { parentComponent: KhonshuTestComponent.ParentComponent,
-                  savedStateHandle, testRoute ->
-                parentComponent.khonshuTestComponentFactory().create(savedStateHandle, testRoute)
+              ): KhonshuTestComponent = componentFromParentRoute(entry, snapshot, provider,
+                  TestParentRoute::class) { parentComponent: KhonshuTestComponent.ParentComponent ->
+                parentComponent.khonshuTestComponentFactory().create(entry.savedStateHandle, entry.route)
               }
             }
 
@@ -165,11 +164,10 @@ internal class NavDestinationCodegenTest {
 
             @Composable
             @OptIn(InternalCodegenApi::class, InternalNavigationCodegenApi::class)
-            public fun KhonshuTest(testRoute: TestRoute) {
-              val executor = LocalNavigationExecutor.current
+            public fun KhonshuTest(snapshot: StackSnapshot, entry: StackEntry<TestRoute>) {
               val provider = LocalActivityComponentProvider.current
-              val component = remember(testRoute, executor, provider) {
-                KhonshuTestComponentProvider.provide(testRoute, executor, provider)
+              val component = remember(entry, snapshot, provider) {
+                KhonshuTestComponentProvider.provide(entry, snapshot, provider)
               }
 
               NavigationSetup(component.navEventNavigator)
@@ -203,8 +201,8 @@ internal class NavDestinationCodegenTest {
               @IntoSet
               @OptIn(InternalNavigationCodegenApi::class)
               public fun provideNavDestination(): NavDestination =
-                  ScreenDestination<TestRoute>(KhonshuTestComponentProvider) {
-                KhonshuTest(it)
+                  ScreenDestination<TestRoute>(KhonshuTestComponentProvider) { snapshot, route ->
+                KhonshuTest(snapshot, route)
               }
             }
 
@@ -259,13 +257,13 @@ internal class NavDestinationCodegenTest {
             import com.freeletics.khonshu.codegen.`internal`.LocalActivityComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.asComposeState
             import com.freeletics.khonshu.codegen.`internal`.component
-            import com.freeletics.khonshu.navigation.LocalNavigationExecutor
             import com.freeletics.khonshu.navigation.NavDestination
             import com.freeletics.khonshu.navigation.NavEventNavigator
             import com.freeletics.khonshu.navigation.NavigationSetup
             import com.freeletics.khonshu.navigation.ScreenDestination
             import com.freeletics.khonshu.navigation.`internal`.InternalNavigationCodegenApi
-            import com.freeletics.khonshu.navigation.`internal`.NavigationExecutor
+            import com.freeletics.khonshu.navigation.`internal`.StackEntry
+            import com.freeletics.khonshu.navigation.`internal`.StackSnapshot
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
             import com.squareup.anvil.annotations.optional.ForScope
@@ -318,12 +316,12 @@ internal class NavDestinationCodegenTest {
             public object KhonshuTestComponentProvider : ComponentProvider<TestRoute, KhonshuTestComponent> {
               @OptIn(InternalNavigationCodegenApi::class)
               override fun provide(
-                route: TestRoute,
-                executor: NavigationExecutor,
+                entry: StackEntry<TestRoute>,
+                snapshot: StackSnapshot,
                 provider: ActivityComponentProvider,
-              ): KhonshuTestComponent = component(route, executor, provider, AppScope::class) { parentComponent:
-                  KhonshuTestComponent.ParentComponent, savedStateHandle, testRoute ->
-                parentComponent.khonshuTestComponentFactory().create(savedStateHandle, testRoute)
+              ): KhonshuTestComponent = component(entry, provider, AppScope::class) { parentComponent:
+                  KhonshuTestComponent.ParentComponent ->
+                parentComponent.khonshuTestComponentFactory().create(entry.savedStateHandle, entry.route)
               }
             }
 
@@ -337,11 +335,10 @@ internal class NavDestinationCodegenTest {
 
             @Composable
             @OptIn(InternalCodegenApi::class, InternalNavigationCodegenApi::class)
-            public fun KhonshuTest(testRoute: TestRoute) {
-              val executor = LocalNavigationExecutor.current
+            public fun KhonshuTest(snapshot: StackSnapshot, entry: StackEntry<TestRoute>) {
               val provider = LocalActivityComponentProvider.current
-              val component = remember(testRoute, executor, provider) {
-                KhonshuTestComponentProvider.provide(testRoute, executor, provider)
+              val component = remember(entry, snapshot, provider) {
+                KhonshuTestComponentProvider.provide(entry, snapshot, provider)
               }
 
               NavigationSetup(component.navEventNavigator)
@@ -375,8 +372,8 @@ internal class NavDestinationCodegenTest {
               @IntoSet
               @OptIn(InternalNavigationCodegenApi::class)
               public fun provideNavDestination(): NavDestination =
-                  ScreenDestination<TestRoute>(KhonshuTestComponentProvider) {
-                KhonshuTest(it)
+                  ScreenDestination<TestRoute>(KhonshuTestComponentProvider) { snapshot, route ->
+                KhonshuTest(snapshot, route)
               }
             }
 
@@ -433,13 +430,13 @@ internal class NavDestinationCodegenTest {
             import com.freeletics.khonshu.codegen.`internal`.LocalActivityComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.asComposeState
             import com.freeletics.khonshu.codegen.`internal`.componentFromParentRoute
-            import com.freeletics.khonshu.navigation.LocalNavigationExecutor
             import com.freeletics.khonshu.navigation.NavDestination
             import com.freeletics.khonshu.navigation.NavEventNavigator
             import com.freeletics.khonshu.navigation.NavigationSetup
             import com.freeletics.khonshu.navigation.OverlayDestination
             import com.freeletics.khonshu.navigation.`internal`.InternalNavigationCodegenApi
-            import com.freeletics.khonshu.navigation.`internal`.NavigationExecutor
+            import com.freeletics.khonshu.navigation.`internal`.StackEntry
+            import com.freeletics.khonshu.navigation.`internal`.StackSnapshot
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
             import com.squareup.anvil.annotations.optional.ForScope
@@ -496,13 +493,12 @@ internal class NavDestinationCodegenTest {
                 ComponentProvider<TestOverlayRoute, KhonshuTestComponent> {
               @OptIn(InternalNavigationCodegenApi::class)
               override fun provide(
-                route: TestOverlayRoute,
-                executor: NavigationExecutor,
+                entry: StackEntry<TestOverlayRoute>,
+                snapshot: StackSnapshot,
                 provider: ActivityComponentProvider,
-              ): KhonshuTestComponent = componentFromParentRoute(route, executor, provider,
-                  TestParentRoute::class) { parentComponent: KhonshuTestComponent.ParentComponent,
-                  savedStateHandle, testOverlayRoute ->
-                parentComponent.khonshuTestComponentFactory().create(savedStateHandle, testOverlayRoute)
+              ): KhonshuTestComponent = componentFromParentRoute(entry, snapshot, provider,
+                  TestParentRoute::class) { parentComponent: KhonshuTestComponent.ParentComponent ->
+                parentComponent.khonshuTestComponentFactory().create(entry.savedStateHandle, entry.route)
               }
             }
 
@@ -516,11 +512,10 @@ internal class NavDestinationCodegenTest {
 
             @Composable
             @OptIn(InternalCodegenApi::class, InternalNavigationCodegenApi::class)
-            public fun KhonshuTest(testOverlayRoute: TestOverlayRoute) {
-              val executor = LocalNavigationExecutor.current
+            public fun KhonshuTest(snapshot: StackSnapshot, entry: StackEntry<TestOverlayRoute>) {
               val provider = LocalActivityComponentProvider.current
-              val component = remember(testOverlayRoute, executor, provider) {
-                KhonshuTestComponentProvider.provide(testOverlayRoute, executor, provider)
+              val component = remember(entry, snapshot, provider) {
+                KhonshuTestComponentProvider.provide(entry, snapshot, provider)
               }
 
               NavigationSetup(component.navEventNavigator)
@@ -554,8 +549,8 @@ internal class NavDestinationCodegenTest {
               @IntoSet
               @OptIn(InternalNavigationCodegenApi::class)
               public fun provideNavDestination(): NavDestination =
-                  OverlayDestination<TestOverlayRoute>(KhonshuTestComponentProvider) {
-                KhonshuTest(it)
+                  OverlayDestination<TestOverlayRoute>(KhonshuTestComponentProvider) { snapshot, route ->
+                KhonshuTest(snapshot, route)
               }
             }
 
@@ -630,13 +625,13 @@ internal class NavDestinationCodegenTest {
             import com.freeletics.khonshu.codegen.`internal`.LocalActivityComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.asComposeState
             import com.freeletics.khonshu.codegen.`internal`.componentFromParentRoute
-            import com.freeletics.khonshu.navigation.LocalNavigationExecutor
             import com.freeletics.khonshu.navigation.NavDestination
             import com.freeletics.khonshu.navigation.NavEventNavigator
             import com.freeletics.khonshu.navigation.NavigationSetup
             import com.freeletics.khonshu.navigation.ScreenDestination
             import com.freeletics.khonshu.navigation.`internal`.InternalNavigationCodegenApi
-            import com.freeletics.khonshu.navigation.`internal`.NavigationExecutor
+            import com.freeletics.khonshu.navigation.`internal`.StackEntry
+            import com.freeletics.khonshu.navigation.`internal`.StackSnapshot
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
             import com.squareup.anvil.annotations.optional.ForScope
@@ -703,13 +698,12 @@ internal class NavDestinationCodegenTest {
             public object KhonshuTest2ComponentProvider : ComponentProvider<TestRoute, KhonshuTest2Component> {
               @OptIn(InternalNavigationCodegenApi::class)
               override fun provide(
-                route: TestRoute,
-                executor: NavigationExecutor,
+                entry: StackEntry<TestRoute>,
+                snapshot: StackSnapshot,
                 provider: ActivityComponentProvider,
-              ): KhonshuTest2Component = componentFromParentRoute(route, executor, provider,
-                  TestParentRoute::class) { parentComponent: KhonshuTest2Component.ParentComponent,
-                  savedStateHandle, testRoute ->
-                parentComponent.khonshuTest2ComponentFactory().create(savedStateHandle, testRoute)
+              ): KhonshuTest2Component = componentFromParentRoute(entry, snapshot, provider,
+                  TestParentRoute::class) { parentComponent: KhonshuTest2Component.ParentComponent ->
+                parentComponent.khonshuTest2ComponentFactory().create(entry.savedStateHandle, entry.route)
               }
             }
 
@@ -723,11 +717,10 @@ internal class NavDestinationCodegenTest {
 
             @Composable
             @OptIn(InternalCodegenApi::class, InternalNavigationCodegenApi::class)
-            public fun KhonshuTest2(testRoute: TestRoute) {
-              val executor = LocalNavigationExecutor.current
+            public fun KhonshuTest2(snapshot: StackSnapshot, entry: StackEntry<TestRoute>) {
               val provider = LocalActivityComponentProvider.current
-              val component = remember(testRoute, executor, provider) {
-                KhonshuTest2ComponentProvider.provide(testRoute, executor, provider)
+              val component = remember(entry, snapshot, provider) {
+                KhonshuTest2ComponentProvider.provide(entry, snapshot, provider)
               }
 
               NavigationSetup(component.navEventNavigator)
@@ -769,8 +762,8 @@ internal class NavDestinationCodegenTest {
               @IntoSet
               @OptIn(InternalNavigationCodegenApi::class)
               public fun provideNavDestination(): NavDestination =
-                  ScreenDestination<TestRoute>(KhonshuTest2ComponentProvider) {
-                KhonshuTest2(it)
+                  ScreenDestination<TestRoute>(KhonshuTest2ComponentProvider) { snapshot, route ->
+                KhonshuTest2(snapshot, route)
               }
             }
 
@@ -820,13 +813,13 @@ internal class NavDestinationCodegenTest {
             import com.freeletics.khonshu.codegen.`internal`.LocalActivityComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.asComposeState
             import com.freeletics.khonshu.codegen.`internal`.componentFromParentRoute
-            import com.freeletics.khonshu.navigation.LocalNavigationExecutor
             import com.freeletics.khonshu.navigation.NavDestination
             import com.freeletics.khonshu.navigation.NavEventNavigator
             import com.freeletics.khonshu.navigation.NavigationSetup
             import com.freeletics.khonshu.navigation.ScreenDestination
             import com.freeletics.khonshu.navigation.`internal`.InternalNavigationCodegenApi
-            import com.freeletics.khonshu.navigation.`internal`.NavigationExecutor
+            import com.freeletics.khonshu.navigation.`internal`.StackEntry
+            import com.freeletics.khonshu.navigation.`internal`.StackSnapshot
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
             import com.squareup.anvil.annotations.optional.ForScope
@@ -879,13 +872,12 @@ internal class NavDestinationCodegenTest {
             public object KhonshuTestComponentProvider : ComponentProvider<TestRoute, KhonshuTestComponent> {
               @OptIn(InternalNavigationCodegenApi::class)
               override fun provide(
-                route: TestRoute,
-                executor: NavigationExecutor,
+                entry: StackEntry<TestRoute>,
+                snapshot: StackSnapshot,
                 provider: ActivityComponentProvider,
-              ): KhonshuTestComponent = componentFromParentRoute(route, executor, provider,
-                  TestParentRoute::class) { parentComponent: KhonshuTestComponent.ParentComponent,
-                  savedStateHandle, testRoute ->
-                parentComponent.khonshuTestComponentFactory().create(savedStateHandle, testRoute)
+              ): KhonshuTestComponent = componentFromParentRoute(entry, snapshot, provider,
+                  TestParentRoute::class) { parentComponent: KhonshuTestComponent.ParentComponent ->
+                parentComponent.khonshuTestComponentFactory().create(entry.savedStateHandle, entry.route)
               }
             }
 
@@ -899,11 +891,10 @@ internal class NavDestinationCodegenTest {
 
             @Composable
             @OptIn(InternalCodegenApi::class, InternalNavigationCodegenApi::class)
-            public fun KhonshuTest(testRoute: TestRoute) {
-              val executor = LocalNavigationExecutor.current
+            public fun KhonshuTest(snapshot: StackSnapshot, entry: StackEntry<TestRoute>) {
               val provider = LocalActivityComponentProvider.current
-              val component = remember(testRoute, executor, provider) {
-                KhonshuTestComponentProvider.provide(testRoute, executor, provider)
+              val component = remember(entry, snapshot, provider) {
+                KhonshuTestComponentProvider.provide(entry, snapshot, provider)
               }
 
               NavigationSetup(component.navEventNavigator)
@@ -932,8 +923,8 @@ internal class NavDestinationCodegenTest {
               @IntoSet
               @OptIn(InternalNavigationCodegenApi::class)
               public fun provideNavDestination(): NavDestination =
-                  ScreenDestination<TestRoute>(KhonshuTestComponentProvider) {
-                KhonshuTest(it)
+                  ScreenDestination<TestRoute>(KhonshuTestComponentProvider) { snapshot, route ->
+                KhonshuTest(snapshot, route)
               }
             }
 
@@ -984,13 +975,13 @@ internal class NavDestinationCodegenTest {
             import com.freeletics.khonshu.codegen.`internal`.LocalActivityComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.asComposeState
             import com.freeletics.khonshu.codegen.`internal`.componentFromParentRoute
-            import com.freeletics.khonshu.navigation.LocalNavigationExecutor
             import com.freeletics.khonshu.navigation.NavDestination
             import com.freeletics.khonshu.navigation.NavEventNavigator
             import com.freeletics.khonshu.navigation.NavigationSetup
             import com.freeletics.khonshu.navigation.ScreenDestination
             import com.freeletics.khonshu.navigation.`internal`.InternalNavigationCodegenApi
-            import com.freeletics.khonshu.navigation.`internal`.NavigationExecutor
+            import com.freeletics.khonshu.navigation.`internal`.StackEntry
+            import com.freeletics.khonshu.navigation.`internal`.StackSnapshot
             import com.squareup.anvil.annotations.ContributesSubcomponent
             import com.squareup.anvil.annotations.ContributesTo
             import com.squareup.anvil.annotations.optional.ForScope
@@ -1045,13 +1036,12 @@ internal class NavDestinationCodegenTest {
             public object KhonshuTestComponentProvider : ComponentProvider<TestRoute, KhonshuTestComponent> {
               @OptIn(InternalNavigationCodegenApi::class)
               override fun provide(
-                route: TestRoute,
-                executor: NavigationExecutor,
+                entry: StackEntry<TestRoute>,
+                snapshot: StackSnapshot,
                 provider: ActivityComponentProvider,
-              ): KhonshuTestComponent = componentFromParentRoute(route, executor, provider,
-                  TestParentRoute::class) { parentComponent: KhonshuTestComponent.ParentComponent,
-                  savedStateHandle, testRoute ->
-                parentComponent.khonshuTestComponentFactory().create(savedStateHandle, testRoute)
+              ): KhonshuTestComponent = componentFromParentRoute(entry, snapshot, provider,
+                  TestParentRoute::class) { parentComponent: KhonshuTestComponent.ParentComponent ->
+                parentComponent.khonshuTestComponentFactory().create(entry.savedStateHandle, entry.route)
               }
             }
 
@@ -1065,11 +1055,10 @@ internal class NavDestinationCodegenTest {
 
             @Composable
             @OptIn(InternalCodegenApi::class, InternalNavigationCodegenApi::class)
-            public fun KhonshuTest(testRoute: TestRoute) {
-              val executor = LocalNavigationExecutor.current
+            public fun KhonshuTest(snapshot: StackSnapshot, entry: StackEntry<TestRoute>) {
               val provider = LocalActivityComponentProvider.current
-              val component = remember(testRoute, executor, provider) {
-                KhonshuTestComponentProvider.provide(testRoute, executor, provider)
+              val component = remember(entry, snapshot, provider) {
+                KhonshuTestComponentProvider.provide(entry, snapshot, provider)
               }
 
               NavigationSetup(component.navEventNavigator)
@@ -1102,8 +1091,8 @@ internal class NavDestinationCodegenTest {
               @IntoSet
               @OptIn(InternalNavigationCodegenApi::class)
               public fun provideNavDestination(): NavDestination =
-                  ScreenDestination<TestRoute>(KhonshuTestComponentProvider) {
-                KhonshuTest(it)
+                  ScreenDestination<TestRoute>(KhonshuTestComponentProvider) { snapshot, route ->
+                KhonshuTest(snapshot, route)
               }
             }
 

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/Data.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/Data.kt
@@ -1,7 +1,5 @@
 package com.freeletics.khonshu.codegen
 
-import com.freeletics.khonshu.codegen.util.getComponent
-import com.freeletics.khonshu.codegen.util.getComponentFromRoute
 import com.freeletics.khonshu.codegen.util.navigationDestination
 import com.freeletics.khonshu.codegen.util.overlayDestination
 import com.freeletics.khonshu.codegen.util.screenDestination
@@ -67,16 +65,11 @@ public data class NavHostActivityData(
 
 public data class Navigation(
     val route: ClassName,
-    private val parentScopeIsRoute: Boolean,
+    val parentScopeIsRoute: Boolean,
     private val overlay: Boolean,
     val destinationScope: ClassName,
 ) {
     val destinationClass: ClassName = navigationDestination
-
-    val parentComponentLookup: MemberName = when (parentScopeIsRoute) {
-        false -> getComponent
-        true -> getComponentFromRoute
-    }
 
     val destinationMethod: MemberName = when (overlay) {
         false -> screenDestination

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationComponentProviderGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationComponentProviderGenerator.kt
@@ -4,10 +4,12 @@ import com.freeletics.khonshu.codegen.BaseData
 import com.freeletics.khonshu.codegen.NavDestinationData
 import com.freeletics.khonshu.codegen.util.activityComponentProvider
 import com.freeletics.khonshu.codegen.util.componentProvider
+import com.freeletics.khonshu.codegen.util.getComponent
+import com.freeletics.khonshu.codegen.util.getComponentFromRoute
 import com.freeletics.khonshu.codegen.util.internalNavigatorApi
-import com.freeletics.khonshu.codegen.util.navigationExecutor
 import com.freeletics.khonshu.codegen.util.optInAnnotation
-import com.freeletics.khonshu.codegen.util.propertyName
+import com.freeletics.khonshu.codegen.util.stackEntry
+import com.freeletics.khonshu.codegen.util.stackSnapshot
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier.OVERRIDE
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
@@ -32,23 +34,31 @@ internal class NavDestinationComponentProviderGenerator(
         return FunSpec.builder("provide")
             .addModifiers(OVERRIDE)
             .addAnnotation(optInAnnotation(internalNavigatorApi))
-            .addParameter("route", data.navigation.route)
-            .addParameter("executor", navigationExecutor)
+            .addParameter("entry", stackEntry.parameterizedBy(data.navigation.route))
+            .addParameter("snapshot", stackSnapshot)
             .addParameter("provider", activityComponentProvider)
             .returns(retainedComponentClassName)
-            .beginControlFlow(
-                "return %M(route, executor, provider, %T::class) " +
-                    "{ parentComponent: %T, savedStateHandle, %L ->",
-                data.navigation.parentComponentLookup,
-                data.parentScope,
-                retainedParentComponentClassName,
-                data.navigation.route.propertyName,
-            )
+            .apply {
+                if (data.navigation.parentScopeIsRoute) {
+                    beginControlFlow(
+                        "return %M(entry, snapshot, provider, %T::class) { parentComponent: %T ->",
+                        getComponentFromRoute,
+                        data.parentScope,
+                        retainedParentComponentClassName,
+                    )
+                } else {
+                    beginControlFlow(
+                        "return %M(entry, provider, %T::class) { parentComponent: %T ->",
+                        getComponent,
+                        data.parentScope,
+                        retainedParentComponentClassName,
+                    )
+                }
+            }
             .addStatement(
-                "parentComponent.%L().%L(savedStateHandle, %L)",
+                "parentComponent.%L().%L(entry.savedStateHandle, entry.route)",
                 retainedParentComponentGetterName,
                 retainedComponentFactoryCreateName,
-                data.navigation.route.propertyName,
             )
             .endControlFlow()
             .build()

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationModuleGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationModuleGenerator.kt
@@ -40,12 +40,12 @@ internal class NavDestinationModuleGenerator(
         val navigation = data.navigation!!
         return CodeBlock.builder()
             .beginControlFlow(
-                "return %M<%T>(%T)",
+                "return %M<%T>(%T) { snapshot, route ->",
                 navigation.destinationMethod,
                 navigation.route,
                 componentProviderClassName,
             )
-            .addStatement("%L(it)", composableName)
+            .addStatement("%L(snapshot, route)", composableName)
             .endControlFlow()
             .build()
     }

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/util/External.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/util/External.kt
@@ -28,18 +28,17 @@ internal val localActivityComponentProvider =
     MemberName("com.freeletics.khonshu.codegen.internal", "LocalActivityComponentProvider")
 
 // Navigator
+internal val stackSnapshot = ClassName("com.freeletics.khonshu.navigation.internal", "StackSnapshot")
+internal val stackEntry = ClassName("com.freeletics.khonshu.navigation.internal", "StackEntry")
 internal val baseRoute = ClassName("com.freeletics.khonshu.navigation", "BaseRoute")
 internal val baseRouteFqName = FqName(baseRoute.canonicalName)
 internal val navRoot = ClassName("com.freeletics.khonshu.navigation", "NavRoot")
 internal val navEventNavigator = ClassName("com.freeletics.khonshu.navigation", "NavEventNavigator")
-internal val navigationExecutor = ClassName("com.freeletics.khonshu.navigation.internal", "NavigationExecutor")
 internal val navHost = MemberName("com.freeletics.khonshu.navigation", "NavHost")
 internal val navigationSetup = MemberName("com.freeletics.khonshu.navigation", "NavigationSetup")
 internal val navigationDestination = ClassName("com.freeletics.khonshu.navigation", "NavDestination")
 internal val screenDestination = MemberName("com.freeletics.khonshu.navigation", "ScreenDestination")
 internal val overlayDestination = MemberName("com.freeletics.khonshu.navigation", "OverlayDestination")
-internal val localNavigationExecutor =
-    MemberName("com.freeletics.khonshu.navigation", "LocalNavigationExecutor")
 internal val deepLinkHandler = ClassName("com.freeletics.khonshu.navigation.deeplinks", "DeepLinkHandler")
 internal val deepLinkPrefix = deepLinkHandler.nestedClass("Prefix")
 internal val internalNavigatorApi =

--- a/navigation/api/android/navigation.api
+++ b/navigation/api/android/navigation.api
@@ -139,7 +139,7 @@ public final class com/freeletics/khonshu/navigation/Navigator$Companion {
 public final class com/freeletics/khonshu/navigation/OverlayDestination {
 	public static final field $stable I
 	public static final field $stable I
-	public synthetic fun <init> (Lkotlin/reflect/KClass;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lkotlin/reflect/KClass;Ljava/lang/Object;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/freeletics/khonshu/navigation/PermissionsResultRequest : com/freeletics/khonshu/navigation/ContractResultOwner {
@@ -179,7 +179,7 @@ public abstract class com/freeletics/khonshu/navigation/ResultOwner {
 public final class com/freeletics/khonshu/navigation/ScreenDestination {
 	public static final field $stable I
 	public static final field $stable I
-	public synthetic fun <init> (Lkotlin/reflect/KClass;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lkotlin/reflect/KClass;Ljava/lang/Object;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/freeletics/khonshu/navigation/deeplinks/ActivityRouteDeepLinkKt {

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavDestination.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavDestination.kt
@@ -5,6 +5,8 @@ import androidx.compose.runtime.Composable
 import com.freeletics.khonshu.navigation.internal.ActivityDestinationId
 import com.freeletics.khonshu.navigation.internal.DestinationId
 import com.freeletics.khonshu.navigation.internal.InternalNavigationCodegenApi
+import com.freeletics.khonshu.navigation.internal.StackEntry
+import com.freeletics.khonshu.navigation.internal.StackSnapshot
 
 /**
  * A destination that can be navigated to. See `NavHost` for how to configure a `NavGraph` with it.
@@ -14,7 +16,7 @@ public sealed interface NavDestination
 internal sealed class ContentDestination<T : BaseRoute> : NavDestination {
     internal abstract val id: DestinationId<T>
     internal abstract val extra: Any?
-    internal abstract val content: @Composable (T) -> Unit
+    internal abstract val content: @Composable (StackSnapshot, StackEntry<T>) -> Unit
 }
 
 /**
@@ -25,20 +27,20 @@ internal sealed class ContentDestination<T : BaseRoute> : NavDestination {
 @Suppress("FunctionName")
 public inline fun <reified T : BaseRoute> ScreenDestination(
     noinline content: @Composable (T) -> Unit,
-): NavDestination = ScreenDestination(DestinationId(T::class), null, content)
+): NavDestination = ScreenDestination(DestinationId(T::class), null) { _, entry -> content(entry.route) }
 
 @InternalNavigationCodegenApi
 @Suppress("FunctionName")
 public inline fun <reified T : BaseRoute> ScreenDestination(
     extra: Any,
-    noinline content: @Composable (T) -> Unit,
+    noinline content: @Composable (StackSnapshot, StackEntry<T>) -> Unit,
 ): NavDestination = ScreenDestination(DestinationId(T::class), extra, content)
 
 @PublishedApi
 internal class ScreenDestination<T : BaseRoute>(
     override val id: DestinationId<T>,
     override val extra: Any?,
-    override val content: @Composable (T) -> Unit,
+    override val content: @Composable (StackSnapshot, StackEntry<T>) -> Unit,
 ) : ContentDestination<T>()
 
 /**
@@ -49,20 +51,20 @@ internal class ScreenDestination<T : BaseRoute>(
 @Suppress("FunctionName")
 public inline fun <reified T : NavRoute> OverlayDestination(
     noinline content: @Composable (T) -> Unit,
-): NavDestination = OverlayDestination(DestinationId(T::class), null, content)
+): NavDestination = OverlayDestination(DestinationId(T::class), null) { _, entry -> content(entry.route) }
 
 @InternalNavigationCodegenApi
 @Suppress("FunctionName")
 public inline fun <reified T : NavRoute> OverlayDestination(
     extra: Any,
-    noinline content: @Composable (T) -> Unit,
+    noinline content: @Composable (StackSnapshot, StackEntry<T>) -> Unit,
 ): NavDestination = OverlayDestination(DestinationId(T::class), extra, content)
 
 @PublishedApi
 internal class OverlayDestination<T : NavRoute>(
     override val id: DestinationId<T>,
     override val extra: Any?,
-    override val content: @Composable (T) -> Unit,
+    override val content: @Composable (StackSnapshot, StackEntry<T>) -> Unit,
 ) : ContentDestination<T>()
 
 /**

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavHost.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavHost.kt
@@ -63,7 +63,7 @@ public fun NavHost(
 
         Box(modifier = modifier) {
             snapshot.forEachVisibleDestination {
-                Show(it, saveableStateHolder)
+                Show(snapshot, it, saveableStateHolder)
             }
         }
     }
@@ -71,6 +71,7 @@ public fun NavHost(
 
 @Composable
 private fun <T : BaseRoute> Show(
+    snapshot: StackSnapshot,
     entry: StackEntry<T>,
     saveableStateHolder: SaveableStateHolder,
 ) {
@@ -87,7 +88,7 @@ private fun <T : BaseRoute> Show(
     saveableCloseable.saveableStateHolderRef = WeakReference(saveableStateHolder)
 
     saveableStateHolder.SaveableStateProvider(entry.id.value) {
-        entry.destination.content(entry.route)
+        entry.destination.content(snapshot, entry)
     }
 }
 

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/Destinations.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/Destinations.kt
@@ -7,11 +7,11 @@ import com.freeletics.khonshu.navigation.ScreenDestination
 import com.freeletics.khonshu.navigation.internal.ActivityDestinationId
 import com.freeletics.khonshu.navigation.internal.DestinationId
 
-internal val simpleRootDestination = ScreenDestination(DestinationId(SimpleRoot::class), null) {}
-internal val otherRootDestination = ScreenDestination(DestinationId(OtherRoot::class), null) {}
-internal val simpleRouteDestination = ScreenDestination(DestinationId(SimpleRoute::class), null) {}
-internal val otherRouteDestination = OverlayDestination(DestinationId(OtherRoute::class), null) {}
-internal val thirdRouteDestination = OverlayDestination(DestinationId(ThirdRoute::class), null) {}
+internal val simpleRootDestination = ScreenDestination(DestinationId(SimpleRoot::class), null) { _, _ -> }
+internal val otherRootDestination = ScreenDestination(DestinationId(OtherRoot::class), null) { _, _ -> }
+internal val simpleRouteDestination = ScreenDestination(DestinationId(SimpleRoute::class), null) { _, _ -> }
+internal val otherRouteDestination = OverlayDestination(DestinationId(OtherRoute::class), null) { _, _ -> }
+internal val thirdRouteDestination = OverlayDestination(DestinationId(ThirdRoute::class), null) { _, _ -> }
 
 internal val destinations = listOf(
     simpleRootDestination,


### PR DESCRIPTION
Part 2 for #780. The internal `*Destination` functions that have the `extra: Any?` for component providers will now get the `StackEntry` instead of the `BaseRoute` plus the `StackSnapshot` passed to the `Composable` lambda. This allows the codegen to then do no lookups for the current entry and use the snapshot for looking up the parent if needed. 

For the public API nothing changes, the `BaseRoute` keeps being the parameter passed to the composable. Once all of these are a bit more mature API wise we can also think about exposing the entry/snapshot/store publicly.