### PR TITLE
support KSP2 in KSP 2.0.0-1.0.23

### DIFF
--- a/codegen-compiler/codegen-compiler.gradle.kts
+++ b/codegen-compiler/codegen-compiler.gradle.kts
@@ -39,4 +39,8 @@ dependencies {
     testFixturesImplementation(libs.anvil.annotations)
     testFixturesImplementation(testFixtures(libs.anvil.compiler.utils))
     testFixturesImplementation(libs.kotlin.compile.testing.ksp)
+    // explicitly depend on ksp to force the version to a newer one than compile testing uses
+    testFixturesImplementation(libs.ksp)
+    testFixturesImplementation(libs.ksp.deps)
+    testFixturesImplementation(libs.ksp.embeddable)
 }

--- a/codegen-compiler/codegen-compiler.gradle.kts
+++ b/codegen-compiler/codegen-compiler.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
     testFixturesImplementation(testFixtures(libs.anvil.compiler.utils))
     testFixturesImplementation(libs.kotlin.compile.testing.ksp)
     // explicitly depend on ksp to force the version to a newer one than compile testing uses
-    testFixturesImplementation(libs.ksp)
-    testFixturesImplementation(libs.ksp.deps)
-    testFixturesImplementation(libs.ksp.embeddable)
+    testFixturesRuntimeOnly(libs.ksp)
+    testFixturesRuntimeOnly(libs.ksp.deps)
+    testFixturesRuntimeOnly(libs.ksp.embeddable)
 }

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/KspParser.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/KspParser.kt
@@ -10,6 +10,7 @@ import com.freeletics.khonshu.codegen.util.functionToLambda
 import com.freeletics.khonshu.codegen.util.overlay
 import com.freeletics.khonshu.codegen.util.simpleNavHost
 import com.freeletics.khonshu.codegen.util.simpleNavHostLambda
+import com.freeletics.khonshu.codegen.util.simpleNavHostParameterized
 import com.freeletics.khonshu.codegen.util.stateMachine
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.KSPLogger
@@ -126,7 +127,9 @@ private fun KSValueParameter.toComposableParameter(condition: (TypeName) -> Bool
 }
 
 private fun KSFunctionDeclaration.navHostParameter(logger: KSPLogger): ComposableParameter? {
-    val parameter = getParameterWithType(simpleNavHost) ?: getParameterWithType(simpleNavHostLambda)
+    val parameter = getParameterWithType(simpleNavHost) ?:
+        getParameterWithType(simpleNavHostParameterized) ?:
+        getParameterWithType(simpleNavHostLambda)
     if (parameter == null) {
         logger.error("Could not find a NavHost parameter with type $simpleNavHost")
     }

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/KspParser.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/KspParser.kt
@@ -127,9 +127,9 @@ private fun KSValueParameter.toComposableParameter(condition: (TypeName) -> Bool
 }
 
 private fun KSFunctionDeclaration.navHostParameter(logger: KSPLogger): ComposableParameter? {
-    val parameter = getParameterWithType(simpleNavHost) ?:
-        getParameterWithType(simpleNavHostParameterized) ?:
-        getParameterWithType(simpleNavHostLambda)
+    val parameter = getParameterWithType(simpleNavHost)
+        ?: getParameterWithType(simpleNavHostParameterized)
+        ?: getParameterWithType(simpleNavHostLambda)
     if (parameter == null) {
         logger.error("Could not find a NavHost parameter with type $simpleNavHost")
     }

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/util/External.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/util/External.kt
@@ -3,7 +3,6 @@ package com.freeletics.khonshu.codegen.util
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.MemberName
-import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.UNIT
 import org.jetbrains.kotlin.name.FqName
@@ -52,7 +51,7 @@ internal val simpleNavHost = ClassName("com.freeletics.khonshu.codegen", "Simple
 internal val simpleNavHostParameterized = simpleNavHost.parameterizedBy(
     ClassName("androidx.compose.ui", "Modifier"),
     LambdaTypeName.get(null, navRoot, baseRoute, returnType = UNIT).copy(nullable = true),
-    UNIT
+    UNIT,
 )
 internal val simpleNavHostLambda = LambdaTypeName.get(
     null,

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/util/External.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/util/External.kt
@@ -3,6 +3,8 @@ package com.freeletics.khonshu.codegen.util
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.MemberName
+import com.squareup.kotlinpoet.ParameterizedTypeName
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.UNIT
 import org.jetbrains.kotlin.name.FqName
 
@@ -47,6 +49,11 @@ internal val internalNavigatorApi =
     ClassName("com.freeletics.khonshu.navigation.internal", "InternalNavigationCodegenApi")
 
 internal val simpleNavHost = ClassName("com.freeletics.khonshu.codegen", "SimpleNavHost")
+internal val simpleNavHostParameterized = simpleNavHost.parameterizedBy(
+    ClassName("androidx.compose.ui", "Modifier"),
+    LambdaTypeName.get(null, navRoot, baseRoute, returnType = UNIT).copy(nullable = true),
+    UNIT
+)
 internal val simpleNavHostLambda = LambdaTypeName.get(
     null,
     ClassName("androidx.compose.ui", "Modifier"),

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/util/KotlinPoet.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/util/KotlinPoet.kt
@@ -15,6 +15,7 @@ import com.squareup.kotlinpoet.KModifier.PRIVATE
 import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.UNIT
@@ -144,6 +145,10 @@ internal fun TypeName.functionToLambda(): TypeName {
     if (this is ParameterizedTypeName && (rawType == function1 || rawType == function2 || rawType == function3)) {
         val parameters = typeArguments.dropLast(1).map { it.functionToLambda() }.toTypedArray()
         return LambdaTypeName.get(null, *parameters, returnType = typeArguments.last())
+            .copy(nullable = isNullable)
+    }
+    if (this is ParameterizedTypeName) {
+        return rawType.parameterizedBy(typeArguments.map { it.functionToLambda() })
             .copy(nullable = isNullable)
     }
     return this

--- a/codegen-compiler/src/testFixtures/kotlin/com/freeletics/khonshu/codegen/KhonshuCompilation.kt
+++ b/codegen-compiler/src/testFixtures/kotlin/com/freeletics/khonshu/codegen/KhonshuCompilation.kt
@@ -108,7 +108,7 @@ private class AnvilKhonshuCompilation(
 ) : KhonshuCompilation {
     val compilation = AnvilCompilation().apply {
         configureAnvil(mode = AnvilCompilationMode.Embedded(codeGenerators = codeGenerators))
-        kotlinCompilation.configure(sources, compilerPlugins, legacyCompilerPlugins, warningsAsErrors)
+        kotlinCompilation.configure(sources, compilerPlugins, legacyCompilerPlugins, warningsAsErrors, "1.9")
     }
 
     override fun compile(block: KhonshuCompilation.(JvmCompilationResult) -> Unit) {
@@ -130,11 +130,12 @@ private class KspKhonshuCompilation(
     ksp2: Boolean,
 ) : KhonshuCompilation {
     val compilation = KotlinCompilation().apply {
+        val languageVersion = "1.9".takeUnless { ksp2 }
+        configure(sources, compilerPlugins, legacyCompilerPlugins, warningsAsErrors, languageVersion)
         if (ksp2) {
             useKsp2()
         }
         symbolProcessorProviders = symbolProcessors.toMutableList()
-        configure(sources, compilerPlugins, legacyCompilerPlugins, warningsAsErrors)
     }
 
     override fun compile(block: KhonshuCompilation.(JvmCompilationResult) -> Unit) {
@@ -152,11 +153,12 @@ private fun KotlinCompilation.configure(
     compilerPlugins: List<CompilerPluginRegistrar>,
     legacyCompilerPlugins: List<ComponentRegistrar>,
     warningsAsErrors: Boolean,
+    kotlinLanguageVersion: String? = null,
 ) {
     componentRegistrars += legacyCompilerPlugins
     compilerPluginRegistrars += compilerPlugins
     jvmTarget = "11"
-    languageVersion = "1.9"
+    languageVersion = kotlinLanguageVersion
     inheritClassPath = true
     messageOutputStream = System.out // see diagnostics in real time
     allWarningsAsErrors = warningsAsErrors

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -92,6 +92,9 @@ truth = { module = "com.google.truth:truth", version.ref = "truth" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 kotlin-compile-testing = { module = "dev.zacsweers.kctfork:core", version.ref = "kotlin-compile-testing" }
 kotlin-compile-testing-ksp = { module = "dev.zacsweers.kctfork:ksp", version.ref = "kotlin-compile-testing" }
+ksp = { module = "com.google.devtools.ksp:symbol-processing", version.ref = "ksp" }
+ksp-deps = { module = "com.google.devtools.ksp:symbol-processing-common-deps", version.ref = "ksp" }
+ksp-embeddable = { module = "com.google.devtools.ksp:symbol-processing-aa-embeddable", version.ref = "ksp" }
 
 [plugins]
 fgp-android = { id = "com.freeletics.gradle.android", version.ref = "fgp" }


### PR DESCRIPTION
With KSP 2.0.0-1.0.23 with KSP2 enabled the representation of the `SimpleNavHost` typealias that we receive has changed. So `simpleNavHostParameterized` is added as an additional type to check against.