### PR TITLE
add navigate {} to HostNavigator, make MultiNavEvent more efficient

### DIFF
--- a/navigation/api/android/navigation.api
+++ b/navigation/api/android/navigation.api
@@ -44,6 +44,7 @@ public abstract interface class com/freeletics/khonshu/navigation/ExternalActivi
 public abstract class com/freeletics/khonshu/navigation/HostNavigator : com/freeletics/khonshu/navigation/Navigator {
 	public static final field $stable I
 	public abstract fun handleDeepLink (Landroid/content/Intent;Lkotlinx/collections/immutable/ImmutableSet;Lkotlinx/collections/immutable/ImmutableSet;)V
+	public abstract fun navigate (Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class com/freeletics/khonshu/navigation/HostNavigatorKt {

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/HostNavigator.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/HostNavigator.kt
@@ -32,6 +32,13 @@ public abstract class HostNavigator internal constructor() : Navigator {
         deepLinkHandlers: ImmutableSet<DeepLinkHandler>,
         deepLinkPrefixes: ImmutableSet<DeepLinkHandler.Prefix>,
     )
+
+    /**
+     * Allows to group multiple navigation actions and execute them atomically. The state of this [HostNavigator] will
+     * only be updated after running all actions. This should be used when navigating multiple times, for example
+     * calling `navigateBackTo` followed by `navigateTo`.
+     */
+    public abstract fun navigate(block: Navigator.() -> Unit)
 }
 
 /**

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStack.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStack.kt
@@ -42,21 +42,23 @@ internal class MultiStack(
         stack.rootEntry.close()
     }
 
-    private fun updateVisibleDestinations() {
-        snapshotState.value = currentStack.snapshot(startStack.id)
+    internal fun updateVisibleDestinations(notify: Boolean) {
+        if (notify) {
+            snapshotState.value = currentStack.snapshot(startStack.id)
+        }
     }
 
-    fun push(route: NavRoute) {
+    fun push(route: NavRoute, notify: Boolean = true) {
         currentStack.push(route)
-        updateVisibleDestinations()
+        updateVisibleDestinations(notify)
     }
 
-    fun popCurrentStack() {
+    fun popCurrentStack(notify: Boolean = true) {
         currentStack.pop()
-        updateVisibleDestinations()
+        updateVisibleDestinations(notify)
     }
 
-    fun pop() {
+    fun pop(notify: Boolean = true) {
         if (currentStack.isAtRoot) {
             check(currentStack.id != startStack.id) {
                 "Can't navigate back from the root of the start back stack"
@@ -69,18 +71,19 @@ internal class MultiStack(
         } else {
             currentStack.pop()
         }
-        updateVisibleDestinations()
+        updateVisibleDestinations(notify)
     }
 
     fun <T : BaseRoute> popUpTo(
         destinationId: DestinationId<T>,
         isInclusive: Boolean,
+        notify: Boolean = true,
     ) {
         currentStack.popUpTo(destinationId, isInclusive)
-        updateVisibleDestinations()
+        updateVisibleDestinations(notify)
     }
 
-    fun push(root: NavRoot, clearTargetStack: Boolean) {
+    fun push(root: NavRoot, clearTargetStack: Boolean, notify: Boolean = true) {
         val stack = getBackStack(root)
         currentStack = if (stack != null) {
             check(currentStack.id != stack.id) {
@@ -98,10 +101,10 @@ internal class MultiStack(
         if (stack?.id == startStack.id) {
             startStack = currentStack
         }
-        updateVisibleDestinations()
+        updateVisibleDestinations(notify)
     }
 
-    fun resetToRoot(root: NavRoot) {
+    fun resetToRoot(root: NavRoot, notify: Boolean = true) {
         if (root.destinationId == startStack.id) {
             if (currentStack.id != startStack.id) {
                 removeBackStack(currentStack)
@@ -117,10 +120,10 @@ internal class MultiStack(
         } else {
             error("$root is not on the current back stack")
         }
-        updateVisibleDestinations()
+        updateVisibleDestinations(notify)
     }
 
-    fun replaceAll(root: NavRoot) {
+    fun replaceAll(root: NavRoot, notify: Boolean = true) {
         // remove all stacks
         while (allStacks.isNotEmpty()) {
             removeBackStack(allStacks.last())
@@ -131,7 +134,7 @@ internal class MultiStack(
         startStack = newStack
         currentStack = newStack
 
-        updateVisibleDestinations()
+        updateVisibleDestinations(notify)
     }
 
     fun saveState(): Bundle {

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackHostNavigator.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackHostNavigator.kt
@@ -8,6 +8,7 @@ import com.freeletics.khonshu.navigation.BaseRoute
 import com.freeletics.khonshu.navigation.HostNavigator
 import com.freeletics.khonshu.navigation.NavRoot
 import com.freeletics.khonshu.navigation.NavRoute
+import com.freeletics.khonshu.navigation.Navigator
 import com.freeletics.khonshu.navigation.deeplinks.DeepLinkHandler
 import com.freeletics.khonshu.navigation.deeplinks.extractDeepLinkRoutes
 import kotlin.reflect.KClass
@@ -97,7 +98,50 @@ internal class MultiStackHostNavigator(
         stack.replaceAll(root)
     }
 
+    override fun navigate(block: Navigator.() -> Unit) {
+        val nonNotifyingNavigator = NonNotifyingNavigator()
+        nonNotifyingNavigator.apply(block)
+        stack.updateVisibleDestinations(true)
+        nonNotifyingNavigator.activityRoutes.forEach { activityStarter(it) }
+    }
+
     internal companion object {
         const val SAVED_STATE_STACK = "com.freeletics.khonshu.navigation.stack"
+    }
+
+    private inner class NonNotifyingNavigator : Navigator {
+        val activityRoutes = mutableListOf<ActivityRoute>()
+
+        override fun navigateTo(route: NavRoute) {
+            stack.push(route, notify = false)
+        }
+
+        override fun navigateTo(route: ActivityRoute) {
+            activityRoutes += route
+        }
+
+        override fun navigateToRoot(root: NavRoot, restoreRootState: Boolean) {
+            stack.push(root, clearTargetStack = !restoreRootState, notify = false)
+        }
+
+        override fun navigateUp() {
+            stack.popCurrentStack(notify = false)
+        }
+
+        override fun navigateBack() {
+            stack.pop(notify = false)
+        }
+
+        override fun <T : BaseRoute> navigateBackTo(popUpTo: KClass<T>, inclusive: Boolean) {
+            stack.popUpTo(DestinationId(popUpTo), inclusive, notify = false)
+        }
+
+        override fun resetToRoot(root: NavRoot) {
+            stack.resetToRoot(root, notify = false)
+        }
+
+        override fun replaceAll(root: NavRoot) {
+            stack.replaceAll(root, notify = false)
+        }
     }
 }

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackSnapshot.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackSnapshot.kt
@@ -1,5 +1,6 @@
 package com.freeletics.khonshu.navigation.internal
 
+import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.Immutable
 import com.freeletics.khonshu.navigation.BaseRoute
 import com.freeletics.khonshu.navigation.OverlayDestination
@@ -9,7 +10,8 @@ import dev.drewhamilton.poko.Poko
 @Immutable
 @InternalNavigationCodegenApi
 public class StackSnapshot internal constructor(
-    private val entries: List<StackEntry<*>>,
+    @get:VisibleForTesting
+    internal val entries: List<StackEntry<*>>,
     private val startStack: Boolean,
 ) {
     private var firstVisibleIndex: Int = -1

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/NavigationSetupTest.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/NavigationSetupTest.kt
@@ -197,13 +197,15 @@ internal class NavigationSetupTest {
         }
 
         assertThat(hostNavigator.received.awaitItem())
-            .isEqualTo(NavEvent.BackToEvent(SimpleRoute::class, inclusive = true))
-
-        assertThat(hostNavigator.received.awaitItem())
-            .isEqualTo(NavEvent.NavigateToEvent(SimpleRoute(1)))
-
-        assertThat(hostNavigator.received.awaitItem())
-            .isEqualTo(NavEvent.BackEvent)
+            .isEqualTo(
+                NavEvent.MultiNavEvent(
+                    listOf(
+                        NavEvent.BackToEvent(SimpleRoute::class, inclusive = true),
+                        NavEvent.NavigateToEvent(SimpleRoute(1)),
+                        NavEvent.BackEvent,
+                    ),
+                ),
+            )
     }
 
     @Test

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackHostNavigatorTest.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackHostNavigatorTest.kt
@@ -2,6 +2,7 @@ package com.freeletics.khonshu.navigation.internal
 
 import androidx.lifecycle.SavedStateHandle
 import com.freeletics.khonshu.navigation.ActivityRoute
+import com.freeletics.khonshu.navigation.Navigator.Companion.navigateBackTo
 import com.freeletics.khonshu.navigation.test.OtherRoot
 import com.freeletics.khonshu.navigation.test.OtherRoute
 import com.freeletics.khonshu.navigation.test.SimpleActivity
@@ -958,5 +959,42 @@ internal class MultiStackHostNavigatorTest {
             StackEntry.Id("102"),
             StackEntry.Id("101"),
         ).inOrder()
+    }
+
+    @Test
+    fun `navigate with block only updates state at the end`() {
+        val hostNavigator = underTest()
+
+        assertThat(hostNavigator.snapshot.value.entries).hasSize(1)
+
+        hostNavigator.navigate {
+            navigateTo(SimpleRoute(2))
+            assertThat(hostNavigator.snapshot.value.entries).hasSize(1)
+            navigateTo(OtherRoute(3))
+            assertThat(hostNavigator.snapshot.value.entries).hasSize(1)
+            navigateTo(ThirdRoute(4))
+            assertThat(hostNavigator.snapshot.value.entries).hasSize(1)
+            navigateTo(ThirdRoute(5))
+            assertThat(hostNavigator.snapshot.value.entries).hasSize(1)
+            navigateTo(ThirdRoute(6))
+
+            navigateTo(SimpleActivity(7))
+            assertThat(started).isEmpty()
+
+            assertThat(hostNavigator.snapshot.value.entries).hasSize(1)
+            navigateBack()
+            assertThat(hostNavigator.snapshot.value.entries).hasSize(1)
+            navigateUp()
+            assertThat(hostNavigator.snapshot.value.entries).hasSize(1)
+
+            navigateBackTo<OtherRoute>(inclusive = true)
+            assertThat(hostNavigator.snapshot.value.entries).hasSize(1)
+
+            navigateTo(SimpleActivity(8))
+            assertThat(started).isEmpty()
+        }
+
+        assertThat(hostNavigator.snapshot.value.entries).hasSize(2)
+        assertThat(started).containsExactly(SimpleActivity(7), SimpleActivity(8))
     }
 }

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/TestHostNavigator.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/TestHostNavigator.kt
@@ -9,8 +9,10 @@ import com.freeletics.khonshu.navigation.BaseRoute
 import com.freeletics.khonshu.navigation.HostNavigator
 import com.freeletics.khonshu.navigation.NavRoot
 import com.freeletics.khonshu.navigation.NavRoute
+import com.freeletics.khonshu.navigation.Navigator
 import com.freeletics.khonshu.navigation.deeplinks.DeepLinkHandler
 import com.freeletics.khonshu.navigation.internal.NavEvent
+import com.freeletics.khonshu.navigation.internal.NavEventCollector
 import com.freeletics.khonshu.navigation.internal.StackSnapshot
 import kotlin.reflect.KClass
 import kotlinx.collections.immutable.ImmutableSet
@@ -54,6 +56,11 @@ internal class TestHostNavigator : HostNavigator() {
 
     override fun replaceAll(root: NavRoot) {
         received.add(NavEvent.ReplaceAll(root))
+    }
+
+    override fun navigate(block: Navigator.() -> Unit) {
+        val events = NavEventCollector().apply(block).navEvents
+        received.add(NavEvent.MultiNavEvent(events))
     }
 
     override fun handleDeepLink(


### PR DESCRIPTION
Currently when receiving a `MultiNavEvent` we execute each navigation action in their one by one. Each action will cause the `State` of the `HostNavigator` to be updated which can cause re-composition and UI updates while we are still making more navigation actions. This adds a `navigate {}` to `HostNavigator` which will not update the state for the individual actions, only at the end. It will also wait until the end to start any `Activity` that might have been part of the MultiNavEvent so that the local state is correct before we leave the current `Activity`.