### PR TITLE
also consider root from start stack in entryFor

### DIFF
--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackSnapshot.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackSnapshot.kt
@@ -48,6 +48,7 @@ public class StackSnapshot internal constructor(
     @InternalNavigationCodegenApi
     public fun <T : BaseRoute> entryFor(destinationId: DestinationId<T>): StackEntry<T> {
         return entries.lastOrNull { it.destinationId == destinationId } as StackEntry<T>?
+            ?: startStackRootEntry.takeIf { it.destinationId == destinationId } as StackEntry<T>?
             ?: throw IllegalStateException("Route $destinationId not found on back stack")
     }
 }


### PR DESCRIPTION
With predictive back the root of the start stack might be accessed through this even when we're in a different stack.