### PR TITLE
make HostNavigator impelement BackInterceptor

### DIFF
--- a/navigation/api/android/navigation.api
+++ b/navigation/api/android/navigation.api
@@ -30,7 +30,7 @@ public final class com/freeletics/khonshu/navigation/ActivityRouteKt {
 }
 
 public abstract interface class com/freeletics/khonshu/navigation/BackInterceptor {
-	public abstract fun backPresses ()Lkotlinx/coroutines/flow/Flow;
+	public fun backPresses ()Lkotlinx/coroutines/flow/Flow;
 	public abstract fun backPresses (Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 }
 
@@ -45,7 +45,7 @@ public abstract interface class com/freeletics/khonshu/navigation/ExternalActivi
 	public fun fillInIntent ()Landroid/content/Intent;
 }
 
-public abstract class com/freeletics/khonshu/navigation/HostNavigator : com/freeletics/khonshu/navigation/Navigator, com/freeletics/khonshu/navigation/ResultNavigator {
+public abstract class com/freeletics/khonshu/navigation/HostNavigator : com/freeletics/khonshu/navigation/BackInterceptor, com/freeletics/khonshu/navigation/Navigator, com/freeletics/khonshu/navigation/ResultNavigator {
 	public static final field $stable I
 	public abstract fun handleDeepLink (Landroid/content/Intent;Lkotlinx/collections/immutable/ImmutableSet;Lkotlinx/collections/immutable/ImmutableSet;)V
 	public abstract fun navigate (Lkotlin/jvm/functions/Function1;)V
@@ -75,7 +75,6 @@ public abstract interface class com/freeletics/khonshu/navigation/NavDestination
 public class com/freeletics/khonshu/navigation/NavEventNavigator : com/freeletics/khonshu/navigation/ActivityResultNavigator, com/freeletics/khonshu/navigation/BackInterceptor, com/freeletics/khonshu/navigation/Navigator, com/freeletics/khonshu/navigation/ResultNavigator {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun backPresses ()Lkotlinx/coroutines/flow/Flow;
 	public fun backPresses (Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public fun deliverNavigationResult (Lcom/freeletics/khonshu/navigation/NavigationResultRequest$Key;Landroid/os/Parcelable;)V
 	public final fun navigate (Lkotlin/jvm/functions/Function1;)V

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/HostNavigator.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/HostNavigator.kt
@@ -1,6 +1,7 @@
 package com.freeletics.khonshu.navigation
 
 import android.content.Intent
+import androidx.activity.OnBackPressedCallback
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.remember
@@ -19,8 +20,9 @@ import kotlinx.collections.immutable.persistentSetOf
  *
  * An instance can be created by calling [createHostNavigator].
  */
-public abstract class HostNavigator internal constructor() : Navigator, ResultNavigator {
+public abstract class HostNavigator internal constructor() : Navigator, ResultNavigator, BackInterceptor {
     internal abstract val snapshot: State<StackSnapshot>
+    internal abstract val onBackPressedCallback: OnBackPressedCallback
 
     /**
      * If the given [Intent] was created from a [DeepLink] or the `Uri` returned by [Intent.getData]

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavEventNavigator.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavEventNavigator.kt
@@ -132,16 +132,6 @@ public open class NavEventNavigator : Navigator, ResultNavigator, ActivityResult
     }
 
     /**
-     * Returns a [Flow] that will emit [Unit] on every back press. While this Flow is being collected
-     * all back presses will be intercepted and none of the default back press handling happens.
-     *
-     * When this is called multiple times only the latest caller will receive emissions.
-     */
-    override fun backPresses(): Flow<Unit> {
-        return backPresses(Unit)
-    }
-
-    /**
      * Returns a [Flow] that will emit [value] on every back press. While this Flow is being collected
      * all back presses will be intercepted and none of the default back press handling happens.
      *

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavHost.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavHost.kt
@@ -111,7 +111,7 @@ internal class SaveableCloseable(
 }
 
 @Composable
-private fun SystemBackHandling(snapshot: StackSnapshot, navigator: Navigator) {
+private fun SystemBackHandling(snapshot: StackSnapshot, navigator: HostNavigator) {
     val backPressedDispatcher = requireNotNull(LocalOnBackPressedDispatcherOwner.current) {
         "No OnBackPressedDispatcher available"
     }
@@ -131,9 +131,11 @@ private fun SystemBackHandling(snapshot: StackSnapshot, navigator: Navigator) {
 
     DisposableEffect(backPressedDispatcher, callback) {
         backPressedDispatcher.onBackPressedDispatcher.addCallback(callback)
+        backPressedDispatcher.onBackPressedDispatcher.addCallback(navigator.onBackPressedCallback)
 
         onDispose {
             callback.remove()
+            navigator.onBackPressedCallback.remove()
         }
     }
 }

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/Navigator.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/Navigator.kt
@@ -111,7 +111,7 @@ public interface BackInterceptor {
      *
      * When this is called multiple times only the latest caller will receive emissions.
      */
-    public fun backPresses(): Flow<Unit>
+    public fun backPresses(): Flow<Unit> = backPresses(Unit)
 
     /**
      * Returns a [Flow] that will emit [value] on every back press. While this Flow is being collected

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/DelegatingOnBackPressedCallback.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/DelegatingOnBackPressedCallback.kt
@@ -2,16 +2,19 @@ package com.freeletics.khonshu.navigation.internal
 
 import androidx.activity.OnBackPressedCallback
 
-internal class DelegatingOnBackPressedCallback : OnBackPressedCallback(false) {
+@InternalNavigationApi
+public class DelegatingOnBackPressedCallback : OnBackPressedCallback(false) {
 
     private val callbacks = mutableListOf<() -> Unit>()
 
-    fun addCallback(callback: () -> Unit) {
+    @InternalNavigationApi
+    public fun addCallback(callback: () -> Unit) {
         callbacks.add(callback)
         isEnabled = true
     }
 
-    fun removeCallback(callback: () -> Unit) {
+    @InternalNavigationApi
+    public fun removeCallback(callback: () -> Unit) {
         callbacks.remove(callback)
         isEnabled = callbacks.isNotEmpty()
     }

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackHostNavigator.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackHostNavigator.kt
@@ -133,7 +133,7 @@ internal class MultiStackHostNavigator(
             }
         }
     }
-    
+
     override fun navigate(block: Navigator.() -> Unit) {
         val nonNotifyingNavigator = NonNotifyingNavigator()
         nonNotifyingNavigator.apply(block)

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/TestHostNavigator.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/TestHostNavigator.kt
@@ -2,6 +2,7 @@ package com.freeletics.khonshu.navigation.test
 
 import android.content.Intent
 import android.os.Parcelable
+import androidx.activity.OnBackPressedCallback
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import app.cash.turbine.Turbine
@@ -20,6 +21,7 @@ import com.freeletics.khonshu.navigation.internal.NavEventCollector
 import com.freeletics.khonshu.navigation.internal.StackSnapshot
 import kotlin.reflect.KClass
 import kotlinx.collections.immutable.ImmutableSet
+import kotlinx.coroutines.flow.Flow
 
 internal class TestHostNavigator : HostNavigator() {
 
@@ -84,6 +86,17 @@ internal class TestHostNavigator : HostNavigator() {
         id: DestinationId<T>,
         resultType: String,
     ): NavigationResultRequest<O> {
+        throw UnsupportedOperationException()
+    }
+
+    override val onBackPressedCallback: OnBackPressedCallback
+        get() = throw UnsupportedOperationException()
+
+    override fun backPresses(): Flow<Unit> {
+        throw UnsupportedOperationException()
+    }
+
+    override fun <T> backPresses(value: T): Flow<T> {
         throw UnsupportedOperationException()
     }
 }


### PR DESCRIPTION
This is the last piece of functionality that is made independent of nav events. With this it's possible to directly use `HostNavigator` for intercepting back.