### PR TITLE
remove event based ResultOwner implementation

### DIFF
--- a/navigation-testing/api/android/navigation-testing.api
+++ b/navigation-testing/api/android/navigation-testing.api
@@ -33,8 +33,7 @@ public final class com/freeletics/khonshu/navigation/NavigatorTurbineKt {
 }
 
 public final class com/freeletics/khonshu/navigation/ResultOwnerTestingKt {
-	public static final fun sendResult (Lcom/freeletics/khonshu/navigation/ActivityResultRequest;Ljava/lang/Object;)V
-	public static final fun sendResult (Lcom/freeletics/khonshu/navigation/ManagedResultOwner;Landroid/os/Parcelable;)V
+	public static final fun sendResult (Lcom/freeletics/khonshu/navigation/ContractResultOwner;Ljava/lang/Object;)V
 	public static final fun sendResult (Lcom/freeletics/khonshu/navigation/NavigationResultRequest;Landroid/os/Parcelable;)V
 	public static final fun sendResult (Lcom/freeletics/khonshu/navigation/PermissionsResultRequest;Ljava/lang/String;Lcom/freeletics/khonshu/navigation/PermissionsResultRequest$PermissionResult;)V
 	public static final fun sendResult (Lcom/freeletics/khonshu/navigation/PermissionsResultRequest;Ljava/util/Map;)V

--- a/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/ResultOwnerTesting.kt
+++ b/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/ResultOwnerTesting.kt
@@ -2,12 +2,14 @@ package com.freeletics.khonshu.navigation
 
 import android.os.Parcelable
 import com.freeletics.khonshu.navigation.PermissionsResultRequest.PermissionResult
+import com.freeletics.khonshu.navigation.internal.DestinationId
+import com.freeletics.khonshu.navigation.internal.InternalNavigationCodegenApi
 
 /**
  * Send a fake result to collectors of this request. Can be used to test the result handling
  * logic.
  */
-public fun <O> ActivityResultRequest<*, O>.sendResult(result: O) {
+public fun <O> ContractResultOwner<*, *, O>.sendResult(result: O) {
     onResult(result)
 }
 
@@ -39,19 +41,8 @@ public fun PermissionsResultRequest.sendResult(result: Map<String, PermissionRes
  * Send a fake result to collectors of this request. Can be used to test the result handling
  * logic.
  */
-public fun <R : Parcelable> ManagedResultOwner<R>.sendResult(result: R) {
-    onResult(result)
-}
-
-/**
- * Send a fake result to collectors of this request. Can be used to test the result handling
- * logic.
- */
 public fun <R : Parcelable> NavigationResultRequest<R>.sendResult(result: R) {
-    when (this) {
-        is EventNavigationResultRequest -> onResult(result)
-        is StandaloneNavigationResultRequest -> savedStateHandle[key.requestKey] = result
-    }
+    savedStateHandle[key.requestKey] = result
 }
 
 /**
@@ -61,6 +52,7 @@ public fun <R : Parcelable> NavigationResultRequest<R>.sendResult(result: R) {
  * To test the result receiver use a real key from a request obtained by
  * [ResultNavigator.registerForNavigationResult].
  */
+@OptIn(InternalNavigationCodegenApi::class)
 public inline fun <reified R : Parcelable> fakeNavigationResultKey(): NavigationResultRequest.Key<R> {
-    return NavigationResultRequest.Key(NavRoute::class, R::class.qualifiedName!!)
+    return NavigationResultRequest.Key(DestinationId(NavRoute::class), R::class.qualifiedName!!)
 }

--- a/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/TestHostNavigator.kt
+++ b/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/TestHostNavigator.kt
@@ -104,7 +104,7 @@ public class TestHostNavigator(
     ): NavigationResultRequest<O> {
         val requestKey = "${id.route.qualifiedName!!}-$resultType"
         val key = NavigationResultRequest.Key<O>(id, requestKey)
-        return StandaloneNavigationResultRequest(key, SavedStateHandle())
+        return NavigationResultRequest(key, SavedStateHandle())
     }
 
     override fun backPresses(): Flow<Unit> {

--- a/navigation/api/android/navigation.api
+++ b/navigation/api/android/navigation.api
@@ -32,10 +32,6 @@ public abstract interface class com/freeletics/khonshu/navigation/BackIntercepto
 public abstract interface class com/freeletics/khonshu/navigation/BaseRoute : android/os/Parcelable {
 }
 
-public abstract class com/freeletics/khonshu/navigation/ContractResultOwner : com/freeletics/khonshu/navigation/ManagedResultOwner {
-	public static final field $stable I
-}
-
 public abstract class com/freeletics/khonshu/navigation/DestinationNavigator : com/freeletics/khonshu/navigation/ActivityNavigator, com/freeletics/khonshu/navigation/BackInterceptor, com/freeletics/khonshu/navigation/Navigator, com/freeletics/khonshu/navigation/ResultNavigator {
 	public static final field $stable I
 	public fun <init> (Lcom/freeletics/khonshu/navigation/HostNavigator;)V
@@ -92,8 +88,18 @@ public abstract interface class com/freeletics/khonshu/navigation/NavRoot : com/
 public abstract interface class com/freeletics/khonshu/navigation/NavRoute : com/freeletics/khonshu/navigation/BaseRoute {
 }
 
-public abstract interface class com/freeletics/khonshu/navigation/NavigationResultRequest : com/freeletics/khonshu/navigation/ResultOwner {
-	public abstract fun getKey ()Lcom/freeletics/khonshu/navigation/NavigationResultRequest$Key;
+public final class com/freeletics/khonshu/navigation/NavigationResultRequest : com/freeletics/khonshu/navigation/ResultOwner {
+	public static final field $stable I
+	public final fun getKey ()Lcom/freeletics/khonshu/navigation/NavigationResultRequest$Key;
+	public fun getResults ()Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class com/freeletics/khonshu/navigation/NavigationResultRequest$InitialValue$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/freeletics/khonshu/navigation/NavigationResultRequest$InitialValue;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/freeletics/khonshu/navigation/NavigationResultRequest$InitialValue;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/freeletics/khonshu/navigation/NavigationResultRequest$Key : android/os/Parcelable {

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackHostNavigator.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackHostNavigator.kt
@@ -10,7 +10,6 @@ import com.freeletics.khonshu.navigation.NavRoot
 import com.freeletics.khonshu.navigation.NavRoute
 import com.freeletics.khonshu.navigation.NavigationResultRequest
 import com.freeletics.khonshu.navigation.Navigator
-import com.freeletics.khonshu.navigation.StandaloneNavigationResultRequest
 import com.freeletics.khonshu.navigation.deeplinks.DeepLinkHandler
 import com.freeletics.khonshu.navigation.deeplinks.extractDeepLinkRoutes
 import kotlin.reflect.KClass
@@ -108,7 +107,7 @@ internal class MultiStackHostNavigator(
     ): NavigationResultRequest<O> {
         val requestKey = "${id.route.qualifiedName!!}-$resultType"
         val key = NavigationResultRequest.Key<O>(id, requestKey)
-        return StandaloneNavigationResultRequest(key, snapshot.value.entryFor(key.destinationId).savedStateHandle)
+        return NavigationResultRequest(key, snapshot.value.entryFor(id).savedStateHandle)
     }
 
     override val onBackPressedCallback = DelegatingOnBackPressedCallback()

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/ResulterOwnerTest.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/ResulterOwnerTest.kt
@@ -1,14 +1,17 @@
 package com.freeletics.khonshu.navigation
 
+import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.freeletics.khonshu.navigation.PermissionsResultRequest.PermissionResult
+import com.freeletics.khonshu.navigation.test.SimpleRoute
+import com.freeletics.khonshu.navigation.test.simpleRootDestination
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
 
 internal class ResulterOwnerTest {
     @Test
-    fun `ResultOwner emits events`(): Unit = runBlocking {
+    fun `ContractResultOwner emits events`(): Unit = runBlocking {
         val owner = PermissionsResultRequest()
 
         owner.results.test {
@@ -24,7 +27,7 @@ internal class ResulterOwnerTest {
     }
 
     @Test
-    fun `ResultOwner emits results that were delivered before collection`(): Unit = runBlocking {
+    fun `ContractResultOwner emits results that were delivered before collection`(): Unit = runBlocking {
         val owner = PermissionsResultRequest()
 
         owner.onResult(mapOf("a" to PermissionResult.Granted))
@@ -39,7 +42,7 @@ internal class ResulterOwnerTest {
     }
 
     @Test
-    fun `ResultOwner emits results were delivered before and during collection`(): Unit = runBlocking {
+    fun `ContractResultOwner emits results were delivered before and during collection`(): Unit = runBlocking {
         val owner = PermissionsResultRequest()
 
         owner.onResult(mapOf("a" to PermissionResult.Granted))
@@ -48,6 +51,49 @@ internal class ResulterOwnerTest {
 
             owner.onResult(mapOf("b" to PermissionResult.Denied(true)))
             assertThat(awaitItem()).isEqualTo(mapOf("b" to PermissionResult.Denied(true)))
+        }
+    }
+
+    @Test
+    fun `NavigationResultOwner emits events`(): Unit = runBlocking {
+        val handle = SavedStateHandle()
+        val owner = NavigationResultRequest(NavigationResultRequest.Key(simpleRootDestination.id, "key"), handle)
+
+        owner.results.test {
+            handle["key"] = SimpleRoute(1)
+            assertThat(awaitItem()).isEqualTo(SimpleRoute(1))
+
+            handle["key"] = SimpleRoute(2)
+            assertThat(awaitItem()).isEqualTo(SimpleRoute(2))
+
+            handle["key"] = SimpleRoute(3)
+            assertThat(awaitItem()).isEqualTo(SimpleRoute(3))
+        }
+    }
+
+    @Test
+    fun `NavigationResultOwner emits results that were delivered before collection`(): Unit = runBlocking {
+        val handle = SavedStateHandle()
+        val owner = NavigationResultRequest(NavigationResultRequest.Key(simpleRootDestination.id, "key"), handle)
+
+        handle["key"] = SimpleRoute(1)
+
+        owner.results.test {
+            assertThat(awaitItem()).isEqualTo(SimpleRoute(1))
+        }
+    }
+
+    @Test
+    fun `NavigationResultOwner emits results were delivered before and during collection`(): Unit = runBlocking {
+        val handle = SavedStateHandle()
+        val owner = NavigationResultRequest(NavigationResultRequest.Key(simpleRootDestination.id, "key"), handle)
+
+        handle["key"] = SimpleRoute(1)
+        owner.results.test {
+            assertThat(awaitItem()).isEqualTo(SimpleRoute(1))
+
+            handle["key"] = SimpleRoute(2)
+            assertThat(awaitItem()).isEqualTo(SimpleRoute(2))
         }
     }
 }


### PR DESCRIPTION
We don't need the event based `EventNavigationResultRequest` anymore since `NavEventNavigator` is gone. With this `StandaloneNavigationResultRequest` can be merged into the `NavigationResultRequest` base class. `ManagedResultOwner` also only has one usage now so it was merged with `ContractResultOwner`.