### PR TITLE
introduce DestinationNavigator as replacement for NavEventNavigator

### DIFF
--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationCodegenTest.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationCodegenTest.kt
@@ -2,6 +2,7 @@
 
 package com.freeletics.khonshu.codegen.codegen
 
+import com.freeletics.khonshu.codegen.ActivityScope
 import com.freeletics.khonshu.codegen.AppScope
 import com.freeletics.khonshu.codegen.ComposableParameter
 import com.freeletics.khonshu.codegen.NavDestinationData
@@ -219,7 +220,7 @@ internal class NavDestinationCodegenTest {
         )
         val withDefaultValues = data.copy(
             scope = navigation.route,
-            parentScope = AppScope::class.asClassName(),
+            parentScope = ActivityScope::class.asClassName(),
             navigation = navigation,
         )
 
@@ -250,6 +251,7 @@ internal class NavDestinationCodegenTest {
             import androidx.compose.runtime.remember
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.lifecycle.SavedStateHandle
+            import com.freeletics.khonshu.codegen.ActivityScope
             import com.freeletics.khonshu.codegen.AppScope
             import com.freeletics.khonshu.codegen.`internal`.ActivityComponentProvider
             import com.freeletics.khonshu.codegen.`internal`.ComponentProvider
@@ -283,7 +285,7 @@ internal class NavDestinationCodegenTest {
             @SingleIn(TestRoute::class)
             @ContributesSubcomponent(
               scope = TestRoute::class,
-              parentScope = AppScope::class,
+              parentScope = ActivityScope::class,
             )
             public interface KhonshuTestComponent : Closeable {
               public val testStateMachine: TestStateMachine
@@ -306,7 +308,7 @@ internal class NavDestinationCodegenTest {
                     @BindsInstance testRoute: TestRoute): KhonshuTestComponent
               }
 
-              @ContributesTo(AppScope::class)
+              @ContributesTo(ActivityScope::class)
               public interface ParentComponent {
                 public fun khonshuTestComponentFactory(): Factory
               }
@@ -319,7 +321,7 @@ internal class NavDestinationCodegenTest {
                 entry: StackEntry<TestRoute>,
                 snapshot: StackSnapshot,
                 provider: ActivityComponentProvider,
-              ): KhonshuTestComponent = component(entry, provider, AppScope::class) { parentComponent:
+              ): KhonshuTestComponent = component(entry, provider, ActivityScope::class) { parentComponent:
                   KhonshuTestComponent.ParentComponent ->
                 parentComponent.khonshuTestComponentFactory().create(entry.savedStateHandle, entry.route)
               }

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/AnvilParser.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/AnvilParser.kt
@@ -64,7 +64,7 @@ internal fun TopLevelFunctionReference.toNavDestinationData(annotation: Annotati
         baseName = name,
         packageName = packageName,
         scope = annotation.route,
-        parentScope = annotation.parentScope,
+        parentScope = annotation.getParentScope(activityScope),
         stateMachine = stateMachine.asClassName(),
         navigation = navigation,
         composableParameter = getInjectedParameters(stateParameter, actionParameter),
@@ -89,7 +89,7 @@ internal fun TopLevelFunctionReference.toNavHostActivityData(annotation: Annotat
         baseName = name,
         packageName = packageName,
         scope = annotation.scope,
-        parentScope = annotation.parentScope,
+        parentScope = annotation.getParentScope(appScope),
         stateMachine = stateMachine.asClassName(),
         activityBaseClass = annotation.activityBaseClass,
         navHostParameter = navHostParameter,
@@ -108,8 +108,9 @@ private val AnnotationReference.route: ClassName
 private val AnnotationReference.routeReference: ClassReference
     get() = requireClassReferenceArgument("route", 0)
 
-private val AnnotationReference.parentScope: ClassName
-    get() = parentScopeReference?.asClassName() ?: appScope
+private fun AnnotationReference.getParentScope(default: ClassName): ClassName {
+    return parentScopeReference?.asClassName() ?: default
+}
 
 private val AnnotationReference.parentScopeReference: ClassReference?
     get() = optionalClassReferenceArgument("parentScope", 1)

--- a/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/NavDestination.kt
+++ b/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/NavDestination.kt
@@ -19,7 +19,7 @@ import kotlin.reflect.KClass
 @Retention(AnnotationRetention.RUNTIME)
 public annotation class NavDestination(
     val route: KClass<out BaseRoute>,
-    val parentScope: KClass<*> = AppScope::class,
+    val parentScope: KClass<*> = ActivityScope::class,
     val stateMachine: KClass<out StateMachine<*, *>>,
     val destinationScope: KClass<*> = AppScope::class,
 )

--- a/docs/codegen/get-started.md
+++ b/docs/codegen/get-started.md
@@ -196,7 +196,7 @@ internal class ExampleStateMachine @Inject constructor(
 // make ExampleNavigator available as NavEventNavigator so that the generated code can automatically
 // set up the navigation handling
 @ContributesBinding(ExampleRoute::class, ActivityResultNavigator::class)
-class ExampleNavigator @Inject constructor() : NavEventNavigator() {
+class ExampleNavigator @Inject constructor(hostNavigator: HostNavigator) : DestinationNavigator(hostNavigator) {
     // ...
 }
 ```

--- a/navigation/api/android/navigation.api
+++ b/navigation/api/android/navigation.api
@@ -41,6 +41,22 @@ public abstract class com/freeletics/khonshu/navigation/ContractResultOwner : co
 	public static final field $stable I
 }
 
+public abstract class com/freeletics/khonshu/navigation/DestinationNavigator : com/freeletics/khonshu/navigation/ActivityResultNavigator, com/freeletics/khonshu/navigation/BackInterceptor, com/freeletics/khonshu/navigation/Navigator, com/freeletics/khonshu/navigation/ResultNavigator {
+	public static final field $stable I
+	public fun <init> (Lcom/freeletics/khonshu/navigation/HostNavigator;)V
+	public fun backPresses ()Lkotlinx/coroutines/flow/Flow;
+	public fun backPresses (Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public fun deliverNavigationResult (Lcom/freeletics/khonshu/navigation/NavigationResultRequest$Key;Landroid/os/Parcelable;)V
+	public fun navigateBack ()V
+	public fun navigateBackTo (Lkotlin/reflect/KClass;Z)V
+	public fun navigateTo (Lcom/freeletics/khonshu/navigation/ActivityRoute;)V
+	public fun navigateTo (Lcom/freeletics/khonshu/navigation/NavRoute;)V
+	public fun navigateToRoot (Lcom/freeletics/khonshu/navigation/NavRoot;Z)V
+	public fun navigateUp ()V
+	public fun replaceAll (Lcom/freeletics/khonshu/navigation/NavRoot;)V
+	public fun resetToRoot (Lcom/freeletics/khonshu/navigation/NavRoot;)V
+}
+
 public abstract interface class com/freeletics/khonshu/navigation/ExternalActivityRoute : com/freeletics/khonshu/navigation/ActivityRoute {
 	public fun fillInIntent ()Landroid/content/Intent;
 }

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/DestinationNavigator.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/DestinationNavigator.kt
@@ -1,0 +1,9 @@
+package com.freeletics.khonshu.navigation
+
+/**
+ * A combination of [Navigator] and [ActivityResultNavigator] that can
+ * be used as base class for navigators of individual screens.
+ */
+public abstract class DestinationNavigator(
+    navigator: HostNavigator,
+) : Navigator by navigator, ResultNavigator by navigator, BackInterceptor by navigator, ActivityResultNavigator()

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/HostNavigator.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/HostNavigator.kt
@@ -18,7 +18,7 @@ import kotlinx.collections.immutable.persistentSetOf
 /**
  * An implementation of [Navigator] that is meant to be used at the [NavHost] level.
  *
- * An instance can be created by calling [createHostNavigator].
+ * An instance can be created by calling [rememberHostNavigator].
  */
 public abstract class HostNavigator internal constructor() : Navigator, ResultNavigator, BackInterceptor {
     internal abstract val snapshot: State<StackSnapshot>

--- a/sample/simple/feature/bottom-sheet/implementation/src/main/kotlin/kotlin/com/freeletics/khonshu/sample/feature/bottomsheet/BottomSheetNavigator.kt
+++ b/sample/simple/feature/bottom-sheet/implementation/src/main/kotlin/kotlin/com/freeletics/khonshu/sample/feature/bottomsheet/BottomSheetNavigator.kt
@@ -1,7 +1,8 @@
 package com.freeletics.khonshu.sample.feature.bottomsheet
 
 import com.freeletics.khonshu.navigation.ActivityResultNavigator
-import com.freeletics.khonshu.navigation.NavEventNavigator
+import com.freeletics.khonshu.navigation.DestinationNavigator
+import com.freeletics.khonshu.navigation.HostNavigator
 import com.freeletics.khonshu.sample.feature.bottomsheet.nav.BottomSheetRoute
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.optional.ForScope
@@ -11,4 +12,4 @@ import javax.inject.Inject
 @ForScope(BottomSheetRoute::class)
 @SingleIn(BottomSheetRoute::class)
 @ContributesBinding(BottomSheetRoute::class, ActivityResultNavigator::class)
-class BottomSheetNavigator @Inject constructor() : NavEventNavigator()
+class BottomSheetNavigator @Inject constructor(hostNavigator: HostNavigator) : DestinationNavigator(hostNavigator)

--- a/sample/simple/feature/dialog/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/dialog/DialogNavigator.kt
+++ b/sample/simple/feature/dialog/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/dialog/DialogNavigator.kt
@@ -1,7 +1,8 @@
 package com.freeletics.khonshu.sample.feature.dialog
 
 import com.freeletics.khonshu.navigation.ActivityResultNavigator
-import com.freeletics.khonshu.navigation.NavEventNavigator
+import com.freeletics.khonshu.navigation.DestinationNavigator
+import com.freeletics.khonshu.navigation.HostNavigator
 import com.freeletics.khonshu.sample.feature.dialog.nav.DialogRoute
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.optional.ForScope
@@ -11,4 +12,4 @@ import javax.inject.Inject
 @ForScope(DialogRoute::class)
 @SingleIn(DialogRoute::class)
 @ContributesBinding(DialogRoute::class, ActivityResultNavigator::class)
-class DialogNavigator @Inject constructor() : NavEventNavigator()
+class DialogNavigator @Inject constructor(hostNavigator: HostNavigator) : DestinationNavigator(hostNavigator)

--- a/sample/simple/feature/new-root/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/newroot/NewRootNavigator.kt
+++ b/sample/simple/feature/new-root/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/newroot/NewRootNavigator.kt
@@ -1,7 +1,8 @@
 package com.freeletics.khonshu.sample.feature.newroot
 
 import com.freeletics.khonshu.navigation.ActivityResultNavigator
-import com.freeletics.khonshu.navigation.NavEventNavigator
+import com.freeletics.khonshu.navigation.DestinationNavigator
+import com.freeletics.khonshu.navigation.HostNavigator
 import com.freeletics.khonshu.sample.feature.bottomsheet.nav.BottomSheetRoute
 import com.freeletics.khonshu.sample.feature.dialog.nav.DialogRoute
 import com.freeletics.khonshu.sample.feature.newroot.nav.NewRootRoute
@@ -15,7 +16,7 @@ import javax.inject.Inject
 @ForScope(NewRootRoute::class)
 @SingleIn(NewRootRoute::class)
 @ContributesBinding(NewRootRoute::class, ActivityResultNavigator::class)
-class NewRootNavigator @Inject constructor() : NavEventNavigator() {
+class NewRootNavigator @Inject constructor(hostNavigator: HostNavigator) : DestinationNavigator(hostNavigator) {
     fun navigateToScreen() {
         navigateTo(ScreenRoute(100))
     }

--- a/sample/simple/feature/root/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/root/RootNavigator.kt
+++ b/sample/simple/feature/root/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/root/RootNavigator.kt
@@ -1,7 +1,8 @@
 package com.freeletics.khonshu.sample.feature.root
 
 import com.freeletics.khonshu.navigation.ActivityResultNavigator
-import com.freeletics.khonshu.navigation.NavEventNavigator
+import com.freeletics.khonshu.navigation.DestinationNavigator
+import com.freeletics.khonshu.navigation.HostNavigator
 import com.freeletics.khonshu.sample.feature.bottomsheet.nav.BottomSheetRoute
 import com.freeletics.khonshu.sample.feature.dialog.nav.DialogRoute
 import com.freeletics.khonshu.sample.feature.newroot.nav.NewRootRoute
@@ -15,7 +16,7 @@ import javax.inject.Inject
 @ForScope(RootRoute::class)
 @SingleIn(RootRoute::class)
 @ContributesBinding(RootRoute::class, ActivityResultNavigator::class)
-class RootNavigator @Inject constructor() : NavEventNavigator() {
+class RootNavigator @Inject constructor(hostNavigator: HostNavigator) : DestinationNavigator(hostNavigator) {
     fun navigateToScreen() {
         navigateTo(ScreenRoute(1))
     }

--- a/sample/simple/feature/screen/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/screen/ScreenNavigator.kt
+++ b/sample/simple/feature/screen/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/screen/ScreenNavigator.kt
@@ -1,7 +1,8 @@
 package com.freeletics.khonshu.sample.feature.screen
 
 import com.freeletics.khonshu.navigation.ActivityResultNavigator
-import com.freeletics.khonshu.navigation.NavEventNavigator
+import com.freeletics.khonshu.navigation.DestinationNavigator
+import com.freeletics.khonshu.navigation.HostNavigator
 import com.freeletics.khonshu.sample.feature.bottomsheet.nav.BottomSheetRoute
 import com.freeletics.khonshu.sample.feature.dialog.nav.DialogRoute
 import com.freeletics.khonshu.sample.feature.newroot.nav.NewRootRoute
@@ -15,8 +16,9 @@ import javax.inject.Inject
 @SingleIn(ScreenRoute::class)
 @ContributesBinding(ScreenRoute::class, ActivityResultNavigator::class)
 class ScreenNavigator @Inject constructor(
+    hostNavigator: HostNavigator,
     private val route: ScreenRoute,
-) : NavEventNavigator() {
+) : DestinationNavigator(hostNavigator) {
 
     fun navigateToScreen() {
         navigateTo(ScreenRoute(route.number + 1))


### PR DESCRIPTION
Similar to `NavEventNavigator`, `DestinationNavigator` is meant to be used by individual screens (destinations) for their navigation actions. The difference is that most actions are delegated to `HostNavigator`, but it also provides activity result contract functionality which is still and will continue to be event based. 


Why have a base class?
- Internally it worked well for us to have a navigator class in each screen to isolate navigation logic. While you could do the delegation yourself and extend `ActivityResultNavigator` where needed this provides some consistency. 
- There is no additional step needed in case you need activity results or some other functionality.
- In the codegen we can simply expect each screen to provide an `ActivityResultNavigator`.

Since `HostNavigator` is provided in the `ActivityScope` the default parent scope for `@NavDestination` has been changed to `ActivityScope` to make this simpler.