### PR TITLE
fix race condition with 2 DisposableEffect for back handlers

### DIFF
--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/PredictiveBackHandler.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/PredictiveBackHandler.kt
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.freeletics.khonshu.navigation.internal
+
+import androidx.activity.BackEventCompat
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.OnBackPressedDispatcher
+import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import java.util.concurrent.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.BufferOverflow.SUSPEND
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.Channel.Factory.BUFFERED
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.launch
+
+/**
+ * Copy of the AndroidX version that allows adding another callback for better ordering
+ * guarantees.
+ *
+ * --------
+ *
+ * An effect for handling predictive system back gestures.
+ *
+ * Calling this in your composable adds the given lambda to the [OnBackPressedDispatcher] of the
+ * [LocalOnBackPressedDispatcherOwner]. The lambda passes in a Flow<BackEventCompat> where each
+ * [BackEventCompat] reflects the progress of current gesture back. The lambda content should
+ * follow this structure:
+ *
+ * ```
+ * PredictiveBackHandler { progress: Flow<BackEventCompat> ->
+ *      // code for gesture back started
+ *      try {
+ *         progress.collect { backevent ->
+ *              // code for progress
+ *         }
+ *         // code for completion
+ *      } catch (e: CancellationException) {
+ *         // code for cancellation
+ *      }
+ * }
+ * ```
+ *
+ * If this is called by nested composables, if enabled, the inner most composable will consume
+ * the call to system back and invoke its lambda. The call will continue to propagate up until it
+ * finds an enabled BackHandler.
+ *
+ * @sample androidx.activity.compose.samples.PredictiveBack
+ *
+ * @param enabled if this BackHandler should be enabled, true by default
+ * @param onBack the action invoked by back gesture
+ */
+@Composable
+internal fun PredictiveBackHandler(
+    enabled: Boolean = true,
+    extraCallback: OnBackPressedCallback,
+    onBack: suspend (progress: @JvmSuppressWildcards Flow<BackEventCompat>) -> @JvmSuppressWildcards Unit,
+) {
+    // ensure we don't re-register callbacks when onBack changes
+    val currentOnBack by rememberUpdatedState(onBack)
+    val onBackScope = rememberCoroutineScope()
+
+    val backCallBack = remember {
+        object : OnBackPressedCallback(enabled) {
+            var onBackInstance: OnBackInstance? = null
+
+            override fun handleOnBackStarted(backEvent: BackEventCompat) {
+                super.handleOnBackStarted(backEvent)
+                // in case the previous onBackInstance was started by a normal back gesture
+                // we want to make sure it's still cancelled before we start a predictive
+                // back gesture
+                onBackInstance?.cancel()
+                onBackInstance = OnBackInstance(onBackScope, true, currentOnBack)
+            }
+
+            override fun handleOnBackProgressed(backEvent: BackEventCompat) {
+                super.handleOnBackProgressed(backEvent)
+                onBackInstance?.send(backEvent)
+            }
+
+            override fun handleOnBackPressed() {
+                // handleOnBackPressed could be called by regular back to restart
+                // a new back instance. If this is the case (where current back instance
+                // was NOT started by handleOnBackStarted) then we need to reset the previous
+                // regular back.
+                onBackInstance?.apply {
+                    if (!isPredictiveBack) {
+                        cancel()
+                        onBackInstance = null
+                    }
+                }
+                if (onBackInstance == null) {
+                    onBackInstance = OnBackInstance(onBackScope, false, currentOnBack)
+                }
+
+                // finally, we close the channel to ensure no more events can be sent
+                // but let the job complete normally
+                onBackInstance?.close()
+            }
+
+            override fun handleOnBackCancelled() {
+                super.handleOnBackCancelled()
+                // cancel will purge the channel of any sent events that are yet to be received
+                onBackInstance?.cancel()
+            }
+        }
+    }
+
+    LaunchedEffect(enabled) {
+        backCallBack.isEnabled = enabled
+    }
+
+    val backDispatcher = checkNotNull(LocalOnBackPressedDispatcherOwner.current) {
+        "No OnBackPressedDispatcherOwner was provided via LocalOnBackPressedDispatcherOwner"
+    }.onBackPressedDispatcher
+
+    DisposableEffect(backDispatcher) {
+        backDispatcher.addCallback(backCallBack)
+        backDispatcher.addCallback(extraCallback)
+
+        onDispose {
+            backCallBack.remove()
+            extraCallback.remove()
+        }
+    }
+}
+
+private class OnBackInstance(
+    scope: CoroutineScope,
+    val isPredictiveBack: Boolean,
+    onBack: suspend (progress: Flow<BackEventCompat>) -> Unit,
+) {
+    val channel = Channel<BackEventCompat>(capacity = BUFFERED, onBufferOverflow = SUSPEND)
+    val job = scope.launch {
+        var completed = false
+        onBack(
+            channel.consumeAsFlow().onCompletion {
+                completed = true
+            },
+        )
+        check(completed) {
+            "You must collect the progress flow"
+        }
+    }
+
+    fun send(backEvent: BackEventCompat) = channel.trySend(backEvent)
+
+    // idempotent if invoked more than once
+    fun close() = channel.close()
+
+    fun cancel() {
+        channel.cancel(CancellationException("onBack cancelled"))
+        job.cancel()
+    }
+}


### PR DESCRIPTION
`PredictiveBackHandler` uses a `DisposableEffect` to add its `OnBackPressedCallback` to the dispatcher and then we do the same for the `HostNavigator`'s callback. The order is important because if `navigator.backClicks` is collected it needs to take precedence over the predictive back handler. While testing I found some cases where this is not the case which resulted in custom back handling not working.

At least as an initial fix this copies `PredictiveBackHandler` and adds a parameter for an additional callback to it. This way both callbacks are added in the `DisposableEffect` and we can have our ordering guarantee.