### PR TITLE
fix 2 issues with replaceAll

### DIFF
--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/HostNavigator.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/HostNavigator.kt
@@ -68,6 +68,7 @@ public fun rememberHostNavigator(
             viewModel = viewModel,
             startRoot = startRoot,
             destinations = destinations,
+            startRootOverridesSavedRoot = true,
         ).also {
             val handledDeepLinks = viewModel.globalSavedStateHandle.get<Boolean>(SAVED_STATE_HANDLED_DEEP_LINKS)
             if (handledDeepLinks != true) {

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStack.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStack.kt
@@ -24,7 +24,8 @@ internal class MultiStack(
     val snapshot: State<StackSnapshot>
         get() = snapshotState
 
-    val startRoot = startStack.rootEntry.route as NavRoot
+    val startRoot
+        get() = startStack.rootEntry.route as NavRoot
 
     private fun getBackStack(root: NavRoot): Stack? {
         return allStacks.find { it.id == root.destinationId }
@@ -163,14 +164,14 @@ internal class MultiStack(
 
         @Suppress("DEPRECATION")
         fun fromState(
-            root: NavRoot,
+            root: NavRoot?,
             bundle: Bundle,
             createEntry: (BaseRoute) -> StackEntry<*>,
             createRestoredEntry: (BaseRoute, StackEntry.Id, SavedStateHandle) -> StackEntry<*>,
         ): MultiStack {
             val inputRoot = bundle.getParcelable<NavRoot>(SAVED_INPUT_ROOT)!!
 
-            if (inputRoot != root) {
+            if (root != null && inputRoot != root) {
                 return createWith(
                     root = root,
                     createEntry = createEntry,

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackHostNavigatorBuilder.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackHostNavigatorBuilder.kt
@@ -16,6 +16,7 @@ public fun createHostNavigator(
     viewModel: StackEntryStoreViewModel,
     startRoot: NavRoot,
     destinations: ImmutableSet<NavDestination>,
+    startRootOverridesSavedRoot: Boolean = false,
 ): HostNavigator {
     val activityDestinations = destinations.filterIsInstance<ActivityDestination>()
     val starter = ActivityStarter(context.applicationContext, activityDestinations)
@@ -31,7 +32,7 @@ public fun createHostNavigator(
         )
     } else {
         MultiStack.fromState(
-            root = startRoot,
+            root = startRoot.takeIf { startRootOverridesSavedRoot },
             bundle = navState,
             createEntry = factory::create,
             createRestoredEntry = factory::create,

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackTest.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackTest.kt
@@ -360,7 +360,11 @@ internal class MultiStackTest {
     fun `replaceAll with start root from start hostNavigator`() {
         val stack = underTest()
         stack.push(SimpleRoute(1))
+        assertThat(stack.startRoot).isEqualTo(SimpleRoot(1))
+
         stack.replaceAll(SimpleRoot(2))
+
+        assertThat(stack.startRoot).isEqualTo(SimpleRoot(2))
 
         assertThat(stack.snapshot.value.visibleEntries)
             .containsExactly(


### PR DESCRIPTION
1. Existing issue: `val startRoot` was assigned once during the creation of `MultiStack` which means the value is wrong after `replaceAll` changes the `startStack`. The impact is negligible so far since it's only used for 
2. Unreleased issue: Currently when `MultiStack` is created from saved state the navigator if the `startRoot` passed to `NavHost`/`rememberHostNavigator` does not match the saved `NavRoot` we discard the state. This makes sense since from a compose perspective changing the given `startRoot` should re-compose everything and you effectively get a new `NavHost`. However if we create a `HostNavigator` through outside of compose (like we do in the codegen) this behavior doesn't make sense. For example we create the `HostNavigator` with a dummy startRoot and then always use `replaceAll` on the initial start logic and with that we always want to keep the saved state. The solution keeps the behavior for compose but disables it for codegen.