### PR TITLE
support KSP2 in codegen

### DIFF
--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationCodegenTest.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationCodegenTest.kt
@@ -9,6 +9,7 @@ import com.freeletics.khonshu.codegen.NavDestinationData
 import com.freeletics.khonshu.codegen.Navigation
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.INT
+import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.MAP
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.SET
@@ -39,10 +40,7 @@ internal class NavDestinationCodegenTest {
         stateParameter = ComposableParameter("state", ClassName("com.test", "TestState")),
         sendActionParameter = ComposableParameter(
             "sendAction",
-            Function1::class.asClassName().parameterizedBy(
-                ClassName("com.test", "TestAction"),
-                UNIT,
-            ),
+            LambdaTypeName.get(null, ClassName("com.test", "TestAction"), returnType = UNIT)
         ),
     )
 

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationCodegenTest.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationCodegenTest.kt
@@ -40,7 +40,7 @@ internal class NavDestinationCodegenTest {
         stateParameter = ComposableParameter("state", ClassName("com.test", "TestState")),
         sendActionParameter = ComposableParameter(
             "sendAction",
-            LambdaTypeName.get(null, ClassName("com.test", "TestAction"), returnType = UNIT)
+            LambdaTypeName.get(null, ClassName("com.test", "TestAction"), returnType = UNIT),
         ),
     )
 

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavHostActivityCodegenTest.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavHostActivityCodegenTest.kt
@@ -8,6 +8,7 @@ import com.freeletics.khonshu.codegen.ComposableParameter
 import com.freeletics.khonshu.codegen.NavHostActivityData
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.INT
+import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.MAP
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.SET
@@ -33,10 +34,7 @@ internal class NavHostActivityCodegenTest {
         stateParameter = ComposableParameter("state", ClassName("com.test", "TestState")),
         sendActionParameter = ComposableParameter(
             "sendAction",
-            Function1::class.asClassName().parameterizedBy(
-                ClassName("com.test", "TestAction"),
-                UNIT,
-            ),
+            LambdaTypeName.get(null, ClassName("com.test", "TestAction"), returnType = UNIT),
         ),
         composableParameter = emptyList(),
     )

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/TestHelper.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/TestHelper.kt
@@ -52,7 +52,13 @@ private fun compileWithAnvil(fileName: String, source: String, expectedCode: Str
     }
 }
 
-private fun compileWithKsp(fileName: String, source: String, expectedCode: String, warningsAsErrors: Boolean, ksp2: Boolean) {
+private fun compileWithKsp(
+    fileName: String,
+    source: String,
+    expectedCode: String,
+    warningsAsErrors: Boolean,
+    ksp2: Boolean,
+) {
     kspCompilation(
         source = source,
         fileName = fileName,

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/TestHelper.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/TestHelper.kt
@@ -19,7 +19,8 @@ internal fun test(
 ) {
     compile(fileName = fileName, source = source, data = data, expectedCode = expectedCode, warningsAsErrors)
     compileWithAnvil(fileName = fileName, source = source, expectedCode = expectedCode, warningsAsErrors)
-    compileWithKsp(fileName = fileName, source = source, expectedCode = expectedCode, warningsAsErrors)
+    compileWithKsp(fileName = fileName, source = source, expectedCode = expectedCode, warningsAsErrors, ksp2 = false)
+    compileWithKsp(fileName = fileName, source = source, expectedCode = expectedCode, warningsAsErrors, ksp2 = true)
 }
 
 private fun compile(fileName: String, source: String, data: BaseData, expectedCode: String, warningsAsErrors: Boolean) {
@@ -51,13 +52,14 @@ private fun compileWithAnvil(fileName: String, source: String, expectedCode: Str
     }
 }
 
-private fun compileWithKsp(fileName: String, source: String, expectedCode: String, warningsAsErrors: Boolean) {
+private fun compileWithKsp(fileName: String, source: String, expectedCode: String, warningsAsErrors: Boolean, ksp2: Boolean) {
     kspCompilation(
         source = source,
         fileName = fileName,
         legacyCompilerPlugins = listOf(ComposePluginRegistrar()),
         symbolProcessors = listOf(KhonshuSymbolProcessorProvider()),
         warningsAsErrors = warningsAsErrors,
+        ksp2 = ksp2,
     ).compile {
         assertThat(it.exitCode).isEqualTo(ExitCode.OK)
         assertThat(generatedFileFor(fileName)).isEqualTo(expectedCode)

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/ComponentComposableGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/ComponentComposableGenerator.kt
@@ -55,7 +55,7 @@ internal class ComponentComposableGenerator(
                     addStatement("val scope = %M()", rememberCoroutineScope)
                         .beginControlFlow(
                             "val sendAction: %T = %M(stateMachine, scope)",
-                            data.sendActionParameter!!.typeName.functionToLambda(),
+                            data.sendActionParameter!!.typeName,
                             remember,
                         )
                         .addStatement("{ scope.%M { stateMachine.dispatch(it) } }", launch)

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/ComponentComposableGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/ComponentComposableGenerator.kt
@@ -4,7 +4,6 @@ import com.freeletics.khonshu.codegen.BaseData
 import com.freeletics.khonshu.codegen.NavHostActivityData
 import com.freeletics.khonshu.codegen.util.asComposeState
 import com.freeletics.khonshu.codegen.util.composable
-import com.freeletics.khonshu.codegen.util.functionToLambda
 import com.freeletics.khonshu.codegen.util.launch
 import com.freeletics.khonshu.codegen.util.navHostParameter
 import com.freeletics.khonshu.codegen.util.optInAnnotation

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/AnvilParser.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/AnvilParser.kt
@@ -137,7 +137,10 @@ private fun TopLevelFunctionReference.getInjectedParameters(vararg exclude: Type
 }
 
 private fun ParameterReference.toComposableParameter(condition: (TypeName) -> Boolean): ComposableParameter? {
-    return type().asTypeName().functionToLambda().takeIf(condition)?.let { ComposableParameter(name, it) }
+    return type().asTypeName()
+        .functionToLambda()
+        .takeIf(condition)
+        ?.let { ComposableParameter(name, it) }
 }
 
 private fun TopLevelFunctionReference.navHostParameter(): ComposableParameter {

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/KspParser.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/KspParser.kt
@@ -6,6 +6,7 @@ import com.freeletics.khonshu.codegen.NavHostActivityData
 import com.freeletics.khonshu.codegen.Navigation
 import com.freeletics.khonshu.codegen.util.asLambdaParameter
 import com.freeletics.khonshu.codegen.util.baseRoute
+import com.freeletics.khonshu.codegen.util.functionToLambda
 import com.freeletics.khonshu.codegen.util.overlay
 import com.freeletics.khonshu.codegen.util.simpleNavHost
 import com.freeletics.khonshu.codegen.util.simpleNavHostLambda
@@ -118,12 +119,10 @@ private fun KSFunctionDeclaration.getInjectedParameters(vararg exclude: TypeName
 }
 
 private fun KSValueParameter.toComposableParameter(condition: (TypeName) -> Boolean): ComposableParameter? {
-    val type = type.toTypeName()
-    return if (condition(type)) {
-        ComposableParameter(name!!.asString(), type)
-    } else {
-        null
-    }
+    return type.toTypeName()
+        .functionToLambda()
+        .takeIf(condition)
+        ?.let { ComposableParameter(name!!.asString(), it) }
 }
 
 private fun KSFunctionDeclaration.navHostParameter(logger: KSPLogger): ComposableParameter? {

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/util/KotlinPoet.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/util/KotlinPoet.kt
@@ -136,6 +136,11 @@ internal fun TypeName.asLambdaParameter(): TypeName {
 // KSP and Anvil don't have the same behavior for returning lambdas
 // this turns all Function1 and Function2 types into lambdas
 internal fun TypeName.functionToLambda(): TypeName {
+    if (this is LambdaTypeName) {
+        val parameters = parameters.map { it.toBuilder(type = it.type.functionToLambda()).build() }
+        return LambdaTypeName.get(receiver, parameters, returnType.functionToLambda())
+            .copy(nullable = isNullable)
+    }
     if (this is ParameterizedTypeName && (rawType == function1 || rawType == function2 || rawType == function3)) {
         val parameters = typeArguments.dropLast(1).map { it.functionToLambda() }.toTypedArray()
         return LambdaTypeName.get(null, *parameters, returnType = typeArguments.last())

--- a/codegen-compiler/src/testFixtures/kotlin/com/freeletics/khonshu/codegen/KhonshuCompilation.kt
+++ b/codegen-compiler/src/testFixtures/kotlin/com/freeletics/khonshu/codegen/KhonshuCompilation.kt
@@ -16,6 +16,7 @@ import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import com.tschuchort.compiletesting.kspSourcesDir
 import com.tschuchort.compiletesting.symbolProcessorProviders
+import com.tschuchort.compiletesting.useKsp2
 import java.io.File
 import java.nio.file.Files
 import org.intellij.lang.annotations.Language
@@ -65,6 +66,7 @@ interface KhonshuCompilation {
             legacyCompilerPlugins: List<ComponentRegistrar> = emptyList(),
             symbolProcessors: List<SymbolProcessorProvider> = emptyList(),
             warningsAsErrors: Boolean = true,
+            ksp2: Boolean = false,
         ): KhonshuCompilation {
             return KspKhonshuCompilation(
                 sources = listOf(fileName to source),
@@ -72,6 +74,7 @@ interface KhonshuCompilation {
                 legacyCompilerPlugins = legacyCompilerPlugins,
                 symbolProcessors = symbolProcessors,
                 warningsAsErrors = warningsAsErrors,
+                ksp2 = ksp2,
             )
         }
     }
@@ -124,8 +127,12 @@ private class KspKhonshuCompilation(
     legacyCompilerPlugins: List<ComponentRegistrar>,
     symbolProcessors: List<SymbolProcessorProvider>,
     warningsAsErrors: Boolean,
+    ksp2: Boolean,
 ) : KhonshuCompilation {
     val compilation = KotlinCompilation().apply {
+        if (ksp2) {
+            useKsp2()
+        }
         symbolProcessorProviders = symbolProcessors.toMutableList()
         configure(sources, compilerPlugins, legacyCompilerPlugins, warningsAsErrors)
     }


### PR DESCRIPTION
The tests are now also run with ksp2 in addition to ksp1. There is a small behavior difference in how lambdas are represented in types which I added a fix for.