### PR TITLE
prepare for predictive back support

### DIFF
--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStack.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStack.kt
@@ -20,7 +20,7 @@ internal class MultiStack(
 ) {
 
     private val snapshotState: MutableState<StackSnapshot> =
-        mutableStateOf(currentStack.snapshot(startStack.id))
+        mutableStateOf(currentStack.snapshot(startStack.rootEntry))
     val snapshot: State<StackSnapshot>
         get() = snapshotState
 
@@ -45,7 +45,7 @@ internal class MultiStack(
 
     internal fun updateVisibleDestinations(notify: Boolean) {
         if (notify) {
-            snapshotState.value = currentStack.snapshot(startStack.id)
+            snapshotState.value = currentStack.snapshot(startStack.rootEntry)
         }
     }
 

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/Stack.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/Stack.kt
@@ -20,8 +20,8 @@ internal class Stack private constructor(
     val rootEntry: StackEntry<*> get() = stack.first()
     val isAtRoot: Boolean get() = !stack.last().removable
 
-    fun snapshot(startStackId: DestinationId<*>): StackSnapshot {
-        return StackSnapshot(stack.toList(), startStackId == id)
+    fun snapshot(startStackRootEntry: StackEntry<*>): StackSnapshot {
+        return StackSnapshot(stack.toList(), startStackRootEntry)
     }
 
     fun push(route: NavRoute) {

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackSnapshot.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackSnapshot.kt
@@ -23,7 +23,7 @@ public class StackSnapshot internal constructor(
         get() = entries.last()
 
     internal val previous: StackEntry<*>
-        get() = entries.getOrNull(entries.size - 2) ?: startStackRootEntry
+        get() = entries.getOrNull(entries.lastIndex - 1) ?: startStackRootEntry
 
     internal val canNavigateBack
         get() = entries.last().removable || startStackRootEntry.destinationId != root.destinationId

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackSnapshot.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackSnapshot.kt
@@ -12,7 +12,7 @@ import dev.drewhamilton.poko.Poko
 public class StackSnapshot internal constructor(
     @get:VisibleForTesting
     internal val entries: List<StackEntry<*>>,
-    private val startStack: Boolean,
+    private val startStackRootEntry: StackEntry<*>,
 ) {
     private var firstVisibleIndex: Int = -1
 
@@ -22,8 +22,11 @@ public class StackSnapshot internal constructor(
     internal val current: StackEntry<*>
         get() = entries.last()
 
+    internal val previous: StackEntry<*>
+        get() = entries.getOrNull(entries.size - 2) ?: startStackRootEntry
+
     internal val canNavigateBack
-        get() = !startStack || entries.last().removable
+        get() = entries.last().removable || startStackRootEntry.destinationId != root.destinationId
 
     internal inline fun forEachVisibleDestination(block: (StackEntry<*>) -> Unit) {
         if (firstVisibleIndex < 0) {

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/NavigationSetupTest.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/NavigationSetupTest.kt
@@ -217,7 +217,7 @@ internal class NavigationSetupTest {
         setup()
 
         val entry = factory.create(SimpleRoute(0))
-        hostNavigator.snapshot.value = StackSnapshot(listOf(entry), true)
+        hostNavigator.snapshot.value = StackSnapshot(listOf(entry), entry)
         entry.savedStateHandle.getStateFlow<Parcelable?>(resultRequest.key.requestKey, null).test {
             assertThat(awaitItem()).isEqualTo(null)
 
@@ -312,7 +312,7 @@ internal class NavigationSetupTest {
     @Test
     fun `collectAndHandleNavigationResults forwards results`() = runBlocking {
         val entry = factory.create(SimpleRoute(0))
-        hostNavigator.snapshot.value = StackSnapshot(listOf(entry), true)
+        hostNavigator.snapshot.value = StackSnapshot(listOf(entry), entry)
         CoroutineScope(dispatcher).launch {
             hostNavigator.collectAndHandleNavigationResults(resultRequest)
         }
@@ -326,7 +326,7 @@ internal class NavigationSetupTest {
     @Test
     fun `collectAndHandleNavigationResults forwards initial value if set`() = runBlocking {
         val entry = factory.create(SimpleRoute(0))
-        hostNavigator.snapshot.value = StackSnapshot(listOf(entry), true)
+        hostNavigator.snapshot.value = StackSnapshot(listOf(entry), entry)
         CoroutineScope(dispatcher).launch {
             hostNavigator.collectAndHandleNavigationResults(resultRequest)
         }
@@ -340,7 +340,7 @@ internal class NavigationSetupTest {
     @Test
     fun `collectAndHandleNavigationResults does not forward same result twice`() = runBlocking {
         val entry = factory.create(SimpleRoute(0))
-        hostNavigator.snapshot.value = StackSnapshot(listOf(entry), true)
+        hostNavigator.snapshot.value = StackSnapshot(listOf(entry), entry)
         val job = CoroutineScope(dispatcher).launch {
             hostNavigator.collectAndHandleNavigationResults(resultRequest)
         }

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/StackSnapshotTest.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/StackSnapshotTest.kt
@@ -1,5 +1,6 @@
 package com.freeletics.khonshu.navigation.internal
 
+import com.freeletics.khonshu.navigation.test.OtherRoot
 import com.freeletics.khonshu.navigation.test.OtherRoute
 import com.freeletics.khonshu.navigation.test.SimpleRoot
 import com.freeletics.khonshu.navigation.test.SimpleRoute
@@ -19,7 +20,7 @@ internal class StackSnapshotTest {
             listOf(
                 factory.create(StackEntry.Id("a"), SimpleRoot(0)),
             ),
-            startStack = false,
+            factory.create(StackEntry.Id("z"), OtherRoot(0)),
         )
 
         assertThat(stackSnapshot.visibleEntries).containsExactly(
@@ -34,7 +35,7 @@ internal class StackSnapshotTest {
             listOf(
                 factory.create(StackEntry.Id("a"), SimpleRoot(0)),
             ),
-            startStack = true,
+            factory.create(StackEntry.Id("a"), SimpleRoot(0)),
         )
 
         assertThat(stackSnapshot.visibleEntries).containsExactly(
@@ -50,7 +51,7 @@ internal class StackSnapshotTest {
                 factory.create(StackEntry.Id("a"), SimpleRoot(0)),
                 factory.create(StackEntry.Id("b"), SimpleRoute(0)),
             ),
-            startStack = false,
+            factory.create(StackEntry.Id("z"), OtherRoot(0)),
         )
 
         assertThat(stackSnapshot.visibleEntries).containsExactly(
@@ -68,7 +69,7 @@ internal class StackSnapshotTest {
                 factory.create(StackEntry.Id("c"), SimpleRoute(1)),
                 factory.create(StackEntry.Id("d"), SimpleRoute(2)),
             ),
-            startStack = false,
+            factory.create(StackEntry.Id("z"), OtherRoot(0)),
         )
 
         assertThat(stackSnapshot.visibleEntries).containsExactly(
@@ -84,7 +85,7 @@ internal class StackSnapshotTest {
                 factory.create(StackEntry.Id("a"), SimpleRoot(0)),
                 factory.create(StackEntry.Id("b"), OtherRoute(0)),
             ),
-            startStack = false,
+            factory.create(StackEntry.Id("z"), OtherRoot(0)),
         )
 
         assertThat(stackSnapshot.visibleEntries).containsExactly(
@@ -103,7 +104,7 @@ internal class StackSnapshotTest {
                 factory.create(StackEntry.Id("c"), ThirdRoute(0)),
                 factory.create(StackEntry.Id("d"), OtherRoute(1)),
             ),
-            startStack = false,
+            factory.create(StackEntry.Id("z"), OtherRoot(0)),
         )
 
         assertThat(stackSnapshot.visibleEntries).containsExactly(
@@ -123,7 +124,7 @@ internal class StackSnapshotTest {
                 factory.create(StackEntry.Id("b"), SimpleRoute(0)),
                 factory.create(StackEntry.Id("c"), OtherRoute(0)),
             ),
-            startStack = false,
+            factory.create(StackEntry.Id("z"), OtherRoot(0)),
         )
 
         assertThat(stackSnapshot.visibleEntries).containsExactly(
@@ -143,7 +144,7 @@ internal class StackSnapshotTest {
                 factory.create(StackEntry.Id("d"), ThirdRoute(0)),
                 factory.create(StackEntry.Id("e"), OtherRoute(1)),
             ),
-            startStack = false,
+            factory.create(StackEntry.Id("z"), OtherRoot(0)),
         )
 
         assertThat(stackSnapshot.visibleEntries).containsExactly(

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/StackTest.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/StackTest.kt
@@ -51,7 +51,7 @@ internal class StackTest {
     fun `computeVisibleEntries after construction`() {
         val stack = Stack.createWith(SimpleRoot(1), factory::create)
 
-        assertThat(stack.snapshot(stack.id).visibleEntries)
+        assertThat(stack.snapshot(stack.rootEntry).visibleEntries)
             .containsExactly(
                 factory.create(StackEntry.Id("100"), SimpleRoot(1)),
             )
@@ -63,7 +63,7 @@ internal class StackTest {
         val stack = Stack.createWith(SimpleRoot(1), factory::create)
         stack.push(SimpleRoute(2))
 
-        assertThat(stack.snapshot(stack.id).visibleEntries)
+        assertThat(stack.snapshot(stack.rootEntry).visibleEntries)
             .containsExactly(
                 factory.create(StackEntry.Id("101"), SimpleRoute(2)),
             )
@@ -77,7 +77,7 @@ internal class StackTest {
         val stack = Stack.createWith(SimpleRoot(1), factory::create)
         stack.push(OtherRoute(3))
 
-        assertThat(stack.snapshot(stack.id).visibleEntries)
+        assertThat(stack.snapshot(stack.rootEntry).visibleEntries)
             .containsExactly(
                 factory.create(StackEntry.Id("100"), SimpleRoot(1)),
                 factory.create(StackEntry.Id("101"), OtherRoute(3)),
@@ -92,7 +92,7 @@ internal class StackTest {
         val stack = Stack.createWith(SimpleRoot(1), factory::create)
         stack.push(ThirdRoute(4))
 
-        assertThat(stack.snapshot(stack.id).visibleEntries)
+        assertThat(stack.snapshot(stack.rootEntry).visibleEntries)
             .containsExactly(
                 factory.create(StackEntry.Id("100"), SimpleRoot(1)),
                 factory.create(StackEntry.Id("101"), ThirdRoute(4)),
@@ -115,7 +115,7 @@ internal class StackTest {
         stack.push(OtherRoute(9))
         stack.push(ThirdRoute(10))
 
-        assertThat(stack.snapshot(stack.id).visibleEntries)
+        assertThat(stack.snapshot(stack.rootEntry).visibleEntries)
             .containsExactly(
                 factory.create(StackEntry.Id("104"), SimpleRoute(5)),
                 factory.create(StackEntry.Id("105"), OtherRoute(6)),
@@ -142,7 +142,7 @@ internal class StackTest {
         stack.push(OtherRoute(9))
         stack.push(ThirdRoute(10))
 
-        assertThat(stack.snapshot(stack.id).visibleEntries)
+        assertThat(stack.snapshot(stack.rootEntry).visibleEntries)
             .containsExactly(
                 factory.create(StackEntry.Id("106"), SimpleRoute(7)),
                 factory.create(StackEntry.Id("107"), OtherRoute(8)),
@@ -169,7 +169,7 @@ internal class StackTest {
     fun `pop from a screen`() {
         val stack = Stack.createWith(SimpleRoot(1), factory::create)
         stack.push(SimpleRoute(2))
-        assertThat(stack.snapshot(stack.id).visibleEntries)
+        assertThat(stack.snapshot(stack.rootEntry).visibleEntries)
             .containsExactly(
                 factory.create(StackEntry.Id("101"), SimpleRoute(2)),
             )
@@ -177,7 +177,7 @@ internal class StackTest {
 
         stack.pop()
 
-        assertThat(stack.snapshot(stack.id).visibleEntries)
+        assertThat(stack.snapshot(stack.rootEntry).visibleEntries)
             .containsExactly(
                 factory.create(StackEntry.Id("100"), SimpleRoot(1)),
             )
@@ -191,7 +191,7 @@ internal class StackTest {
         val stack = Stack.createWith(SimpleRoot(1), factory::create)
         stack.push(SimpleRoute(2))
 
-        assertThat(stack.snapshot(stack.id).visibleEntries)
+        assertThat(stack.snapshot(stack.rootEntry).visibleEntries)
             .containsExactly(
                 factory.create(StackEntry.Id("101"), SimpleRoute(2)),
             )
@@ -200,7 +200,7 @@ internal class StackTest {
         stack.pop()
         stack.push(SimpleRoute(2))
 
-        assertThat(stack.snapshot(stack.id).visibleEntries)
+        assertThat(stack.snapshot(stack.rootEntry).visibleEntries)
             .containsExactly(
                 factory.create(StackEntry.Id("102"), SimpleRoute(2)),
             )
@@ -222,11 +222,11 @@ internal class StackTest {
         stack.push(OtherRoute(9))
         stack.push(ThirdRoute(10))
 
-        assertThat(stack.snapshot(stack.id).visibleEntries).hasSize(6)
+        assertThat(stack.snapshot(stack.rootEntry).visibleEntries).hasSize(6)
 
         stack.popUpTo(simpleRouteDestination.id, isInclusive = false)
 
-        assertThat(stack.snapshot(stack.id).visibleEntries)
+        assertThat(stack.snapshot(stack.rootEntry).visibleEntries)
             .containsExactly(
                 factory.create(StackEntry.Id("104"), SimpleRoute(5)),
             )
@@ -254,11 +254,11 @@ internal class StackTest {
         stack.push(OtherRoute(9))
         stack.push(ThirdRoute(10))
 
-        assertThat(stack.snapshot(stack.id).visibleEntries).hasSize(6)
+        assertThat(stack.snapshot(stack.rootEntry).visibleEntries).hasSize(6)
 
         stack.popUpTo(simpleRouteDestination.id, isInclusive = true)
 
-        assertThat(stack.snapshot(stack.id).visibleEntries)
+        assertThat(stack.snapshot(stack.rootEntry).visibleEntries)
             .containsExactly(
                 factory.create(StackEntry.Id("103"), SimpleRoute(4)),
             )
@@ -287,11 +287,11 @@ internal class StackTest {
         stack.push(OtherRoute(9))
         stack.push(ThirdRoute(10))
 
-        assertThat(stack.snapshot(stack.id).visibleEntries).hasSize(6)
+        assertThat(stack.snapshot(stack.rootEntry).visibleEntries).hasSize(6)
 
         stack.popUpTo(simpleRootDestination.id, isInclusive = false)
 
-        assertThat(stack.snapshot(stack.id).visibleEntries)
+        assertThat(stack.snapshot(stack.rootEntry).visibleEntries)
             .containsExactly(
                 factory.create(StackEntry.Id("100"), SimpleRoot(1)),
             )
@@ -323,7 +323,7 @@ internal class StackTest {
         stack.push(OtherRoute(9))
         stack.push(ThirdRoute(10))
 
-        assertThat(stack.snapshot(stack.id).visibleEntries).hasSize(6)
+        assertThat(stack.snapshot(stack.rootEntry).visibleEntries).hasSize(6)
 
         val exception = assertThrows(IllegalStateException::class.java) {
             stack.popUpTo(simpleRootDestination.id, isInclusive = true)
@@ -353,7 +353,7 @@ internal class StackTest {
         stack.push(ThirdRoute(6))
         stack.push(ThirdRoute(7))
 
-        assertThat(stack.snapshot(stack.id).visibleEntries).hasSize(3)
+        assertThat(stack.snapshot(stack.rootEntry).visibleEntries).hasSize(3)
 
         val exception = assertThrows(IllegalStateException::class.java) {
             stack.popUpTo(otherRouteDestination.id, isInclusive = false)
@@ -384,11 +384,11 @@ internal class StackTest {
         stack.push(ThirdRoute(6))
         stack.push(ThirdRoute(7))
 
-        assertThat(stack.snapshot(stack.id).visibleEntries).hasSize(3)
+        assertThat(stack.snapshot(stack.rootEntry).visibleEntries).hasSize(3)
 
         stack.clear()
 
-        assertThat(stack.snapshot(stack.id).visibleEntries)
+        assertThat(stack.snapshot(stack.rootEntry).visibleEntries)
             .containsExactly(
                 factory.create(StackEntry.Id("100"), SimpleRoot(1)),
             )

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/TestHostNavigator.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/TestHostNavigator.kt
@@ -26,7 +26,8 @@ internal class TestHostNavigator : HostNavigator() {
 
     val received = Turbine<NavEvent>()
 
-    override val snapshot: MutableState<StackSnapshot> = mutableStateOf(StackSnapshot(emptyList(), false))
+    private val entry = TestStackEntryFactory().create(SimpleRoot(0))
+    override val snapshot: MutableState<StackSnapshot> = mutableStateOf(StackSnapshot(listOf(entry), entry))
 
     override fun navigateTo(route: NavRoute) {
         received.add(NavEvent.NavigateToEvent(route))

--- a/sample/simple/app/simple/app-simple.gradle.kts
+++ b/sample/simple/app/simple/app-simple.gradle.kts
@@ -7,6 +7,7 @@ freeletics {
 
     app {
         applicationId("com.freeletics.khonshu.sample.simple")
+        minify()
     }
 }
 

--- a/sample/simple/app/simple/src/main/AndroidManifest.xml
+++ b/sample/simple/app/simple/src/main/AndroidManifest.xml
@@ -3,7 +3,8 @@
     <application
         android:name="com.freeletics.khonshu.sample.app.App"
         android:icon="@mipmap/ic_launcher"
-        android:label="Khonshu Example">
+        android:label="Khonshu Example"
+        android:enableOnBackInvokedCallback="true">
     </application>
 
 </manifest>

--- a/sample/simple/gradle/libs.versions.toml
+++ b/sample/simple/gradle/libs.versions.toml
@@ -1,10 +1,10 @@
 [versions]
 
-android-compile = "34"
+android-compile = "35"
+android-target = "35"
 android-desugarjdklibs = "2.0.4"
 android-gradle = "8.5.1"
 android-min = "26"
-android-target = "33"
 androidx-activity = "1.9.0"
 androidx-annotations = "1.6.0"
 androidx-compose-runtime = "1.6.8"


### PR DESCRIPTION
This adds an internal `previous: StackEntry<*>` to the snapshot so that we can show the previous screen for predictive back support. For proper multi back stack support this means that we need the `StackEntry` of the start stack inside the snapshot so that we are able to show that as well.