### PR TITLE
add rememberHostNavigator and NavHost(HostNavigator, ...)

### DIFF
--- a/navigation/api/android/navigation.api
+++ b/navigation/api/android/navigation.api
@@ -45,6 +45,10 @@ public abstract class com/freeletics/khonshu/navigation/HostNavigator : com/free
 	public static final field $stable I
 }
 
+public final class com/freeletics/khonshu/navigation/HostNavigatorKt {
+	public static final fun rememberHostNavigator (Lcom/freeletics/khonshu/navigation/NavRoot;Lkotlinx/collections/immutable/ImmutableSet;Lkotlinx/collections/immutable/ImmutableSet;Lkotlinx/collections/immutable/ImmutableSet;Landroidx/compose/runtime/Composer;II)Lcom/freeletics/khonshu/navigation/HostNavigator;
+}
+
 public final class com/freeletics/khonshu/navigation/InitialValue$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/freeletics/khonshu/navigation/InitialValue;
@@ -87,6 +91,7 @@ public class com/freeletics/khonshu/navigation/NavEventNavigator : com/freeletic
 }
 
 public final class com/freeletics/khonshu/navigation/NavHostKt {
+	public static final fun NavHost (Lcom/freeletics/khonshu/navigation/HostNavigator;Landroidx/compose/ui/Modifier;Lcom/freeletics/khonshu/navigation/NavEventNavigator;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 	public static final fun NavHost (Lcom/freeletics/khonshu/navigation/NavRoot;Lkotlinx/collections/immutable/ImmutableSet;Landroidx/compose/ui/Modifier;Lkotlinx/collections/immutable/ImmutableSet;Lkotlinx/collections/immutable/ImmutableSet;Lcom/freeletics/khonshu/navigation/NavEventNavigator;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 }
 

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/HostNavigator.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/HostNavigator.kt
@@ -1,11 +1,54 @@
 package com.freeletics.khonshu.navigation
 
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.freeletics.khonshu.navigation.deeplinks.DeepLinkHandler
+import com.freeletics.khonshu.navigation.internal.StackEntryStoreViewModel
 import com.freeletics.khonshu.navigation.internal.StackSnapshot
+import com.freeletics.khonshu.navigation.internal.createHostNavigator
+import kotlinx.collections.immutable.ImmutableSet
+import kotlinx.collections.immutable.persistentSetOf
 
 /**
  * An implementation of [Navigator] that is meant to be used at the [NavHost] level.
+ *
+ * An instance can be created by calling [createHostNavigator].
  */
 public abstract class HostNavigator internal constructor() : Navigator {
     internal abstract val snapshot: State<StackSnapshot>
+}
+
+/**
+ * Returns an instance of [HostNavigator] with the given [destinations] and
+ * [startRoot] as initially shown destination.
+ *
+ * To support deep links a set of [DeepLinkHandlers][DeepLinkHandler] can be passed in optionally.
+ * These will be used to build the correct back stack when the current `Activity` was launched with
+ * an `ACTION_VIEW` `Intent` that contains an url in it's data. [deepLinkPrefixes] can be used to
+ * provide a default set of url patterns that should be matched by any [DeepLinkHandler] that
+ * doesn't provide its own [DeepLinkHandler.prefixes].
+ */
+@Composable
+public fun rememberHostNavigator(
+    startRoot: NavRoot,
+    destinations: ImmutableSet<NavDestination>,
+    deepLinkHandlers: ImmutableSet<DeepLinkHandler> = persistentSetOf(),
+    deepLinkPrefixes: ImmutableSet<DeepLinkHandler.Prefix> = persistentSetOf(),
+): HostNavigator {
+    val context = LocalContext.current
+    val viewModel = viewModel<StackEntryStoreViewModel>()
+    return remember(context, viewModel, startRoot, destinations, deepLinkHandlers, deepLinkPrefixes) {
+        createHostNavigator(
+            context = context.applicationContext,
+            intent = context.findActivity().intent,
+            viewModel = viewModel,
+            startRoot = startRoot,
+            destinations = destinations,
+            deepLinkHandlers = deepLinkHandlers,
+            deepLinkPrefixes = deepLinkPrefixes,
+        )
+    }
 }

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavHost.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavHost.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.Modifier
 import com.freeletics.khonshu.navigation.deeplinks.DeepLinkHandler
 import com.freeletics.khonshu.navigation.internal.StackEntry
 import com.freeletics.khonshu.navigation.internal.StackSnapshot
-import com.freeletics.khonshu.navigation.internal.createHostNavigator
 import java.io.Closeable
 import java.lang.ref.WeakReference
 import kotlinx.collections.immutable.ImmutableSet

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavHost.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavHost.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.Modifier
 import com.freeletics.khonshu.navigation.deeplinks.DeepLinkHandler
 import com.freeletics.khonshu.navigation.internal.StackEntry
 import com.freeletics.khonshu.navigation.internal.StackSnapshot
-import com.freeletics.khonshu.navigation.internal.rememberHostNavigator
+import com.freeletics.khonshu.navigation.internal.createHostNavigator
 import java.io.Closeable
 import java.lang.ref.WeakReference
 import kotlinx.collections.immutable.ImmutableSet
@@ -49,6 +49,27 @@ public fun NavHost(
     destinationChangedCallback: ((NavRoot, BaseRoute) -> Unit)? = null,
 ) {
     val navigator = rememberHostNavigator(startRoute, destinations, deepLinkHandlers, deepLinkPrefixes)
+    NavHost(navigator, modifier, navEventNavigator, destinationChangedCallback)
+}
+
+/**
+ * Create a new `NavHost` with the given [HostNavigator]. The start [NavRoot], available
+ * destinations and deep link handling are all dependent on the `navigator`. For more see
+ * [rememberHostNavigator].
+ *
+ * If a [NavEventNavigator] is passed it will be automatically set up and can be used to
+ * navigate within the `NavHost`.
+ *
+ * The [destinationChangedCallback] can be used to be notified when the current destination
+ * changes. Note that this will not be invoked when navigating to a [ActivityDestination].
+ */
+@Composable
+public fun NavHost(
+    navigator: HostNavigator,
+    modifier: Modifier = Modifier,
+    navEventNavigator: NavEventNavigator? = null,
+    destinationChangedCallback: ((NavRoot, BaseRoute) -> Unit)? = null,
+) {
     val snapshot by navigator.snapshot
 
     SystemBackHandling(snapshot, navigator)

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackHostNavigatorBuilder.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackHostNavigatorBuilder.kt
@@ -1,13 +1,9 @@
 package com.freeletics.khonshu.navigation.internal
 
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import android.os.Parcelable
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
-import androidx.compose.ui.platform.LocalContext
-import androidx.lifecycle.SavedStateViewModelFactory
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.eygraber.uri.toUri
 import com.freeletics.khonshu.navigation.ActivityDestination
 import com.freeletics.khonshu.navigation.ContentDestination
@@ -16,73 +12,59 @@ import com.freeletics.khonshu.navigation.NavRoot
 import com.freeletics.khonshu.navigation.deeplinks.DeepLinkHandler
 import com.freeletics.khonshu.navigation.deeplinks.EXTRA_DEEPLINK_ROUTES
 import com.freeletics.khonshu.navigation.deeplinks.createDeepLinkIfMatching
-import com.freeletics.khonshu.navigation.findActivity
 import com.freeletics.khonshu.navigation.internal.MultiStackHostNavigator.Companion.SAVED_STATE_HANDLED_DEEP_LINKS
 import com.freeletics.khonshu.navigation.internal.MultiStackHostNavigator.Companion.SAVED_STATE_STACK
 import kotlinx.collections.immutable.ImmutableSet
 
-@Composable
-internal fun rememberHostNavigator(
+internal fun createHostNavigator(
+    context: Context,
+    intent: Intent,
+    viewModel: StackEntryStoreViewModel,
     startRoot: NavRoot,
     destinations: ImmutableSet<NavDestination>,
     deepLinkHandlers: ImmutableSet<DeepLinkHandler>,
     deepLinkPrefixes: ImmutableSet<DeepLinkHandler.Prefix>,
 ): MultiStackHostNavigator {
-    val context = LocalContext.current
+    val activityDestinations = destinations.filterIsInstance<ActivityDestination>()
+    val starter = ActivityStarter(context.applicationContext, activityDestinations)
 
-    val viewModel = viewModel<StackEntryStoreViewModel>(factory = SavedStateViewModelFactory())
+    val contentDestinations = destinations.filterIsInstance<ContentDestination<*>>()
+    val factory = StackEntryFactory(contentDestinations, viewModel)
 
-    val starter = remember(context, destinations) {
-        val activityDestinations = destinations.filterIsInstance<ActivityDestination>()
-        ActivityStarter(context, activityDestinations)
-    }
-
-    val stack = remember(destinations, viewModel, startRoot) {
-        val contentDestinations = destinations.filterIsInstance<ContentDestination<*>>()
-        val factory = StackEntryFactory(contentDestinations, viewModel)
-
-        val navState = viewModel.globalSavedStateHandle.get<Bundle>(SAVED_STATE_STACK)
-        if (navState == null) {
-            MultiStack.createWith(
-                root = startRoot,
-                createEntry = factory::create,
-            )
-        } else {
-            MultiStack.fromState(
-                root = startRoot,
-                bundle = navState,
-                createEntry = factory::create,
-                createRestoredEntry = factory::create,
-            )
-        }
-    }
-
-    val deepLinkRoutes = remember(viewModel, context, deepLinkHandlers, deepLinkPrefixes) {
-        val navState = viewModel.globalSavedStateHandle.get<Bundle>(SAVED_STATE_STACK)
-
-        if (navState?.getBoolean(SAVED_STATE_HANDLED_DEEP_LINKS) != true) {
-            deepLinkRoutes(context, deepLinkHandlers, deepLinkPrefixes)
-        } else {
-            emptyList()
-        }
-    }
-
-    return remember(stack, viewModel, starter, deepLinkRoutes) {
-        MultiStackHostNavigator(
-            stack = stack,
-            activityStarter = starter::start,
-            viewModel = viewModel,
-            deepLinkRoutes = deepLinkRoutes,
+    val navState = viewModel.globalSavedStateHandle.get<Bundle>(SAVED_STATE_STACK)
+    val stack = if (navState == null) {
+        MultiStack.createWith(
+            root = startRoot,
+            createEntry = factory::create,
+        )
+    } else {
+        MultiStack.fromState(
+            root = startRoot,
+            bundle = navState,
+            createEntry = factory::create,
+            createRestoredEntry = factory::create,
         )
     }
+
+    val deepLinkRoutes = if (navState?.getBoolean(SAVED_STATE_HANDLED_DEEP_LINKS) != true) {
+        deepLinkRoutes(intent, deepLinkHandlers, deepLinkPrefixes)
+    } else {
+        emptyList()
+    }
+
+    return MultiStackHostNavigator(
+        stack = stack,
+        viewModel = viewModel,
+        activityStarter = starter::start,
+        deepLinkRoutes = deepLinkRoutes,
+    )
 }
 
 private fun deepLinkRoutes(
-    context: Context,
+    intent: Intent,
     deepLinkHandlers: Set<DeepLinkHandler>,
     deepLinkPrefixes: Set<DeepLinkHandler.Prefix>,
 ): List<Parcelable> {
-    val intent = context.findActivity().intent
     if (intent.hasExtra(EXTRA_DEEPLINK_ROUTES)) {
         @Suppress("DEPRECATION")
         return intent.getParcelableArrayListExtra(EXTRA_DEEPLINK_ROUTES)!!


### PR DESCRIPTION
Adds `rememberHostNavigator` that allows to manually create a `HostNavigator` that can then be used directly. `NavHost` gets an overload that allows passing such an already created navigator to the `NavHost` instead of the root, destinations and deeplinks. The remember is a bit less granular than before but in practice it shouldn't make much of a difference.

There will be a separate PR that will start using `HostNavigator` in codegen. This will use the internal `createHostNavigator` which is why it's a separate method.