### PR TITLE
add TestHostNavigator

### DIFF
--- a/navigation-testing/api/android/navigation-testing.api
+++ b/navigation-testing/api/android/navigation-testing.api
@@ -20,10 +20,15 @@ public abstract interface class com/freeletics/khonshu/navigation/NavigatorTurbi
 
 public final class com/freeletics/khonshu/navigation/NavigatorTurbineKt {
 	public static final fun dispatchBackPress (Lcom/freeletics/khonshu/navigation/NavEventNavigator;)V
+	public static final fun dispatchBackPress (Lcom/freeletics/khonshu/navigation/TestHostNavigator;)V
 	public static final fun test-C2H2yOE (Lcom/freeletics/khonshu/navigation/NavEventNavigator;Lkotlin/time/Duration;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun test-C2H2yOE (Lcom/freeletics/khonshu/navigation/TestHostNavigator;Lkotlin/time/Duration;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun test-C2H2yOE$default (Lcom/freeletics/khonshu/navigation/NavEventNavigator;Lkotlin/time/Duration;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun test-C2H2yOE$default (Lcom/freeletics/khonshu/navigation/TestHostNavigator;Lkotlin/time/Duration;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun testIn-5_5nbZA (Lcom/freeletics/khonshu/navigation/NavEventNavigator;Lkotlinx/coroutines/CoroutineScope;Lkotlin/time/Duration;Ljava/lang/String;)Lcom/freeletics/khonshu/navigation/NavigatorTurbine;
+	public static final fun testIn-5_5nbZA (Lcom/freeletics/khonshu/navigation/TestHostNavigator;Lkotlinx/coroutines/CoroutineScope;Lkotlin/time/Duration;Ljava/lang/String;)Lcom/freeletics/khonshu/navigation/NavigatorTurbine;
 	public static synthetic fun testIn-5_5nbZA$default (Lcom/freeletics/khonshu/navigation/NavEventNavigator;Lkotlinx/coroutines/CoroutineScope;Lkotlin/time/Duration;Ljava/lang/String;ILjava/lang/Object;)Lcom/freeletics/khonshu/navigation/NavigatorTurbine;
+	public static synthetic fun testIn-5_5nbZA$default (Lcom/freeletics/khonshu/navigation/TestHostNavigator;Lkotlinx/coroutines/CoroutineScope;Lkotlin/time/Duration;Ljava/lang/String;ILjava/lang/Object;)Lcom/freeletics/khonshu/navigation/NavigatorTurbine;
 }
 
 public final class com/freeletics/khonshu/navigation/ResultOwnerTestingKt {
@@ -33,6 +38,27 @@ public final class com/freeletics/khonshu/navigation/ResultOwnerTestingKt {
 	public static final fun sendResult (Lcom/freeletics/khonshu/navigation/PermissionsResultRequest;Ljava/lang/String;Lcom/freeletics/khonshu/navigation/PermissionsResultRequest$PermissionResult;)V
 	public static final fun sendResult (Lcom/freeletics/khonshu/navigation/PermissionsResultRequest;Ljava/util/Map;)V
 	public static final fun sendResult (Lcom/freeletics/khonshu/navigation/PermissionsResultRequest;[Lkotlin/Pair;)V
+}
+
+public final class com/freeletics/khonshu/navigation/TestHostNavigator : com/freeletics/khonshu/navigation/HostNavigator {
+	public fun <init> ()V
+	public fun <init> (Lcom/freeletics/khonshu/navigation/NavRoute;)V
+	public synthetic fun <init> (Lcom/freeletics/khonshu/navigation/NavRoute;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun backPresses ()Lkotlinx/coroutines/flow/Flow;
+	public fun backPresses (Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public fun deliverNavigationResult (Lcom/freeletics/khonshu/navigation/NavigationResultRequest$Key;Landroid/os/Parcelable;)V
+	public final fun getHandleDeepLinkRoute ()Lcom/freeletics/khonshu/navigation/NavRoute;
+	public fun handleDeepLink (Landroid/content/Intent;Lkotlinx/collections/immutable/ImmutableSet;Lkotlinx/collections/immutable/ImmutableSet;)Z
+	public fun navigate (Lkotlin/jvm/functions/Function1;)V
+	public fun navigateBack ()V
+	public fun navigateBackTo (Lkotlin/reflect/KClass;Z)V
+	public fun navigateTo (Lcom/freeletics/khonshu/navigation/ActivityRoute;)V
+	public fun navigateTo (Lcom/freeletics/khonshu/navigation/NavRoute;)V
+	public fun navigateToRoot (Lcom/freeletics/khonshu/navigation/NavRoot;Z)V
+	public fun navigateUp ()V
+	public fun replaceAll (Lcom/freeletics/khonshu/navigation/NavRoot;)V
+	public fun resetToRoot (Lcom/freeletics/khonshu/navigation/NavRoot;)V
+	public final fun setHandleDeepLinkRoute (Lcom/freeletics/khonshu/navigation/NavRoute;)V
 }
 
 public final class com/freeletics/khonshu/navigation/TestNavEventCollector {

--- a/navigation-testing/api/android/navigation-testing.api
+++ b/navigation-testing/api/android/navigation-testing.api
@@ -19,14 +19,19 @@ public abstract interface class com/freeletics/khonshu/navigation/NavigatorTurbi
 }
 
 public final class com/freeletics/khonshu/navigation/NavigatorTurbineKt {
+	public static final fun dispatchBackPress (Lcom/freeletics/khonshu/navigation/DestinationNavigator;)V
 	public static final fun dispatchBackPress (Lcom/freeletics/khonshu/navigation/NavEventNavigator;)V
 	public static final fun dispatchBackPress (Lcom/freeletics/khonshu/navigation/TestHostNavigator;)V
+	public static final fun test-C2H2yOE (Lcom/freeletics/khonshu/navigation/DestinationNavigator;Lkotlin/time/Duration;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun test-C2H2yOE (Lcom/freeletics/khonshu/navigation/NavEventNavigator;Lkotlin/time/Duration;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun test-C2H2yOE (Lcom/freeletics/khonshu/navigation/TestHostNavigator;Lkotlin/time/Duration;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun test-C2H2yOE$default (Lcom/freeletics/khonshu/navigation/DestinationNavigator;Lkotlin/time/Duration;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun test-C2H2yOE$default (Lcom/freeletics/khonshu/navigation/NavEventNavigator;Lkotlin/time/Duration;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun test-C2H2yOE$default (Lcom/freeletics/khonshu/navigation/TestHostNavigator;Lkotlin/time/Duration;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun testIn-5_5nbZA (Lcom/freeletics/khonshu/navigation/DestinationNavigator;Lkotlinx/coroutines/CoroutineScope;Lkotlin/time/Duration;Ljava/lang/String;)Lcom/freeletics/khonshu/navigation/NavigatorTurbine;
 	public static final fun testIn-5_5nbZA (Lcom/freeletics/khonshu/navigation/NavEventNavigator;Lkotlinx/coroutines/CoroutineScope;Lkotlin/time/Duration;Ljava/lang/String;)Lcom/freeletics/khonshu/navigation/NavigatorTurbine;
 	public static final fun testIn-5_5nbZA (Lcom/freeletics/khonshu/navigation/TestHostNavigator;Lkotlinx/coroutines/CoroutineScope;Lkotlin/time/Duration;Ljava/lang/String;)Lcom/freeletics/khonshu/navigation/NavigatorTurbine;
+	public static synthetic fun testIn-5_5nbZA$default (Lcom/freeletics/khonshu/navigation/DestinationNavigator;Lkotlinx/coroutines/CoroutineScope;Lkotlin/time/Duration;Ljava/lang/String;ILjava/lang/Object;)Lcom/freeletics/khonshu/navigation/NavigatorTurbine;
 	public static synthetic fun testIn-5_5nbZA$default (Lcom/freeletics/khonshu/navigation/NavEventNavigator;Lkotlinx/coroutines/CoroutineScope;Lkotlin/time/Duration;Ljava/lang/String;ILjava/lang/Object;)Lcom/freeletics/khonshu/navigation/NavigatorTurbine;
 	public static synthetic fun testIn-5_5nbZA$default (Lcom/freeletics/khonshu/navigation/TestHostNavigator;Lkotlinx/coroutines/CoroutineScope;Lkotlin/time/Duration;Ljava/lang/String;ILjava/lang/Object;)Lcom/freeletics/khonshu/navigation/NavigatorTurbine;
 }

--- a/navigation-testing/navigation-testing.gradle.kts
+++ b/navigation-testing/navigation-testing.gradle.kts
@@ -1,4 +1,5 @@
 import com.android.build.api.dsl.CommonExtension
+import com.freeletics.gradle.plugin.FreeleticsAndroidExtension
 
 plugins {
     alias(libs.plugins.fgp.multiplatform)
@@ -12,6 +13,10 @@ freeletics {
     multiplatform {
         addJvmTarget()
         addAndroidTarget()
+    }
+
+    extensions.configure(FreeleticsAndroidExtension::class) {
+        enableParcelize()
     }
 }
 

--- a/navigation-testing/navigation-testing.gradle.kts
+++ b/navigation-testing/navigation-testing.gradle.kts
@@ -1,5 +1,4 @@
 import com.android.build.api.dsl.CommonExtension
-import com.freeletics.gradle.plugin.FreeleticsAndroidExtension
 
 plugins {
     alias(libs.plugins.fgp.multiplatform)
@@ -13,10 +12,6 @@ freeletics {
     multiplatform {
         addJvmTarget()
         addAndroidTarget()
-    }
-
-    extensions.configure(FreeleticsAndroidExtension::class) {
-        enableParcelize()
     }
 }
 

--- a/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavigatorTurbine.kt
+++ b/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavigatorTurbine.kt
@@ -30,7 +30,7 @@ public suspend fun TestHostNavigator.test(
 }
 
 /**
- * Collects events from [DestinationNavigator] and and allows the [validate] lambda to consume
+ * Collects events from [DestinationNavigator] and allows the [validate] lambda to consume
  * and assert properties on them in order. If any exception occurs during validation the
  * exception is rethrown from this method.
  *

--- a/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavigatorTurbine.kt
+++ b/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavigatorTurbine.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.merge
 
 /**
- * Collects events from [TestHostNavigator] and and allows the [validate] lambda to consume
+ * Collects events from [TestHostNavigator] and allows the [validate] lambda to consume
  * and assert properties on them in order. If any exception occurs during validation the
  * exception is rethrown from this method.
  *

--- a/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavigatorTurbine.kt
+++ b/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavigatorTurbine.kt
@@ -11,6 +11,51 @@ import kotlin.time.Duration
 import kotlinx.coroutines.CoroutineScope
 
 /**
+ * Collects events from [TestHostNavigator] and and allows the [validate] lambda to consume
+ * and assert properties on them in order. If any exception occurs during validation the
+ * exception is rethrown from this method.
+ *
+ * [timeout] - If non-null, overrides the current Turbine timeout inside validate.
+ */
+public suspend fun TestHostNavigator.test(
+    timeout: Duration? = null,
+    name: String? = null,
+    validate: suspend NavigatorTurbine.() -> Unit,
+) {
+    navEventNavigator.navEvents.test(timeout, name) {
+        val turbine = DefaultNavigatorTurbine(navEventNavigator, this)
+        validate(turbine)
+    }
+}
+
+/**
+ * Collects events from [TestHostNavigator] and returns a [NavigatorTurbine] for consuming
+ * and asserting properties on them in order. If any exception occurs during validation the
+ * exception is rethrown from this method.
+ *
+ * Unlike test which automatically cancels the flow at the end of the lambda, the returned
+ * NavigatorTurbine be explicitly canceled.
+ *
+ * [timeout] - If non-null, overrides the current Turbine timeout inside validate.
+ */
+public fun TestHostNavigator.testIn(
+    scope: CoroutineScope,
+    timeout: Duration? = null,
+    name: String? = null,
+): NavigatorTurbine {
+    val turbine = navEventNavigator.navEvents.testIn(scope, timeout, name)
+    return DefaultNavigatorTurbine(navEventNavigator, turbine)
+}
+
+/**
+ * Causes an emission to the current [TestHostNavigator.backPresses] collector to make it possible
+ * to simulate a back press in tests that check custom back press logic.
+ */
+public fun TestHostNavigator.dispatchBackPress() {
+    onBackPressedCallback.handleOnBackPressed()
+}
+
+/**
  * Collects events from [NavEventNavigator] and and allows the [validate] lambda to consume
  * and assert properties on them in order. If any exception occurs during validation the
  * exception is rethrown from this method.

--- a/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/TestHostNavigator.kt
+++ b/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/TestHostNavigator.kt
@@ -1,0 +1,104 @@
+package com.freeletics.khonshu.navigation
+
+import android.content.Intent
+import android.os.Parcelable
+import androidx.activity.OnBackPressedCallback
+import androidx.compose.runtime.State
+import com.freeletics.khonshu.navigation.deeplinks.DeepLinkHandler
+import com.freeletics.khonshu.navigation.internal.DestinationId
+import com.freeletics.khonshu.navigation.internal.InternalNavigationApi
+import com.freeletics.khonshu.navigation.internal.InternalNavigationCodegenApi
+import com.freeletics.khonshu.navigation.internal.InternalNavigationTestingApi
+import com.freeletics.khonshu.navigation.internal.StackSnapshot
+import kotlin.reflect.KClass
+import kotlinx.collections.immutable.ImmutableSet
+import kotlinx.coroutines.flow.Flow
+
+public class TestHostNavigator(
+    public var handleDeepLinkRoute: NavRoute? = null,
+) : HostNavigator() {
+
+    internal val navEventNavigator = NavEventNavigator()
+
+    @InternalNavigationCodegenApi
+    @InternalNavigationTestingApi
+    override val snapshot: State<StackSnapshot>
+        get() = throw UnsupportedOperationException()
+
+    @InternalNavigationTestingApi
+    override val onBackPressedCallback: OnBackPressedCallback
+        get() = throw UnsupportedOperationException()
+
+    /**
+     * The fake implementation will call [navigateTo] with [handleDeepLinkRoute] if
+     * the latter is not `null`. Otherwise it will just return false.
+     */
+    override fun handleDeepLink(
+        intent: Intent,
+        deepLinkHandlers: ImmutableSet<DeepLinkHandler>,
+        deepLinkPrefixes: ImmutableSet<DeepLinkHandler.Prefix>,
+    ): Boolean {
+        handleDeepLinkRoute?.let {
+            navEventNavigator.navigateTo(it)
+            return true
+        }
+        return false
+    }
+
+    override fun navigate(block: Navigator.() -> Unit) {
+        navEventNavigator.navigate(block)
+    }
+
+    override fun navigateTo(route: NavRoute) {
+        navEventNavigator.navigateTo(route)
+    }
+
+    override fun navigateTo(route: ActivityRoute) {
+        navEventNavigator.navigateTo(route)
+    }
+
+    override fun navigateToRoot(root: NavRoot, restoreRootState: Boolean) {
+        navEventNavigator.navigateToRoot(root, restoreRootState)
+    }
+
+    override fun navigateUp() {
+        navEventNavigator.navigateUp()
+    }
+
+    override fun navigateBack() {
+        navEventNavigator.navigateBack()
+    }
+
+    override fun <T : BaseRoute> navigateBackTo(popUpTo: KClass<T>, inclusive: Boolean) {
+        navEventNavigator.navigateBackTo(popUpTo, inclusive)
+    }
+
+    override fun resetToRoot(root: NavRoot) {
+        navEventNavigator.resetToRoot(root)
+    }
+
+    override fun replaceAll(root: NavRoot) {
+        navEventNavigator.replaceAll(root)
+    }
+
+    override fun <O : Parcelable> deliverNavigationResult(key: NavigationResultRequest.Key<O>, result: O) {
+        navEventNavigator.deliverNavigationResult(key, result)
+    }
+
+    @InternalNavigationApi
+    @InternalNavigationCodegenApi
+    override fun <T : BaseRoute, O : Parcelable> registerForNavigationResultInternal(
+        id: DestinationId<T>,
+        resultType: String,
+    ): NavigationResultRequest<O> {
+        return navEventNavigator.registerForNavigationResultInternal(id, resultType)
+    }
+
+    override fun backPresses(): Flow<Unit> {
+        return navEventNavigator.backPresses()
+    }
+
+    override fun <T> backPresses(value: T): Flow<T> {
+        return navEventNavigator.backPresses(value)
+    }
+}

--- a/navigation/api/android/navigation.api
+++ b/navigation/api/android/navigation.api
@@ -64,7 +64,7 @@ public abstract interface class com/freeletics/khonshu/navigation/ExternalActivi
 
 public abstract class com/freeletics/khonshu/navigation/HostNavigator : com/freeletics/khonshu/navigation/BackInterceptor, com/freeletics/khonshu/navigation/Navigator, com/freeletics/khonshu/navigation/ResultNavigator {
 	public static final field $stable I
-	public abstract fun handleDeepLink (Landroid/content/Intent;Lkotlinx/collections/immutable/ImmutableSet;Lkotlinx/collections/immutable/ImmutableSet;)V
+	public abstract fun handleDeepLink (Landroid/content/Intent;Lkotlinx/collections/immutable/ImmutableSet;Lkotlinx/collections/immutable/ImmutableSet;)Z
 	public abstract fun navigate (Lkotlin/jvm/functions/Function1;)V
 }
 

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/DestinationNavigator.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/DestinationNavigator.kt
@@ -1,17 +1,23 @@
 package com.freeletics.khonshu.navigation
 
+import com.freeletics.khonshu.navigation.internal.InternalNavigationTestingApi
+
 /**
  * A combination of [Navigator] and [ActivityResultNavigator] that can
  * be used as base class for navigators of individual screens.
  */
 public abstract class DestinationNavigator(
-    private val navigator: HostNavigator,
-) : Navigator by navigator, ResultNavigator by navigator, BackInterceptor by navigator, ActivityResultNavigator() {
+    @property:InternalNavigationTestingApi
+    public val hostNavigator: HostNavigator,
+) : Navigator by hostNavigator,
+    ResultNavigator by hostNavigator,
+    BackInterceptor by hostNavigator,
+    ActivityResultNavigator() {
 
     /**
      * See [HostNavigator.navigate].
      */
     public fun navigate(block: Navigator.() -> Unit) {
-        navigator.navigate(block)
+        hostNavigator.navigate(block)
     }
 }

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/HostNavigator.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/HostNavigator.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.freeletics.khonshu.navigation.deeplinks.DeepLink
 import com.freeletics.khonshu.navigation.deeplinks.DeepLinkHandler
+import com.freeletics.khonshu.navigation.internal.InternalNavigationTestingApi
 import com.freeletics.khonshu.navigation.internal.StackEntryStoreViewModel
 import com.freeletics.khonshu.navigation.internal.StackSnapshot
 import com.freeletics.khonshu.navigation.internal.createHostNavigator
@@ -20,20 +21,28 @@ import kotlinx.collections.immutable.persistentSetOf
  *
  * An instance can be created by calling [rememberHostNavigator].
  */
-public abstract class HostNavigator internal constructor() : Navigator, ResultNavigator, BackInterceptor {
-    internal abstract val snapshot: State<StackSnapshot>
-    internal abstract val onBackPressedCallback: OnBackPressedCallback
+public abstract class HostNavigator @InternalNavigationTestingApi constructor() :
+    Navigator,
+    ResultNavigator,
+    BackInterceptor {
+    @InternalNavigationTestingApi
+    public abstract val snapshot: State<StackSnapshot>
+
+    @InternalNavigationTestingApi
+    public abstract val onBackPressedCallback: OnBackPressedCallback
 
     /**
      * If the given [Intent] was created from a [DeepLink] or the `Uri` returned by [Intent.getData]
      * can be handled using [deepLinkHandlers] and [deepLinkPrefixes] then the navigator will
      * clear the current back stack and navigate to the required destinations.
+     *
+     * Returns `true` if the `Intent` contained a deeplink that was handled.
      */
     public abstract fun handleDeepLink(
         intent: Intent,
         deepLinkHandlers: ImmutableSet<DeepLinkHandler>,
         deepLinkPrefixes: ImmutableSet<DeepLinkHandler.Prefix>,
-    )
+    ): Boolean
 
     /**
      * Allows to group multiple navigation actions and execute them atomically. The state of this [HostNavigator] will

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackHostNavigator.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackHostNavigator.kt
@@ -40,15 +40,15 @@ internal class MultiStackHostNavigator(
         intent: Intent,
         deepLinkHandlers: ImmutableSet<DeepLinkHandler>,
         deepLinkPrefixes: ImmutableSet<DeepLinkHandler.Prefix>,
-    ) {
+    ): Boolean {
         val deepLinkRoutes = intent.extractDeepLinkRoutes(deepLinkHandlers, deepLinkPrefixes)
-        handleDeepLink(deepLinkRoutes)
+        return handleDeepLink(deepLinkRoutes)
     }
 
     @VisibleForTesting
-    internal fun handleDeepLink(deepLinkRoutes: List<Parcelable>) {
+    internal fun handleDeepLink(deepLinkRoutes: List<Parcelable>): Boolean {
         if (deepLinkRoutes.isEmpty()) {
-            return
+            return false
         }
 
         stack.resetToRoot(stack.startRoot)
@@ -68,6 +68,8 @@ internal class MultiStackHostNavigator(
                 is ActivityRoute -> navigateTo(route)
             }
         }
+
+        return true
     }
 
     override fun navigateTo(route: NavRoute) {

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/TestHostNavigator.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/TestHostNavigator.kt
@@ -73,7 +73,7 @@ internal class TestHostNavigator : HostNavigator() {
         intent: Intent,
         deepLinkHandlers: ImmutableSet<DeepLinkHandler>,
         deepLinkPrefixes: ImmutableSet<DeepLinkHandler.Prefix>,
-    ) {
+    ): Boolean {
         throw UnsupportedOperationException()
     }
 


### PR DESCRIPTION
Adds a test helper for using `HostNavigator` which makes interactions with both `HostNavigator` and `DestinationNavigator` testable. This initial implementation will use nav events internally so that the existing test code  can be re-used. Once we remove nav events we can re-think this.

I've also added a `Boolean` return value to `handleDeepLink` this allows us to do other navigation actions based on whether the method did something or not.