### PR TITLE
add navigate {} to DestinationNavigator

### DIFF
--- a/navigation/api/android/navigation.api
+++ b/navigation/api/android/navigation.api
@@ -47,6 +47,7 @@ public abstract class com/freeletics/khonshu/navigation/DestinationNavigator : c
 	public fun backPresses ()Lkotlinx/coroutines/flow/Flow;
 	public fun backPresses (Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public fun deliverNavigationResult (Lcom/freeletics/khonshu/navigation/NavigationResultRequest$Key;Landroid/os/Parcelable;)V
+	public final fun navigate (Lkotlin/jvm/functions/Function1;)V
 	public fun navigateBack ()V
 	public fun navigateBackTo (Lkotlin/reflect/KClass;Z)V
 	public fun navigateTo (Lcom/freeletics/khonshu/navigation/ActivityRoute;)V

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/DestinationNavigator.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/DestinationNavigator.kt
@@ -5,5 +5,13 @@ package com.freeletics.khonshu.navigation
  * be used as base class for navigators of individual screens.
  */
 public abstract class DestinationNavigator(
-    navigator: HostNavigator,
-) : Navigator by navigator, ResultNavigator by navigator, BackInterceptor by navigator, ActivityResultNavigator()
+    private val navigator: HostNavigator,
+) : Navigator by navigator, ResultNavigator by navigator, BackInterceptor by navigator, ActivityResultNavigator() {
+
+    /**
+     * See [HostNavigator.navigate].
+     */
+    public fun navigate(block: Navigator.() -> Unit) {
+        navigator.navigate(block)
+    }
+}


### PR DESCRIPTION
Follow up to #803, since `navigate {}` is available in `HostNavigator` now, we also want it in `DestinationNavigator`. In this case we need to manually delegate since it's not part of the `Navigator` interface (we could think about adding it to that, the only downside is that it would allow nested calls to it).