### PR TITLE
add handleDeepLink to HostNavigator

### DIFF
--- a/navigation/api/android/navigation.api
+++ b/navigation/api/android/navigation.api
@@ -43,6 +43,7 @@ public abstract interface class com/freeletics/khonshu/navigation/ExternalActivi
 
 public abstract class com/freeletics/khonshu/navigation/HostNavigator : com/freeletics/khonshu/navigation/Navigator {
 	public static final field $stable I
+	public abstract fun handleDeepLink (Landroid/content/Intent;Lkotlinx/collections/immutable/ImmutableSet;Lkotlinx/collections/immutable/ImmutableSet;)V
 }
 
 public final class com/freeletics/khonshu/navigation/HostNavigatorKt {

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/deeplinks/AndroidDeepLinkExtensions.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/deeplinks/AndroidDeepLinkExtensions.kt
@@ -7,6 +7,8 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import androidx.core.app.TaskStackBuilder
+import com.eygraber.uri.toUri
+import com.freeletics.khonshu.navigation.internal.Parcelable
 
 /**
  * Creates an [Intent] that can be used to launch this deep link.
@@ -45,7 +47,7 @@ public fun DeepLink.buildPendingIntent(
     return buildTaskStack(context).getPendingIntent(requestCode, flags)!!
 }
 
-internal const val EXTRA_DEEPLINK_ROUTES: String = "com.freeletics.khonshu.navigation.DEEPLINK_ROUTES"
+private const val EXTRA_DEEPLINK_ROUTES: String = "com.freeletics.khonshu.navigation.DEEPLINK_ROUTES"
 
 private fun defaultFlag(): Int {
     return if (Build.VERSION.SDK_INT >= 23) {
@@ -53,4 +55,20 @@ private fun defaultFlag(): Int {
     } else {
         FLAG_UPDATE_CURRENT
     }
+}
+
+internal fun Intent.extractDeepLinkRoutes(
+    deepLinkHandlers: Set<DeepLinkHandler>,
+    deepLinkPrefixes: Set<DeepLinkHandler.Prefix>,
+): List<Parcelable> {
+    if (hasExtra(EXTRA_DEEPLINK_ROUTES)) {
+        @Suppress("DEPRECATION")
+        return getParcelableArrayListExtra(EXTRA_DEEPLINK_ROUTES)!!
+    }
+    val uri = data
+    if (uri != null) {
+        val deepLink = deepLinkHandlers.createDeepLinkIfMatching(uri.toUri(), deepLinkPrefixes)
+        return deepLink?.routes ?: emptyList()
+    }
+    return emptyList()
 }

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackHostNavigatorBuilder.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackHostNavigatorBuilder.kt
@@ -1,29 +1,19 @@
 package com.freeletics.khonshu.navigation.internal
 
 import android.content.Context
-import android.content.Intent
 import android.os.Bundle
-import android.os.Parcelable
-import com.eygraber.uri.toUri
 import com.freeletics.khonshu.navigation.ActivityDestination
 import com.freeletics.khonshu.navigation.ContentDestination
 import com.freeletics.khonshu.navigation.NavDestination
 import com.freeletics.khonshu.navigation.NavRoot
-import com.freeletics.khonshu.navigation.deeplinks.DeepLinkHandler
-import com.freeletics.khonshu.navigation.deeplinks.EXTRA_DEEPLINK_ROUTES
-import com.freeletics.khonshu.navigation.deeplinks.createDeepLinkIfMatching
-import com.freeletics.khonshu.navigation.internal.MultiStackHostNavigator.Companion.SAVED_STATE_HANDLED_DEEP_LINKS
 import com.freeletics.khonshu.navigation.internal.MultiStackHostNavigator.Companion.SAVED_STATE_STACK
 import kotlinx.collections.immutable.ImmutableSet
 
 internal fun createHostNavigator(
     context: Context,
-    intent: Intent,
     viewModel: StackEntryStoreViewModel,
     startRoot: NavRoot,
     destinations: ImmutableSet<NavDestination>,
-    deepLinkHandlers: ImmutableSet<DeepLinkHandler>,
-    deepLinkPrefixes: ImmutableSet<DeepLinkHandler.Prefix>,
 ): MultiStackHostNavigator {
     val activityDestinations = destinations.filterIsInstance<ActivityDestination>()
     val starter = ActivityStarter(context.applicationContext, activityDestinations)
@@ -46,33 +36,9 @@ internal fun createHostNavigator(
         )
     }
 
-    val deepLinkRoutes = if (navState?.getBoolean(SAVED_STATE_HANDLED_DEEP_LINKS) != true) {
-        deepLinkRoutes(intent, deepLinkHandlers, deepLinkPrefixes)
-    } else {
-        emptyList()
-    }
-
     return MultiStackHostNavigator(
         stack = stack,
         viewModel = viewModel,
         activityStarter = starter::start,
-        deepLinkRoutes = deepLinkRoutes,
     )
-}
-
-private fun deepLinkRoutes(
-    intent: Intent,
-    deepLinkHandlers: Set<DeepLinkHandler>,
-    deepLinkPrefixes: Set<DeepLinkHandler.Prefix>,
-): List<Parcelable> {
-    if (intent.hasExtra(EXTRA_DEEPLINK_ROUTES)) {
-        @Suppress("DEPRECATION")
-        return intent.getParcelableArrayListExtra(EXTRA_DEEPLINK_ROUTES)!!
-    }
-    val uri = intent.data
-    if (uri != null) {
-        val deepLink = deepLinkHandlers.createDeepLinkIfMatching(uri.toUri(), deepLinkPrefixes)
-        return deepLink?.routes ?: emptyList()
-    }
-    return emptyList()
 }

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackHostNavigatorTest.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackHostNavigatorTest.kt
@@ -1,6 +1,5 @@
 package com.freeletics.khonshu.navigation.internal
 
-import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import com.freeletics.khonshu.navigation.ActivityRoute
 import com.freeletics.khonshu.navigation.test.OtherRoot
@@ -30,14 +29,11 @@ internal class MultiStackHostNavigatorTest {
 
     private val viewModel = StackEntryStoreViewModel(SavedStateHandle())
 
-    private fun underTest(
-        deepLinkRoutes: List<Parcelable> = emptyList(),
-    ): MultiStackHostNavigator {
+    private fun underTest(): MultiStackHostNavigator {
         return MultiStackHostNavigator(
             stack = MultiStack.createWith(SimpleRoot(1), factory::create),
             activityStarter = starter,
             viewModel = viewModel,
-            deepLinkRoutes = deepLinkRoutes,
         )
     }
 
@@ -57,10 +53,9 @@ internal class MultiStackHostNavigatorTest {
 
     @Test
     fun `deep link with start root`() {
+        val hostNavigator = underTest()
         val exception = assertThrows(IllegalArgumentException::class.java) {
-            underTest(
-                listOf(SimpleRoot(3)),
-            )
+            hostNavigator.handleDeepLink(listOf(SimpleRoot(3)))
         }
 
         assertThat(exception).hasMessageThat().isEqualTo(
@@ -72,10 +67,9 @@ internal class MultiStackHostNavigatorTest {
 
     @Test
     fun `deep links passed with a root at an index other than the first`() {
+        val hostNavigator = underTest()
         val exception = assertThrows(IllegalArgumentException::class.java) {
-            underTest(
-                listOf(SimpleRoute(1), SimpleRoot(3)),
-            )
+            hostNavigator.handleDeepLink(listOf(SimpleRoute(1), SimpleRoot(3)))
         }
 
         assertThat(exception).hasMessageThat()
@@ -84,9 +78,8 @@ internal class MultiStackHostNavigatorTest {
 
     @Test
     fun `deep links passed with a NavRoute`() {
-        val hostNavigator = underTest(
-            listOf(SimpleRoute(2)),
-        )
+        val hostNavigator = underTest()
+        hostNavigator.handleDeepLink(listOf(SimpleRoute(2)))
 
         assertThat(hostNavigator.snapshot.value.visibleEntries)
             .containsExactly(
@@ -107,9 +100,8 @@ internal class MultiStackHostNavigatorTest {
 
     @Test
     fun `deep links passed with a NavRoot`() {
-        val hostNavigator = underTest(
-            listOf(OtherRoot(2)),
-        )
+        val hostNavigator = underTest()
+        hostNavigator.handleDeepLink(listOf(OtherRoot(2)))
 
         assertThat(hostNavigator.snapshot.value.visibleEntries)
             .containsExactly(
@@ -130,9 +122,8 @@ internal class MultiStackHostNavigatorTest {
 
     @Test
     fun `deep links passed with NavRoot and NavRoute`() {
-        val hostNavigator = underTest(
-            listOf(OtherRoot(2), SimpleRoute(3)),
-        )
+        val hostNavigator = underTest()
+        hostNavigator.handleDeepLink(listOf(OtherRoot(2), SimpleRoute(3)))
 
         assertThat(hostNavigator.snapshot.value.visibleEntries)
             .containsExactly(
@@ -162,9 +153,8 @@ internal class MultiStackHostNavigatorTest {
 
     @Test
     fun `deep links passed with multiple NavRoutes`() {
-        val hostNavigator = underTest(
-            listOf(SimpleRoute(2), SimpleRoute(3), OtherRoute(4), ThirdRoute(5)),
-        )
+        val hostNavigator = underTest()
+        hostNavigator.handleDeepLink(listOf(SimpleRoute(2), SimpleRoute(3), OtherRoute(4), ThirdRoute(5)))
 
         assertThat(hostNavigator.snapshot.value.visibleEntries)
             .containsExactly(
@@ -178,9 +168,8 @@ internal class MultiStackHostNavigatorTest {
 
     @Test
     fun `deep links passed with an ActivityRoute`() {
-        val hostNavigator = underTest(
-            listOf(SimpleActivity(2)),
-        )
+        val hostNavigator = underTest()
+        hostNavigator.handleDeepLink(listOf(SimpleActivity(2)))
 
         assertThat(hostNavigator.snapshot.value.visibleEntries)
             .containsExactly(
@@ -194,9 +183,8 @@ internal class MultiStackHostNavigatorTest {
 
     @Test
     fun `deep links passed with a NavRoute and an ActivityRoute`() {
-        val hostNavigator = underTest(
-            listOf(SimpleRoute(2), SimpleActivity(3)),
-        )
+        val hostNavigator = underTest()
+        hostNavigator.handleDeepLink(listOf(SimpleRoute(2), SimpleActivity(3)))
 
         assertThat(hostNavigator.snapshot.value.visibleEntries)
             .containsExactly(

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/TestHostNavigator.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/TestHostNavigator.kt
@@ -1,5 +1,6 @@
 package com.freeletics.khonshu.navigation.test
 
+import android.content.Intent
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import app.cash.turbine.Turbine
@@ -8,9 +9,11 @@ import com.freeletics.khonshu.navigation.BaseRoute
 import com.freeletics.khonshu.navigation.HostNavigator
 import com.freeletics.khonshu.navigation.NavRoot
 import com.freeletics.khonshu.navigation.NavRoute
+import com.freeletics.khonshu.navigation.deeplinks.DeepLinkHandler
 import com.freeletics.khonshu.navigation.internal.NavEvent
 import com.freeletics.khonshu.navigation.internal.StackSnapshot
 import kotlin.reflect.KClass
+import kotlinx.collections.immutable.ImmutableSet
 
 internal class TestHostNavigator : HostNavigator() {
 
@@ -51,5 +54,13 @@ internal class TestHostNavigator : HostNavigator() {
 
     override fun replaceAll(root: NavRoot) {
         received.add(NavEvent.ReplaceAll(root))
+    }
+
+    override fun handleDeepLink(
+        intent: Intent,
+        deepLinkHandlers: ImmutableSet<DeepLinkHandler>,
+        deepLinkPrefixes: ImmutableSet<DeepLinkHandler.Prefix>,
+    ) {
+        throw UnsupportedOperationException()
     }
 }


### PR DESCRIPTION
Decouples checking the deep links and navigating based on them from instantiating a `HostNavigator`. Instead of `createHostNavigator` find deep link routes and then passing them on to `MultiStackHostNavigator`, `HostNavigator` is now exposing a `handleDeepLink()` method that does this. `rememberHostNavigator` will still call this automatically to maintain the current functionality. However you could not pass any `DeepLinkHandlers` to it and then call `handleDeepLink` yourself later and separately. 

The main use case that we have is that we want to eagerly create a `HostNavigator` in our DI graph, but need to apply some logic to the deep link handling (like having different sets of deep links based on the logged in status). This allows us to create the `HostNavigator` and then call `handleDeepLink` once we are ready for that.