### PR TITLE
use movableContentOf to avoid blinking

### DIFF
--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackEntry.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackEntry.kt
@@ -1,11 +1,14 @@
 package com.freeletics.khonshu.navigation.internal
 
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.movableContentOf
 import androidx.lifecycle.SavedStateHandle
 import com.freeletics.khonshu.navigation.BaseRoute
 import com.freeletics.khonshu.navigation.ContentDestination
 import com.freeletics.khonshu.navigation.NavRoot
 import com.freeletics.khonshu.navigation.NavRoute
+import com.freeletics.khonshu.navigation.OverlayDestination
 import dev.drewhamilton.poko.Poko
 
 @Poko
@@ -14,12 +17,15 @@ import dev.drewhamilton.poko.Poko
 public class StackEntry<T : BaseRoute> internal constructor(
     internal val id: Id,
     public val route: T,
-    internal val destination: ContentDestination<T>,
+    private val destination: ContentDestination<T>,
     public val savedStateHandle: SavedStateHandle,
     public val store: StackEntryStore,
 ) {
     internal val destinationId
         get() = route.destinationId
+
+    internal val isOverlay
+        get() = destination is OverlayDestination<*>
 
     @InternalNavigationCodegenApi
     public val extra: Any?
@@ -32,6 +38,10 @@ public class StackEntry<T : BaseRoute> internal constructor(
             is NavRoute -> true
             is NavRoot -> false
         }
+
+    internal fun content(snapshot: StackSnapshot): @Composable () -> Unit = movableContentOf {
+        destination.content(snapshot, this)
+    }
 
     internal fun close() {
         store.close()

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackSnapshot.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackSnapshot.kt
@@ -3,7 +3,6 @@ package com.freeletics.khonshu.navigation.internal
 import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.Immutable
 import com.freeletics.khonshu.navigation.BaseRoute
-import com.freeletics.khonshu.navigation.OverlayDestination
 import dev.drewhamilton.poko.Poko
 
 @Poko
@@ -22,8 +21,9 @@ public class StackSnapshot internal constructor(
     internal val current: StackEntry<*>
         get() = entries.last()
 
-    internal val previous: StackEntry<*>
-        get() = entries.getOrNull(entries.lastIndex - 1) ?: startStackRootEntry
+    internal val previous: StackEntry<*>?
+        get() = entries.getOrNull(entries.lastIndex - 1)
+            ?: startStackRootEntry.takeIf { current.id != it.id }
 
     internal val canNavigateBack
         get() = entries.last().removable || startStackRootEntry.destinationId != root.destinationId
@@ -40,7 +40,7 @@ public class StackSnapshot internal constructor(
 
     private fun computeFirstVisibleDestination() {
         firstVisibleIndex = entries.indexOfLast {
-            it.destination !is OverlayDestination<*>
+            !it.isOverlay
         }
     }
 


### PR DESCRIPTION
Currently when the animation finished and the previous entry becomes the current entry, the screen blinks once at the moment when the re-composition happens. This is because the composable is removed at it's previous place and added again in the new place. With this we're using `movableContentOf` to avoid that blinking and letting compose to re-use the already added composable.

https://github.com/user-attachments/assets/24e36e37-fa20-4cb9-acdd-c36026360056 

https://github.com/user-attachments/assets/c4c8ab1d-0c2f-4b82-bccf-148bc6d86c0e 





