### PR TITLE
add Context parameter to buildIntent

### DIFF
--- a/docs/navigation/activities.md
+++ b/docs/navigation/activities.md
@@ -27,7 +27,7 @@ This is example shows the route for a `SettingsActivity`:
 data class SettingsActivityRoute(
     val id: String,
 ) : InternalActivityRoute() {
-    override fun buildIntent() = Intent("com.example.SETTINGS")
+    override fun buildIntent(context: Context) = Intent("com.example.SETTINGS")
 }
 ```
 
@@ -51,7 +51,7 @@ A very simple route would just be an object without any parameters:
 ```kotlin
 @Parcelize
 data object SystemLocationSettings : ExternalActivityRoute {
-    override fun buildIntent() = Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS)
+    override fun buildIntent(context: Context) = Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS)
 }
 ```
 
@@ -64,7 +64,7 @@ class ShareRoute(
     private val title: String,
     private val message: String
 ) : ExternalActivityRoute {
-    override fun fillInIntent() = Intent(Intent.ACTION_CHOOSER)
+    override fun buildIntent(context: Context) = Intent(Intent.ACTION_CHOOSER)
         .putExtra(Intent.EXTRA_TITLE, title)
         .putExtra(Intent.EXTRA_INTENT, Intent().apply {
             action = Intent.ACTION_SEND
@@ -78,9 +78,7 @@ class ShareRoute(
 class BrowserRoute(
     private val uri: Uri,
 ) : ExternalActivityRoute {
-    // the returned Intent is filled into the Intent of the destination by calling
-    // destinationIntent.fillIn(fillInIntent())
-    override fun fillInIntent() = Intent(Intent.ACTION_VIEW).setData(uri)
+    override fun buildIntent(context: Context) = Intent(Intent.ACTION_VIEW).setData(uri)
 }
 ```
 

--- a/navigation/api/android/navigation.api
+++ b/navigation/api/android/navigation.api
@@ -16,7 +16,7 @@ public final class com/freeletics/khonshu/navigation/ActivityResultRequest : com
 }
 
 public abstract interface class com/freeletics/khonshu/navigation/ActivityRoute : android/os/Parcelable {
-	public abstract fun buildIntent ()Landroid/content/Intent;
+	public abstract fun buildIntent (Landroid/content/Context;)Landroid/content/Intent;
 }
 
 public final class com/freeletics/khonshu/navigation/ActivityRouteKt {

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/ActivityRoute.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/ActivityRoute.kt
@@ -1,6 +1,7 @@
 package com.freeletics.khonshu.navigation
 
 import android.app.Activity
+import android.content.Context
 import android.content.Intent
 import android.os.Parcelable
 
@@ -9,7 +10,7 @@ import android.os.Parcelable
  * and [ExternalActivityRoute].
  */
 public sealed interface ActivityRoute : Parcelable {
-    public fun buildIntent(): Intent
+    public fun buildIntent(context: Context): Intent
 }
 
 /**

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/ActivityStarter.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/ActivityStarter.kt
@@ -13,7 +13,7 @@ internal class ActivityStarter(
     private val navigator: Navigator,
 ) {
     fun start(route: ActivityRoute, fallbackRoute: NavRoute?) {
-        val intent = route.buildIntent()
+        val intent = route.buildIntent(context)
         if (route is InternalActivityRoute) {
             intent
                 .setPackage(context.packageName)

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/Routes.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/Routes.kt
@@ -1,5 +1,6 @@
 package com.freeletics.khonshu.navigation.test
 
+import android.content.Context
 import android.content.Intent
 import android.os.Parcelable
 import com.freeletics.khonshu.navigation.ExternalActivityRoute
@@ -39,13 +40,13 @@ internal class OtherRoot(val number: Int) : NavRoot, Parcelable
 @Poko
 @Parcelize
 internal class SimpleActivity(val number: Int) : InternalActivityRoute() {
-    override fun buildIntent(): Intent = Intent()
+    override fun buildIntent(context: Context): Intent = Intent()
 }
 
 @Poko
 @Parcelize
 internal class OtherActivity(val number: Int) : ExternalActivityRoute {
-    override fun buildIntent(): Intent = Intent()
+    override fun buildIntent(context: Context): Intent = Intent()
 }
 
 @Poko


### PR DESCRIPTION
This makes implementing `ActivityRoute` easier since you can use the given context to get something like the current package name.