### PR TITLE
stop depending on NavEventNavigator in testing module

### DIFF
--- a/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavigatorTurbine.kt
+++ b/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavigatorTurbine.kt
@@ -310,7 +310,7 @@ public interface NavigatorTurbine {
 
 internal class DefaultNavigatorTurbine(
     private val turbine: ReceiveTurbine<NavEvent>,
-    private val dispatchBackPress: () -> Unit
+    private val dispatchBackPress: () -> Unit,
 ) : NavigatorTurbine {
     override fun dispatchBackPress() {
         dispatchBackPress.invoke()

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/ResultOwner.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/ResultOwner.kt
@@ -130,7 +130,7 @@ public sealed interface NavigationResultRequest<R : Parcelable> : ResultOwner<R>
      */
     @Poko
     @Parcelize
-    public class Key<R : Parcelable> internal constructor(
+    public class Key<R : Parcelable> @InternalNavigationTestingApi constructor(
         internal val destinationId: DestinationId<*>,
         @property:InternalNavigationTestingApi
         public val requestKey: String,
@@ -160,7 +160,7 @@ public sealed interface NavigationResultRequest<R : Parcelable> : ResultOwner<R>
 }
 
 @InternalNavigationTestingApi
-public class StandaloneNavigationResultRequest<R : Parcelable> internal constructor(
+public class StandaloneNavigationResultRequest<R : Parcelable> @InternalNavigationTestingApi constructor(
     override val key: NavigationResultRequest.Key<R>,
     @property:InternalNavigationTestingApi
     public val savedStateHandle: SavedStateHandle,


### PR DESCRIPTION
`TestHostNavigator` is currently internally just holding a `NavEventNavigator`. In preparation of removing the latter this dependency is now removed and `TestHostNavigator` will collect events on its own. Some of the event stream merging that is added here will be removed again in the end after the cleanup.