### PR TITLE
extract Activity result and event logic

### DIFF
--- a/navigation/api/android/navigation.api
+++ b/navigation/api/android/navigation.api
@@ -5,11 +5,15 @@ public final class com/freeletics/khonshu/navigation/ActivityDestination : com/f
 	public final fun getIntent ()Landroid/content/Intent;
 }
 
-public abstract interface class com/freeletics/khonshu/navigation/ActivityResultNavigator {
-	public abstract fun navigateForResult (Lcom/freeletics/khonshu/navigation/ActivityResultRequest;)V
-	public abstract fun navigateForResult (Lcom/freeletics/khonshu/navigation/ActivityResultRequest;Ljava/lang/Object;)V
-	public abstract fun requestPermissions (Lcom/freeletics/khonshu/navigation/PermissionsResultRequest;Ljava/util/List;)V
-	public abstract fun requestPermissions (Lcom/freeletics/khonshu/navigation/PermissionsResultRequest;[Ljava/lang/String;)V
+public abstract class com/freeletics/khonshu/navigation/ActivityResultNavigator {
+	public static final field $stable I
+	public fun <init> ()V
+	public final fun navigateForResult (Lcom/freeletics/khonshu/navigation/ActivityResultRequest;)V
+	public final fun navigateForResult (Lcom/freeletics/khonshu/navigation/ActivityResultRequest;Ljava/lang/Object;)V
+	public final fun registerForActivityResult (Landroidx/activity/result/contract/ActivityResultContract;)Lcom/freeletics/khonshu/navigation/ActivityResultRequest;
+	public final fun registerForPermissionsResult ()Lcom/freeletics/khonshu/navigation/PermissionsResultRequest;
+	public final fun requestPermissions (Lcom/freeletics/khonshu/navigation/PermissionsResultRequest;Ljava/util/List;)V
+	public final fun requestPermissions (Lcom/freeletics/khonshu/navigation/PermissionsResultRequest;[Ljava/lang/String;)V
 }
 
 public final class com/freeletics/khonshu/navigation/ActivityResultRequest : com/freeletics/khonshu/navigation/ContractResultOwner {
@@ -76,18 +80,12 @@ public class com/freeletics/khonshu/navigation/NavEventNavigator : com/freeletic
 	public final fun navigate (Lkotlin/jvm/functions/Function1;)V
 	public fun navigateBack ()V
 	public fun navigateBackTo (Lkotlin/reflect/KClass;Z)V
-	public fun navigateForResult (Lcom/freeletics/khonshu/navigation/ActivityResultRequest;)V
-	public fun navigateForResult (Lcom/freeletics/khonshu/navigation/ActivityResultRequest;Ljava/lang/Object;)V
 	public fun navigateTo (Lcom/freeletics/khonshu/navigation/ActivityRoute;)V
 	public fun navigateTo (Lcom/freeletics/khonshu/navigation/NavRoute;)V
 	public fun navigateToRoot (Lcom/freeletics/khonshu/navigation/NavRoot;Z)V
 	public fun navigateUp ()V
-	protected final fun registerForActivityResult (Landroidx/activity/result/contract/ActivityResultContract;)Lcom/freeletics/khonshu/navigation/ActivityResultRequest;
 	public final fun registerForNavigationResult-UamjCxQ (Lkotlin/reflect/KClass;Ljava/lang/String;)Lcom/freeletics/khonshu/navigation/NavigationResultRequest;
-	protected final fun registerForPermissionsResult ()Lcom/freeletics/khonshu/navigation/PermissionsResultRequest;
 	public fun replaceAll (Lcom/freeletics/khonshu/navigation/NavRoot;)V
-	public fun requestPermissions (Lcom/freeletics/khonshu/navigation/PermissionsResultRequest;Ljava/util/List;)V
-	public fun requestPermissions (Lcom/freeletics/khonshu/navigation/PermissionsResultRequest;[Ljava/lang/String;)V
 	public fun resetToRoot (Lcom/freeletics/khonshu/navigation/NavRoot;)V
 }
 
@@ -126,7 +124,7 @@ public final class com/freeletics/khonshu/navigation/NavigationResultRequest$Key
 }
 
 public final class com/freeletics/khonshu/navigation/NavigationSetupKt {
-	public static final fun NavigationSetup (Lcom/freeletics/khonshu/navigation/NavEventNavigator;Landroidx/compose/runtime/Composer;I)V
+	public static final fun NavigationSetup (Lcom/freeletics/khonshu/navigation/ActivityResultNavigator;Landroidx/compose/runtime/Composer;I)V
 }
 
 public abstract interface class com/freeletics/khonshu/navigation/Navigator {

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/ActivityResultNavigator.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/ActivityResultNavigator.kt
@@ -1,0 +1,127 @@
+package com.freeletics.khonshu.navigation
+
+import androidx.activity.result.contract.ActivityResultContract
+import com.freeletics.khonshu.navigation.internal.InternalNavigationTestingApi
+import com.freeletics.khonshu.navigation.internal.NavEvent
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.receiveAsFlow
+
+/**
+ * This allows to trigger [ActivityResultContract] related navigation actions from outside t
+ * he view layer without keeping references to Android framework classes that might leak.
+ * It also improves the testability of your navigation logic since it is possible to just write
+ * test that the correct events were emitted.
+ *
+ * For this work [NavigationSetup] needs to be called.
+ */
+public abstract class ActivityResultNavigator {
+
+    private val _navEvents = Channel<NavEvent>(Channel.UNLIMITED)
+
+    @InternalNavigationTestingApi
+    public val navEvents: Flow<NavEvent> = _navEvents.receiveAsFlow()
+
+    private val _activityResultRequests = mutableListOf<ContractResultOwner<*, *, *>>()
+    internal var allowedToAddRequests = true
+
+    @InternalNavigationTestingApi
+    public val activityResultRequests: List<ContractResultOwner<*, *, *>>
+        get() {
+            allowedToAddRequests = false
+            return _activityResultRequests.toList()
+        }
+
+    /**
+     * Register for receiving activity results for the given [contract].
+     *
+     * The returned [ActivityResultRequest] can be used to collect incoming results (via
+     * [ActivityResultRequest.results]) and to launch the actual activity result call via
+     * [navigateForResult].
+     *
+     * For permission requests prefer using [registerForPermissionsResult] instead.
+     *
+     * Note: You must call this before [NavigationSetup] is called with this navigator.
+     */
+    public fun <I, O> registerForActivityResult(
+        contract: ActivityResultContract<I, O>,
+    ): ActivityResultRequest<I, O> {
+        checkAllowedToAddRequests()
+        val request = ActivityResultRequest(contract)
+        _activityResultRequests.add(request)
+        return request
+    }
+
+    /**
+     * Register for receiving permission results.
+     *
+     * The returned [PermissionsResultRequest] can be used to collect incoming permission results (via
+     * [PermissionsResultRequest.results]) and to launch the actual permission result call via
+     * [requestPermissions].
+     *
+     * Compared to using [registerForActivityResult] with
+     * [androidx.activity.result.contract.ActivityResultContracts.RequestPermission] this provides
+     * a `PermissionResult` instead of a `boolean. See `[PermissionsResultRequest.PermissionResult]`
+     * for more information.
+     *
+     * Note: You must call this before [NavigationSetup] is called with this navigator.
+     */
+    public fun registerForPermissionsResult(): PermissionsResultRequest {
+        checkAllowedToAddRequests()
+        val request = PermissionsResultRequest()
+        _activityResultRequests.add(request)
+        return request
+    }
+
+    /**
+     * Launches the given [request].
+     */
+    public fun navigateForResult(request: ActivityResultRequest<Void?, *>) {
+        navigateForResult(request, null)
+    }
+
+    /**
+     * Launches the given [request] with the given [input].
+     */
+    public fun <I> navigateForResult(request: ActivityResultRequest<I, *>, input: I) {
+        val event = NavEvent.ActivityResultEvent(request, input)
+        sendNavEvent(event)
+    }
+
+    /**
+     * Launches the [request] for the given [permissions].
+     *
+     * Compared to using [navigateForResult] with
+     * [androidx.activity.result.contract.ActivityResultContracts.RequestPermission] this provides
+     * a `PermissionResult` instead of a `boolean. See `[PermissionsResultRequest.PermissionResult]`
+     * for more information.
+     */
+    public fun requestPermissions(request: PermissionsResultRequest, vararg permissions: String) {
+        requestPermissions(request, permissions.toList())
+    }
+
+    /**
+     * Launches the [request] for the given [permissions].
+     *
+     * Compared to using [navigateForResult] with
+     * [androidx.activity.result.contract.ActivityResultContracts.RequestPermission] this provides
+     * a `PermissionResult` instead of a `boolean. See `[PermissionsResultRequest.PermissionResult]`
+     * for more information.
+     */
+    public fun requestPermissions(request: PermissionsResultRequest, permissions: List<String>) {
+        val event = NavEvent.ActivityResultEvent(request, permissions)
+        sendNavEvent(event)
+    }
+
+    internal fun sendNavEvent(event: NavEvent) {
+        val result = _navEvents.trySendBlocking(event)
+        check(result.isSuccess)
+    }
+
+    internal fun checkAllowedToAddRequests() {
+        check(allowedToAddRequests) {
+            "Failed to register for result! You must call this before NavigationSetup is called with this navigator."
+        }
+    }
+}

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavHost.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavHost.kt
@@ -52,9 +52,6 @@ public fun NavHost(
  * destinations and deep link handling are all dependent on the `navigator`. For more see
  * [rememberHostNavigator].
  *
- * If a [NavEventNavigator] is passed it will be automatically set up and can be used to
- * navigate within the `NavHost`.
- *
  * The [destinationChangedCallback] can be used to be notified when the current destination
  * changes. Note that this will not be invoked when navigating to a [ActivityDestination].
  */

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/Navigator.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/Navigator.kt
@@ -75,38 +75,6 @@ public interface ResultNavigator {
     public fun <O : Parcelable> deliverNavigationResult(key: NavigationResultRequest.Key<O>, result: O)
 }
 
-public interface ActivityResultNavigator {
-    /**
-     * Launches the given [request].
-     */
-    public fun navigateForResult(request: ActivityResultRequest<Void?, *>)
-
-    /**
-     * Launches the given [request] with the given [input].
-     */
-    public fun <I> navigateForResult(request: ActivityResultRequest<I, *>, input: I)
-
-    /**
-     * Launches the [request] for the given [permissions].
-     *
-     * Compared to using [navigateForResult] with
-     * [androidx.activity.result.contract.ActivityResultContracts.RequestPermission] this provides
-     * a `PermissionResult` instead of a `boolean. See `[PermissionsResultRequest.PermissionResult]`
-     * for more information.
-     */
-    public fun requestPermissions(request: PermissionsResultRequest, vararg permissions: String)
-
-    /**
-     * Launches the [request] for the given [permissions].
-     *
-     * Compared to using [navigateForResult] with
-     * [androidx.activity.result.contract.ActivityResultContracts.RequestPermission] this provides
-     * a `PermissionResult` instead of a `boolean. See `[PermissionsResultRequest.PermissionResult]`
-     * for more information.
-     */
-    public fun requestPermissions(request: PermissionsResultRequest, permissions: List<String>)
-}
-
 public interface BackInterceptor {
     /**
      * Returns a [Flow] that will emit [Unit] on every back press. While this Flow is being collected

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/ResultOwner.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/ResultOwner.kt
@@ -46,11 +46,11 @@ public sealed class ContractResultOwner<I, O, R> : ResultOwner<R>() {
 }
 
 /**
- * Class returned from [NavEventNavigator.registerForActivityResult].
+ * Class returned from [ActivityResultNavigator.registerForActivityResult].
  *
  * This class has two purposes:
  *  - It exposes a [results] `Flow` that can be used to observe incoming results
- *  - It can be passed to [NavEventNavigator.navigateForResult] to trigger the execution of a result
+ *  - It can be passed to [ActivityResultNavigator.navigateForResult] to trigger the execution of a result
  *    request
  */
 public class ActivityResultRequest<I, O> internal constructor(
@@ -58,11 +58,11 @@ public class ActivityResultRequest<I, O> internal constructor(
 ) : ContractResultOwner<I, O, O>()
 
 /**
- * Class returned from [NavEventNavigator.registerForPermissionsResult].
+ * Class returned from [ActivityResultNavigator.registerForPermissionsResult].
  *
  * This class has two purposes:
  *  - It exposes a `results` `Flow` that can be used to observe incoming permission results
- *  - It can be passed to [NavEventNavigator.requestPermissions] to trigger the execution of a
+ *  - It can be passed to [ActivityResultNavigator.requestPermissions] to trigger the execution of a
  *    permissions request
  *
  *  This provides extra functionality over [ActivityResultRequest] by also checking

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/ActivityResultNavigatorTest.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/ActivityResultNavigatorTest.kt
@@ -1,0 +1,70 @@
+package com.freeletics.khonshu.navigation
+
+import androidx.activity.result.contract.ActivityResultContracts
+import app.cash.turbine.test
+import com.freeletics.khonshu.navigation.internal.NavEvent
+import com.freeletics.khonshu.navigation.test.TestActivityResultNavigator
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+internal class ActivityResultNavigatorTest {
+
+    @Test
+    fun `navigateForResult event is received`(): Unit = runBlocking {
+        val navigator = TestActivityResultNavigator()
+
+        navigator.navEvents.test {
+            val launcher = navigator.testRegisterForActivityResult(ActivityResultContracts.GetContent())
+            navigator.navigateForResult(launcher, "image/*")
+
+            assertThat(awaitItem()).isEqualTo(NavEvent.ActivityResultEvent(launcher, "image/*"))
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `requestPermissions event is received`(): Unit = runBlocking {
+        val navigator = TestActivityResultNavigator()
+
+        navigator.navEvents.test {
+            val launcher = navigator.testRegisterForPermissionResult()
+            val permission = "android.permission.READ_CALENDAR"
+            navigator.requestPermissions(launcher, permission)
+
+            assertThat(awaitItem()).isEqualTo(NavEvent.ActivityResultEvent(launcher, listOf(permission)))
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `registerForActivityResult after read is disallowed`(): Unit = runBlocking {
+        val navigator = TestActivityResultNavigator()
+
+        navigator.activityResultRequests
+
+        val exception = assertThrows(IllegalStateException::class.java) {
+            navigator.testRegisterForActivityResult(ActivityResultContracts.GetContent())
+        }
+        assertThat(exception).hasMessageThat().isEqualTo(
+            "Failed to register for result! You must call this before NavigationSetup is called with this navigator.",
+        )
+    }
+
+    @Test
+    fun `registerForPermissionsResult after read is disallowed`(): Unit = runBlocking {
+        val navigator = TestActivityResultNavigator()
+
+        navigator.activityResultRequests
+
+        val exception = assertThrows(IllegalStateException::class.java) {
+            navigator.testRegisterForPermissionResult()
+        }
+        assertThat(exception).hasMessageThat().isEqualTo(
+            "Failed to register for result! You must call this before NavigationSetup is called with this navigator.",
+        )
+    }
+}

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/NavEventNavigatorTest.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/NavEventNavigatorTest.kt
@@ -11,7 +11,7 @@ import com.freeletics.khonshu.navigation.test.OtherRoute
 import com.freeletics.khonshu.navigation.test.SimpleActivity
 import com.freeletics.khonshu.navigation.test.SimpleRoot
 import com.freeletics.khonshu.navigation.test.SimpleRoute
-import com.freeletics.khonshu.navigation.test.TestNavigator
+import com.freeletics.khonshu.navigation.test.TestNavEventNavigator
 import com.freeletics.khonshu.navigation.test.TestParcelable
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.runBlocking
@@ -22,7 +22,7 @@ internal class NavEventNavigatorTest {
 
     @Test
     fun `navigateTo event is received`(): Unit = runBlocking {
-        val navigator = TestNavigator()
+        val navigator = TestNavEventNavigator()
 
         navigator.navEvents.test {
             navigator.navigateTo(SimpleRoute(1))
@@ -35,7 +35,7 @@ internal class NavEventNavigatorTest {
 
     @Test
     fun `multiple navigateTo event are received`(): Unit = runBlocking {
-        val navigator = TestNavigator()
+        val navigator = TestNavEventNavigator()
 
         navigator.navEvents.test {
             navigator.navigateTo(SimpleRoute(1))
@@ -52,7 +52,7 @@ internal class NavEventNavigatorTest {
 
     @Test
     fun `navigateToRoot event is received`(): Unit = runBlocking {
-        val navigator = TestNavigator()
+        val navigator = TestNavEventNavigator()
 
         navigator.navEvents.test {
             navigator.navigateToRoot(
@@ -73,7 +73,7 @@ internal class NavEventNavigatorTest {
 
     @Test
     fun `navigateTo Activity event is received`(): Unit = runBlocking {
-        val navigator = TestNavigator()
+        val navigator = TestNavEventNavigator()
 
         navigator.navEvents.test {
             navigator.navigateTo(SimpleActivity(1))
@@ -86,7 +86,7 @@ internal class NavEventNavigatorTest {
 
     @Test
     fun `navigateUp event is received`(): Unit = runBlocking {
-        val navigator = TestNavigator()
+        val navigator = TestNavEventNavigator()
 
         navigator.navEvents.test {
             navigator.navigateUp()
@@ -99,7 +99,7 @@ internal class NavEventNavigatorTest {
 
     @Test
     fun `navigateBack event is received`(): Unit = runBlocking {
-        val navigator = TestNavigator()
+        val navigator = TestNavEventNavigator()
 
         navigator.navEvents.test {
             navigator.navigateBack()
@@ -112,7 +112,7 @@ internal class NavEventNavigatorTest {
 
     @Test
     fun `navigateBackTo event is received`(): Unit = runBlocking {
-        val navigator = TestNavigator()
+        val navigator = TestNavEventNavigator()
 
         navigator.navEvents.test {
             navigator.navigateBackTo<SimpleRoute>(true)
@@ -127,7 +127,7 @@ internal class NavEventNavigatorTest {
 
     @Test
     fun `resetToRoot event is received`(): Unit = runBlocking {
-        val navigator = TestNavigator()
+        val navigator = TestNavEventNavigator()
 
         navigator.navEvents.test {
             navigator.resetToRoot(
@@ -146,7 +146,7 @@ internal class NavEventNavigatorTest {
 
     @Test
     fun `replaceAll event is received`(): Unit = runBlocking {
-        val navigator = TestNavigator()
+        val navigator = TestNavEventNavigator()
 
         navigator.navEvents.test {
             navigator.replaceAll(
@@ -165,7 +165,7 @@ internal class NavEventNavigatorTest {
 
     @Test
     fun `navigateForResult event is received`(): Unit = runBlocking {
-        val navigator = TestNavigator()
+        val navigator = TestNavEventNavigator()
 
         navigator.navEvents.test {
             val launcher = navigator.testRegisterForActivityResult(ActivityResultContracts.GetContent())
@@ -179,7 +179,7 @@ internal class NavEventNavigatorTest {
 
     @Test
     fun `requestPermissions event is received`(): Unit = runBlocking {
-        val navigator = TestNavigator()
+        val navigator = TestNavEventNavigator()
 
         navigator.navEvents.test {
             val launcher = navigator.testRegisterForPermissionResult()
@@ -194,7 +194,7 @@ internal class NavEventNavigatorTest {
 
     @Test
     fun `deliverResult event is received`(): Unit = runBlocking {
-        val navigator = TestNavigator()
+        val navigator = TestNavEventNavigator()
 
         navigator.navEvents.test {
             val launcher = navigator.testRegisterForNavigationResult<SimpleRoute, TestParcelable>()
@@ -210,7 +210,7 @@ internal class NavEventNavigatorTest {
 
     @Test
     fun `navigate event with multiple nav directions is received`(): Unit = runBlocking {
-        val navigator = TestNavigator()
+        val navigator = TestNavEventNavigator()
 
         navigator.navEvents.test {
             navigator.navigate {
@@ -235,7 +235,7 @@ internal class NavEventNavigatorTest {
 
     @Test
     fun `backPresses sends out events`(): Unit = runBlocking {
-        val navigator = TestNavigator()
+        val navigator = TestNavEventNavigator()
 
         assertThat(navigator.onBackPressedCallback.isEnabled).isFalse()
 
@@ -258,7 +258,7 @@ internal class NavEventNavigatorTest {
 
     @Test
     fun `registerForActivityResult after read is disallowed`(): Unit = runBlocking {
-        val navigator = TestNavigator()
+        val navigator = TestNavEventNavigator()
 
         navigator.activityResultRequests
 
@@ -272,7 +272,7 @@ internal class NavEventNavigatorTest {
 
     @Test
     fun `registerForPermissionsResult after read is disallowed`(): Unit = runBlocking {
-        val navigator = TestNavigator()
+        val navigator = TestNavEventNavigator()
 
         navigator.activityResultRequests
 
@@ -286,7 +286,7 @@ internal class NavEventNavigatorTest {
 
     @Test
     fun `registerForNavigationResult after read is disallowed`(): Unit = runBlocking {
-        val navigator = TestNavigator()
+        val navigator = TestNavEventNavigator()
 
         navigator.navigationResultRequests
 

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/NavigationSetupTest.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/NavigationSetupTest.kt
@@ -1,6 +1,5 @@
 package com.freeletics.khonshu.navigation
 
-import android.os.Parcelable
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.lifecycle.Lifecycle
@@ -10,13 +9,14 @@ import app.cash.turbine.test
 import com.freeletics.khonshu.navigation.Navigator.Companion.navigateBackTo
 import com.freeletics.khonshu.navigation.PermissionsResultRequest.PermissionResult
 import com.freeletics.khonshu.navigation.internal.NavEvent
+import com.freeletics.khonshu.navigation.internal.Parcelable
 import com.freeletics.khonshu.navigation.internal.StackSnapshot
 import com.freeletics.khonshu.navigation.test.SimpleActivity
 import com.freeletics.khonshu.navigation.test.SimpleRoot
 import com.freeletics.khonshu.navigation.test.SimpleRoute
 import com.freeletics.khonshu.navigation.test.TestActivityResultLauncher
 import com.freeletics.khonshu.navigation.test.TestHostNavigator
-import com.freeletics.khonshu.navigation.test.TestNavigator
+import com.freeletics.khonshu.navigation.test.TestNavEventNavigator
 import com.freeletics.khonshu.navigation.test.TestParcelable
 import com.freeletics.khonshu.navigation.test.TestStackEntryFactory
 import com.google.common.truth.Truth.assertThat
@@ -36,7 +36,7 @@ import org.junit.Test
 
 internal class NavigationSetupTest {
 
-    private val navigator = TestNavigator()
+    private val navigator = TestNavEventNavigator()
     private val hostNavigator = TestHostNavigator()
     private val resultRequest = navigator.testRegisterForNavigationResult<SimpleRoute, TestParcelable>()
     private val activityRequest = navigator.testRegisterForActivityResult(ActivityResultContracts.GetContent())
@@ -237,7 +237,7 @@ internal class NavigationSetupTest {
     }
 
     @Test
-    fun `ActivityResultEvent throws exception if `() = runBlocking {
+    fun `ActivityResultEvent throws exception if no launcher was registered`() = runBlocking {
         navigator.navigateForResult(activityRequest, "")
         val exception = assertThrows(IllegalStateException::class.java) {
             runBlocking {

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/TestActivityResultNavigator.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/TestActivityResultNavigator.kt
@@ -1,24 +1,16 @@
 package com.freeletics.khonshu.navigation.test
 
-import android.os.Parcelable
 import androidx.activity.result.contract.ActivityResultContract
+import com.freeletics.khonshu.navigation.ActivityResultNavigator
 import com.freeletics.khonshu.navigation.ActivityResultRequest
-import com.freeletics.khonshu.navigation.BaseRoute
-import com.freeletics.khonshu.navigation.NavEventNavigator
-import com.freeletics.khonshu.navigation.NavigationResultRequest
 import com.freeletics.khonshu.navigation.PermissionsResultRequest
 
-internal class TestNavigator : NavEventNavigator() {
+internal class TestActivityResultNavigator : ActivityResultNavigator() {
     fun <I, O> testRegisterForActivityResult(contract: ActivityResultContract<I, O>): ActivityResultRequest<I, O> {
         return registerForActivityResult(contract)
     }
 
     fun testRegisterForPermissionResult(): PermissionsResultRequest {
         return registerForPermissionsResult()
-    }
-
-    inline fun <reified I : BaseRoute, reified O : Parcelable>
-    testRegisterForNavigationResult(): NavigationResultRequest<O> {
-        return registerForNavigationResult<I, O>()
     }
 }

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/TestNavEventNavigator.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/TestNavEventNavigator.kt
@@ -1,0 +1,24 @@
+package com.freeletics.khonshu.navigation.test
+
+import android.os.Parcelable
+import androidx.activity.result.contract.ActivityResultContract
+import com.freeletics.khonshu.navigation.ActivityResultRequest
+import com.freeletics.khonshu.navigation.BaseRoute
+import com.freeletics.khonshu.navigation.NavEventNavigator
+import com.freeletics.khonshu.navigation.NavigationResultRequest
+import com.freeletics.khonshu.navigation.PermissionsResultRequest
+
+internal class TestNavEventNavigator : NavEventNavigator() {
+    fun <I, O> testRegisterForActivityResult(contract: ActivityResultContract<I, O>): ActivityResultRequest<I, O> {
+        return registerForActivityResult(contract)
+    }
+
+    fun testRegisterForPermissionResult(): PermissionsResultRequest {
+        return registerForPermissionsResult()
+    }
+
+    inline fun <reified I : BaseRoute, reified O : Parcelable>
+    testRegisterForNavigationResult(): NavigationResultRequest<O> {
+        return registerForNavigationResult<I, O>()
+    }
+}


### PR DESCRIPTION
Background info:
- With the introduction of `HostNavigator` regular navigation does not require nav events anymore
- Activity results will always need them because we need to create the launchers and we wouldn't want to do that globally for any possible contract that an app needs.
    - A small exception could be the permission logic, we could have the `PermissionResultContract` in the `HostNavigator` and create a launcher in the `Activity` and then don't need it separately in each destination that needs permission requests. However even that would still require nav events.

Based on that this exctracts the event logic and required code for activity results to `ActivityResultNavigator`. `NavEventNavigator` extends that so from a consumer perspective nothing really changes. This will then allow having a destination level `Navigator` class that doesn't use nav events for anything else but instead delegates to `HostNavigator` for regular navigation.