### PR TITLE
avoid ConcurrentModificationException when clearing store

### DIFF
--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackEntryStoreViewModel.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackEntryStoreViewModel.kt
@@ -19,9 +19,9 @@ internal class StackEntryStoreViewModel(
     }
 
     public override fun onCleared() {
-        for (store in stores.values) {
-            store.close()
+        while (stores.isNotEmpty()) {
+            val key = stores.firstNotNullOf { it.key }
+            stores.remove(key)?.close()
         }
-        stores.clear()
     }
 }


### PR DESCRIPTION
We're seeing a `ConcurrentModificationException` in this code. So far it only happened in Google Play pre launch report and I assume it's an edge case when a machine interacts with the app (extremely fast interactions). Since this is happening when the ViewModel is cleared and the Activity is being destroyed I just made the clearing more defensive, instead of making everything in the ViewModel thread safe.