### PR TITLE
Add screen-with-result as example for destination results

### DIFF
--- a/sample/simple/app/simple/app-simple.gradle.kts
+++ b/sample/simple/app/simple/app-simple.gradle.kts
@@ -30,6 +30,8 @@ dependencies {
     implementation(projects.feature.root.nav)
     implementation(projects.feature.screen.implementation)
     implementation(projects.feature.screen.nav)
+    implementation(projects.feature.screenWithResult.implementation)
+    implementation(projects.feature.screenWithResult.nav)
     implementation(projects.feature.newRoot.implementation)
     implementation(projects.feature.newRoot.nav)
 }

--- a/sample/simple/feature/new-root/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/newroot/NewRootScreen.kt
+++ b/sample/simple/feature/new-root/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/newroot/NewRootScreen.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.freeletics.khonshu.codegen.NavDestination
 import com.freeletics.khonshu.sample.feature.newroot.nav.NewRootRoute
@@ -27,7 +29,12 @@ fun NewRootScreen(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
-        BasicText("Feature New Root")
+        BasicText(
+            "Feature New Root",
+            style = TextStyle.Default.copy(
+                fontWeight = FontWeight.Bold,
+            ),
+        )
 
         Spacer(Modifier.height(12.dp))
 

--- a/sample/simple/feature/root/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/root/RootScreen.kt
+++ b/sample/simple/feature/root/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/root/RootScreen.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.freeletics.khonshu.codegen.NavDestination
 import com.freeletics.khonshu.sample.feature.root.nav.RootRoute
@@ -27,7 +29,12 @@ fun RootScreen(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
-        BasicText("Feature Root")
+        BasicText(
+            "Feature Root",
+            style = TextStyle.Default.copy(
+                fontWeight = FontWeight.Bold,
+            ),
+        )
 
         Spacer(Modifier.height(12.dp))
 

--- a/sample/simple/feature/screen-with-result/implementation/feature-screen-with-result-implementation.gradle.kts
+++ b/sample/simple/feature/screen-with-result/implementation/feature-screen-with-result-implementation.gradle.kts
@@ -15,12 +15,9 @@ dependencies {
     api(libs.khonshu.navigation)
     api(libs.khonshu.statemachine)
     api(libs.khonshu.codegen)
-    api(projects.feature.screen.nav)
+    api(projects.feature.screenWithResult.nav)
 
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.foundation)
-    implementation(projects.feature.bottomSheet.nav)
-    implementation(projects.feature.dialog.nav)
-    implementation(projects.feature.newRoot.nav)
-    implementation(projects.feature.screenWithResult.nav)
+    implementation(libs.androidx.compose.material)
 }

--- a/sample/simple/feature/screen-with-result/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/screen/result/ScreenWithResultNavigator.kt
+++ b/sample/simple/feature/screen-with-result/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/screen/result/ScreenWithResultNavigator.kt
@@ -1,0 +1,25 @@
+package com.freeletics.khonshu.sample.feature.screen.result
+
+import com.freeletics.khonshu.navigation.ActivityNavigator
+import com.freeletics.khonshu.navigation.DestinationNavigator
+import com.freeletics.khonshu.navigation.HostNavigator
+import com.freeletics.khonshu.sample.feature.screen.result.nav.Result
+import com.freeletics.khonshu.sample.feature.screen.result.nav.ScreenWithResultRoute
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.anvil.annotations.optional.ForScope
+import com.squareup.anvil.annotations.optional.SingleIn
+import javax.inject.Inject
+
+@ForScope(ScreenWithResultRoute::class)
+@SingleIn(ScreenWithResultRoute::class)
+@ContributesBinding(ScreenWithResultRoute::class, ActivityNavigator::class)
+class ScreenWithResultNavigator @Inject constructor(
+    hostNavigator: HostNavigator,
+    private val route: ScreenWithResultRoute,
+) : DestinationNavigator(hostNavigator) {
+
+    fun deliverResult(data: String) {
+        deliverNavigationResult(route.key, Result(data))
+        navigateBack()
+    }
+}

--- a/sample/simple/feature/screen-with-result/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/screen/result/ScreenWithResultScreen.kt
+++ b/sample/simple/feature/screen-with-result/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/screen/result/ScreenWithResultScreen.kt
@@ -1,0 +1,74 @@
+package com.freeletics.khonshu.sample.feature.screen.result
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material3.Button
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.freeletics.khonshu.codegen.NavDestination
+import com.freeletics.khonshu.sample.feature.screen.result.nav.ScreenWithResultRoute
+
+@NavDestination(
+    route = ScreenWithResultRoute::class,
+    stateMachine = ScreenWithResultStateMachine::class,
+)
+@Composable
+fun ScreenWithResultScreen(
+    state: ScreenWithResultState,
+    sendAction: (ScreenWithResultAction) -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        BasicText(
+            "Feature Screen with Result",
+            style = TextStyle.Default.copy(
+                fontWeight = FontWeight.Bold,
+            ),
+        )
+
+        Spacer(Modifier.height(12.dp))
+
+        Row(
+            modifier = Modifier
+                .padding(horizontal = 8.dp)
+                .fillMaxWidth(),
+        ) {
+            val input = remember {
+                mutableStateOf(state.data)
+            }
+            TextField(
+                modifier = Modifier.weight(1f),
+                value = input.value,
+                onValueChange = {
+                    input.value = it
+                    sendAction(ScreenWithResultAction.UpdateResult(it))
+                },
+            )
+
+            Spacer(Modifier.width(12.dp))
+
+            Button(onClick = { sendAction(ScreenWithResultAction.DeliverResult) }) {
+                BasicText("Send result")
+            }
+        }
+    }
+}

--- a/sample/simple/feature/screen-with-result/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/screen/result/ScreenWithResultStateMachine.kt
+++ b/sample/simple/feature/screen-with-result/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/screen/result/ScreenWithResultStateMachine.kt
@@ -1,0 +1,27 @@
+package com.freeletics.khonshu.sample.feature.screen.result
+
+import com.freeletics.khonshu.statemachine.StateMachine
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+data class ScreenWithResultState(val data: String)
+
+sealed interface ScreenWithResultAction {
+    data class UpdateResult(val data: String): ScreenWithResultAction
+    data object DeliverResult: ScreenWithResultAction
+}
+
+class ScreenWithResultStateMachine @Inject constructor(
+    private val navigator: ScreenWithResultNavigator,
+) : StateMachine<ScreenWithResultState, ScreenWithResultAction> {
+    private val _state = MutableStateFlow(ScreenWithResultState(data = ""))
+    override val state: Flow<ScreenWithResultState> = _state
+
+    override suspend fun dispatch(action: ScreenWithResultAction) {
+        when (action) {
+            ScreenWithResultAction.DeliverResult -> navigator.deliverResult(_state.value.data)
+            is ScreenWithResultAction.UpdateResult -> _state.emit(ScreenWithResultState(action.data))
+        }
+    }
+}

--- a/sample/simple/feature/screen-with-result/nav/feature-screen-with-result-nav.gradle.kts
+++ b/sample/simple/feature/screen-with-result/nav/feature-screen-with-result-nav.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    alias(libs.plugins.fgp.nav)
+}
+
+dependencies {
+    api(libs.khonshu.navigation)
+}

--- a/sample/simple/feature/screen-with-result/nav/src/main/kotlin/com/freeletics/khonshu/sample/feature/screen/result/nav/ScreenWithResultRoute.kt
+++ b/sample/simple/feature/screen-with-result/nav/src/main/kotlin/com/freeletics/khonshu/sample/feature/screen/result/nav/ScreenWithResultRoute.kt
@@ -1,0 +1,12 @@
+package com.freeletics.khonshu.sample.feature.screen.result.nav
+
+import android.os.Parcelable
+import com.freeletics.khonshu.navigation.NavRoute
+import com.freeletics.khonshu.navigation.NavigationResultRequest
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class ScreenWithResultRoute(val key: NavigationResultRequest.Key<Result>) : NavRoute
+
+@Parcelize
+data class Result(val data: String) : Parcelable

--- a/sample/simple/feature/screen/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/screen/ScreenNavigator.kt
+++ b/sample/simple/feature/screen/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/screen/ScreenNavigator.kt
@@ -3,10 +3,13 @@ package com.freeletics.khonshu.sample.feature.screen
 import com.freeletics.khonshu.navigation.ActivityNavigator
 import com.freeletics.khonshu.navigation.DestinationNavigator
 import com.freeletics.khonshu.navigation.HostNavigator
+import com.freeletics.khonshu.navigation.ResultNavigator.Companion.registerForNavigationResult
 import com.freeletics.khonshu.sample.feature.bottomsheet.nav.BottomSheetRoute
 import com.freeletics.khonshu.sample.feature.dialog.nav.DialogRoute
 import com.freeletics.khonshu.sample.feature.newroot.nav.NewRootRoute
 import com.freeletics.khonshu.sample.feature.screen.nav.ScreenRoute
+import com.freeletics.khonshu.sample.feature.screen.result.nav.Result
+import com.freeletics.khonshu.sample.feature.screen.result.nav.ScreenWithResultRoute
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.optional.ForScope
 import com.squareup.anvil.annotations.optional.SingleIn
@@ -19,6 +22,8 @@ class ScreenNavigator @Inject constructor(
     hostNavigator: HostNavigator,
     private val route: ScreenRoute,
 ) : DestinationNavigator(hostNavigator) {
+
+    val destinationResult = registerForNavigationResult<ScreenRoute, Result>()
 
     fun navigateToScreen() {
         navigateTo(ScreenRoute(route.number + 1))
@@ -34,5 +39,9 @@ class ScreenNavigator @Inject constructor(
 
     fun replaceAllWithNewRoot() {
         replaceAll(NewRootRoute)
+    }
+
+    fun navigateToScreenForResult() {
+        navigateTo(ScreenWithResultRoute(destinationResult.key))
     }
 }

--- a/sample/simple/feature/screen/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/screen/ScreenScreen.kt
+++ b/sample/simple/feature/screen/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/screen/ScreenScreen.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.freeletics.khonshu.codegen.NavDestination
 import com.freeletics.khonshu.sample.feature.screen.nav.ScreenRoute
@@ -28,7 +30,12 @@ fun ScreenScreen(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
-        BasicText("Feature Screen ${state.number}")
+        BasicText(
+            "Feature Screen ${state.number}",
+            style = TextStyle.Default.copy(
+                fontWeight = FontWeight.Bold,
+            ),
+        )
 
         Spacer(Modifier.height(12.dp))
 
@@ -36,6 +43,19 @@ fun ScreenScreen(
             modifier = Modifier.clickable { sendAction(ScreenAction.ScreenButtonClicked) },
             text = "Open Screen",
         )
+
+        Spacer(Modifier.height(12.dp))
+
+        BasicText(
+            modifier = Modifier.clickable { sendAction(ScreenAction.ScreenForResultButtonClicked) },
+            text = "Open Screen for Result",
+        )
+
+        if (state.result != null) {
+            BasicText(
+                text = "Result received: ${state.result}",
+            )
+        }
 
         Spacer(Modifier.height(12.dp))
 


### PR DESCRIPTION
Adds example screen for destination results and its delivery. Also made title of screens bold to stand out.