### PR TITLE
refactor NavRoot/backstack related navigation methods

### DIFF
--- a/docs/navigation/back-stacks.md
+++ b/docs/navigation/back-stacks.md
@@ -33,21 +33,20 @@ When using multiple back stacks the start route of the nav host should be a `Nav
 
 ## Navigation
 
-Starting a new back stack is then as simple as calling `HostNavigator.navigateToRoot(LibraryTab)`.
+Starting a new back stack is then as simple as calling `HostNavigator.switchBackStack(LibraryTab)`.
 This will save the state of the current back stack and remove it and then create a new one for
-`LibraryTab`. Note that the nav hosts start route/destination will always remain on the back stack.
-If `HomeTab` was used as start route, then calling `navigateToRoot(LibraryTab)` would always result
-in a back stack of `HomeTab` -> `LibraryTab` and pressing the back button would show home again.
-Back would only exit the app from `HomeTab`.
+`LibraryTab`. If `LibraryTab` was shown before it will automatically show the existing back stack instead of
+creating a new one. If the back stack was `LibraryTab` -> `Subscreen1` before, calling `switchBackStack(LibraryTab)`
+will result in `Subscreen1` being shown.
 
-If the current back stack should not be saved `saveCurrentRootState = false` can be passed as an
-additional parameter to `navigateToRoot`.
+To reset a back stack or open it at its root without any restoration of previous state there is `showRoot`. In
+the example above calling `HostNavigator.showRoot(LibraryTab)` would result in the back stack of `LibraryTab` being
+cleared, so that `LibraryTab` is shown instead of `Subscreen1`.
 
-It is also possible to restore a previously as part of the `navigateToRoot` operation by passing
-`restoreRootState = true` to it. This will then restore a previously saved back stack if there was
-one. The saved back stack is identified by the `NavRoot`. If `LibraryTab` was open before and the
-user was viewing `LibrarySubscreenA` when navigating to a different tab then the next
-`navigateToRoot(LibraryTab, restoreRootState = true)` call would result in `HomeTab` -> `LibraryTab`
--> `LibrarySubscreenA` as back stack. Without the `restoreRootState = true` or when explicitly
-passing `false` the previously saved back stack of `LibraryTab` would be cleared and `LibraryTab`
-would be visible instead of `LibrarySubscreenA`.
+Note that the nav hosts start route/destination will always remain on the back stack. If `HomeTab` was used as
+start route, then calling `switchBackStack(LibraryTab)` would always result in a back stack of `HomeTab` ->
+`LibraryTab` and pressing the back button would show home again. Back would only exit the app from `HomeTab`.
+
+The last back stack related navigation method is `replaceAllBackStacks(root: NavRoot)`. This will clear all back
+stacks including the start back stack and then create a new one with `root`. This method should be used very rarely.
+The primary use case is to change the start destination, for example when the user logs in or out.

--- a/navigation-testing/api/android/navigation-testing.api
+++ b/navigation-testing/api/android/navigation-testing.api
@@ -7,13 +7,13 @@ public abstract interface class com/freeletics/khonshu/navigation/NavigatorTurbi
 	public abstract fun awaitNavigateTo (Lcom/freeletics/khonshu/navigation/ActivityRoute;Lcom/freeletics/khonshu/navigation/NavRoute;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun awaitNavigateTo (Lcom/freeletics/khonshu/navigation/NavRoute;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun awaitNavigateTo$default (Lcom/freeletics/khonshu/navigation/NavigatorTurbine;Lcom/freeletics/khonshu/navigation/ActivityRoute;Lcom/freeletics/khonshu/navigation/NavRoute;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public abstract fun awaitNavigateToRoot (Lcom/freeletics/khonshu/navigation/NavRoot;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun awaitNavigateUp (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun awaitNavigationResult (Lcom/freeletics/khonshu/navigation/NavigationResultRequest$Key;Landroid/os/Parcelable;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun awaitReplaceAll (Lcom/freeletics/khonshu/navigation/NavRoot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun awaitReplaceAllBackStacks (Lcom/freeletics/khonshu/navigation/NavRoot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun awaitRequestPermissions (Lcom/freeletics/khonshu/navigation/PermissionsResultRequest;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun awaitRequestPermissions (Lcom/freeletics/khonshu/navigation/PermissionsResultRequest;[Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun awaitResetToRoot (Lcom/freeletics/khonshu/navigation/NavRoot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun awaitShowRoot (Lcom/freeletics/khonshu/navigation/NavRoot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun awaitSwitchBackStack (Lcom/freeletics/khonshu/navigation/NavRoot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun cancel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun cancelAndIgnoreRemainingNavEvents (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun dispatchBackPress ()V
@@ -53,11 +53,11 @@ public final class com/freeletics/khonshu/navigation/TestHostNavigator : com/fre
 	public fun navigateBack ()V
 	public fun navigateBackTo (Lkotlin/reflect/KClass;Z)V
 	public fun navigateTo (Lcom/freeletics/khonshu/navigation/NavRoute;)V
-	public fun navigateToRoot (Lcom/freeletics/khonshu/navigation/NavRoot;Z)V
 	public fun navigateUp ()V
-	public fun replaceAll (Lcom/freeletics/khonshu/navigation/NavRoot;)V
-	public fun resetToRoot (Lcom/freeletics/khonshu/navigation/NavRoot;)V
+	public fun replaceAllBackStacks (Lcom/freeletics/khonshu/navigation/NavRoot;)V
 	public final fun setHandleDeepLinkRoute (Lcom/freeletics/khonshu/navigation/NavRoute;)V
+	public fun showRoot (Lcom/freeletics/khonshu/navigation/NavRoot;)V
+	public fun switchBackStack (Lcom/freeletics/khonshu/navigation/NavRoot;)V
 }
 
 public final class com/freeletics/khonshu/navigation/deeplinks/DeepLinkDefinition {

--- a/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavigatorTurbine.kt
+++ b/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavigatorTurbine.kt
@@ -129,16 +129,6 @@ public interface NavigatorTurbine {
     public suspend fun awaitNavigateTo(route: NavRoute)
 
     /**
-     * Assert that the next event received was a navigation event to the given [root]. This function
-     * will suspend if no events have been received.
-     *
-     * @throws AssertionError - if the next event was not a matching event.
-     */
-    public suspend fun awaitSwitchBackStack(
-        root: NavRoot,
-    )
-
-    /**
      * Assert that the next event received was a navigation event to the given [route]. This function
      * will suspend if no events have been received.
      *
@@ -182,24 +172,28 @@ public interface NavigatorTurbine {
     )
 
     /**
-     * Assert that the next event received was a "reset to root" navigation event with matching
+     * Assert that the next event received was a "switch back stack" navigation event with matching
      * parameters. This function will suspend if no events have been received.
      *
      * @throws AssertionError - if the next event was not a matching event.
      */
-    public suspend fun awaitShowRoot(
-        root: NavRoot,
-    )
+    public suspend fun awaitSwitchBackStack(root: NavRoot)
 
     /**
-     * Assert that the next event received was a "replace all" navigation event with matching
+     * Assert that the next event received was a "show root" navigation event with matching
      * parameters. This function will suspend if no events have been received.
      *
      * @throws AssertionError - if the next event was not a matching event.
      */
-    public suspend fun awaitReplaceAllBackStacks(
-        root: NavRoot,
-    )
+    public suspend fun awaitShowRoot(root: NavRoot)
+
+    /**
+     * Assert that the next event received was a "replace all back stacks" navigation event with matching
+     * parameters. This function will suspend if no events have been received.
+     *
+     * @throws AssertionError - if the next event was not a matching event.
+     */
+    public suspend fun awaitReplaceAllBackStacks(root: NavRoot)
 
     /**
      * Assert that the next event received was a navigate for result event to [request].

--- a/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavigatorTurbine.kt
+++ b/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavigatorTurbine.kt
@@ -134,9 +134,8 @@ public interface NavigatorTurbine {
      *
      * @throws AssertionError - if the next event was not a matching event.
      */
-    public suspend fun awaitNavigateToRoot(
+    public suspend fun awaitSwitchBackStack(
         root: NavRoot,
-        restoreRootState: Boolean,
     )
 
     /**
@@ -188,7 +187,7 @@ public interface NavigatorTurbine {
      *
      * @throws AssertionError - if the next event was not a matching event.
      */
-    public suspend fun awaitResetToRoot(
+    public suspend fun awaitShowRoot(
         root: NavRoot,
     )
 
@@ -198,7 +197,7 @@ public interface NavigatorTurbine {
      *
      * @throws AssertionError - if the next event was not a matching event.
      */
-    public suspend fun awaitReplaceAll(
+    public suspend fun awaitReplaceAllBackStacks(
         root: NavRoot,
     )
 
@@ -278,14 +277,6 @@ internal class DefaultNavigatorTurbine(
         Truth.assertThat(turbine.awaitItem()).isEqualTo(event)
     }
 
-    override suspend fun awaitNavigateToRoot(
-        root: NavRoot,
-        restoreRootState: Boolean,
-    ) {
-        val event = NavigateToRootEvent(root, restoreRootState)
-        Truth.assertThat(turbine.awaitItem()).isEqualTo(event)
-    }
-
     override suspend fun awaitNavigateTo(route: ActivityRoute, fallbackRoute: NavRoute?) {
         val event = NavigateToActivityEvent(ActivityEvent.NavigateTo(route, fallbackRoute))
         Truth.assertThat(turbine.awaitItem()).isEqualTo(event)
@@ -316,15 +307,18 @@ internal class DefaultNavigatorTurbine(
         Truth.assertThat(turbine.awaitItem()).isEqualTo(event)
     }
 
-    override suspend fun awaitResetToRoot(
-        root: NavRoot,
-    ) {
-        val event = ResetToRootEvent(root)
+    override suspend fun awaitSwitchBackStack(root: NavRoot) {
+        val event = SwitchBackStackEvent(root)
         Truth.assertThat(turbine.awaitItem()).isEqualTo(event)
     }
 
-    override suspend fun awaitReplaceAll(root: NavRoot) {
-        val event = ReplaceAllEvent(root)
+    override suspend fun awaitShowRoot(root: NavRoot) {
+        val event = ShowRootEvent(root)
+        Truth.assertThat(turbine.awaitItem()).isEqualTo(event)
+    }
+
+    override suspend fun awaitReplaceAllBackStacks(root: NavRoot) {
+        val event = ReplaceAllBackStacksEvent(root)
         Truth.assertThat(turbine.awaitItem()).isEqualTo(event)
     }
 

--- a/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/TestEvent.kt
+++ b/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/TestEvent.kt
@@ -14,17 +14,6 @@ internal class NavigateToEvent(
     private val route: NavRoute,
 ) : TestEvent
 
-@Poko
-internal class NavigateToRootEvent(
-    private val root: NavRoot,
-    private val restoreRootState: Boolean,
-) : TestEvent
-
-@Poko
-internal class NavigateToActivityEvent(
-    private val event: ActivityEvent.NavigateTo,
-) : TestEvent
-
 internal data object UpEvent : TestEvent
 
 internal data object BackEvent : TestEvent
@@ -36,13 +25,23 @@ internal class BackToEvent(
 ) : TestEvent
 
 @Poko
-internal class ResetToRootEvent(
+internal class SwitchBackStackEvent(
     private val root: NavRoot,
 ) : TestEvent
 
 @Poko
-internal class ReplaceAllEvent(
+internal class ShowRootEvent(
     private val root: NavRoot,
+) : TestEvent
+
+@Poko
+internal class ReplaceAllBackStacksEvent(
+    private val root: NavRoot,
+) : TestEvent
+
+@Poko
+internal class NavigateToActivityEvent(
+    private val event: ActivityEvent.NavigateTo,
 ) : TestEvent
 
 @Poko

--- a/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/TestHostNavigator.kt
+++ b/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/TestHostNavigator.kt
@@ -64,10 +64,6 @@ public class TestHostNavigator(
         eventTurbine += NavigateToEvent(route)
     }
 
-    override fun navigateToRoot(root: NavRoot, restoreRootState: Boolean) {
-        eventTurbine += NavigateToRootEvent(root, restoreRootState)
-    }
-
     override fun navigateUp() {
         eventTurbine += UpEvent
     }
@@ -80,12 +76,16 @@ public class TestHostNavigator(
         eventTurbine += BackToEvent(popUpTo, inclusive)
     }
 
-    override fun resetToRoot(root: NavRoot) {
-        eventTurbine += ResetToRootEvent(root)
+    override fun switchBackStack(root: NavRoot) {
+        eventTurbine += SwitchBackStackEvent(root)
     }
 
-    override fun replaceAll(root: NavRoot) {
-        eventTurbine += ReplaceAllEvent(root)
+    override fun showRoot(root: NavRoot) {
+        eventTurbine += ShowRootEvent(root)
+    }
+
+    override fun replaceAllBackStacks(root: NavRoot) {
+        eventTurbine += ReplaceAllBackStacksEvent(root)
     }
 
     override fun <O : Parcelable> deliverNavigationResult(key: NavigationResultRequest.Key<O>, result: O) {

--- a/navigation/api/android/navigation.api
+++ b/navigation/api/android/navigation.api
@@ -42,10 +42,10 @@ public abstract class com/freeletics/khonshu/navigation/DestinationNavigator : c
 	public fun navigateBack ()V
 	public fun navigateBackTo (Lkotlin/reflect/KClass;Z)V
 	public fun navigateTo (Lcom/freeletics/khonshu/navigation/NavRoute;)V
-	public fun navigateToRoot (Lcom/freeletics/khonshu/navigation/NavRoot;Z)V
 	public fun navigateUp ()V
-	public fun replaceAll (Lcom/freeletics/khonshu/navigation/NavRoot;)V
-	public fun resetToRoot (Lcom/freeletics/khonshu/navigation/NavRoot;)V
+	public fun replaceAllBackStacks (Lcom/freeletics/khonshu/navigation/NavRoot;)V
+	public fun showRoot (Lcom/freeletics/khonshu/navigation/NavRoot;)V
+	public fun switchBackStack (Lcom/freeletics/khonshu/navigation/NavRoot;)V
 }
 
 public abstract interface class com/freeletics/khonshu/navigation/ExternalActivityRoute : com/freeletics/khonshu/navigation/ActivityRoute {
@@ -130,11 +130,10 @@ public abstract interface class com/freeletics/khonshu/navigation/Navigator {
 	public abstract fun navigateBackTo (Lkotlin/reflect/KClass;Z)V
 	public static synthetic fun navigateBackTo$default (Lcom/freeletics/khonshu/navigation/Navigator;Lkotlin/reflect/KClass;ZILjava/lang/Object;)V
 	public abstract fun navigateTo (Lcom/freeletics/khonshu/navigation/NavRoute;)V
-	public abstract fun navigateToRoot (Lcom/freeletics/khonshu/navigation/NavRoot;Z)V
-	public static synthetic fun navigateToRoot$default (Lcom/freeletics/khonshu/navigation/Navigator;Lcom/freeletics/khonshu/navigation/NavRoot;ZILjava/lang/Object;)V
 	public abstract fun navigateUp ()V
-	public abstract fun replaceAll (Lcom/freeletics/khonshu/navigation/NavRoot;)V
-	public abstract fun resetToRoot (Lcom/freeletics/khonshu/navigation/NavRoot;)V
+	public abstract fun replaceAllBackStacks (Lcom/freeletics/khonshu/navigation/NavRoot;)V
+	public abstract fun showRoot (Lcom/freeletics/khonshu/navigation/NavRoot;)V
+	public abstract fun switchBackStack (Lcom/freeletics/khonshu/navigation/NavRoot;)V
 }
 
 public final class com/freeletics/khonshu/navigation/Navigator$Companion {

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/Navigator.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/Navigator.kt
@@ -13,16 +13,6 @@ public interface Navigator {
     public fun navigateTo(route: NavRoute)
 
     /**
-     * Triggers navigation to the given [root]. The current back stack will be removed
-     * and saved. Whether the backstack of the given `root` is restored depends on
-     * [restoreRootState].
-     */
-    public fun navigateToRoot(
-        root: NavRoot,
-        restoreRootState: Boolean = false,
-    )
-
-    /**
      * Triggers up navigation.
      */
     public fun navigateUp()
@@ -39,20 +29,30 @@ public interface Navigator {
     public fun <T : BaseRoute> navigateBackTo(popUpTo: KClass<T>, inclusive: Boolean = false)
 
     /**
-     * Reset the back stack to the given [root]. The current back stack will cleared and if
-     * root was already on it it will be recreated.
+     * Show the existing back stack for [root] or create a new back stack if none exists. If an existing back stack
+     * is shown it will be shown in it's previous state. If [root] is the root of the current back stack this is a
+     * no-op.
+     *
+     * The back stack that is shown at the time of calling this method will not back stack will not be modified.
      */
-    public fun resetToRoot(root: NavRoot)
+    public fun switchBackStack(root: NavRoot)
 
     /**
-     * Replace the current back stack with the given [root].
-     * The current back stack will cleared and the given [root] will be recreated.
-     * After this call the back stack will only contain the given [root].
+     * Show [root] as the current destination. If there already is a back stack for [root], regardless of whether
+     * it is the current back stack or not, the stack will be cleared.
      *
-     * This differs from [resetToRoot] in that [resetToRoot] does not pop the start route (exclusive)
-     * whereas this does.
+     * The back stack that is shown at the time of calling this method, if it isn't the back stack of [root],
+     * will not back stack will not be modified.
      */
-    public fun replaceAll(root: NavRoot)
+    public fun showRoot(root: NavRoot)
+
+    /**
+     * Remove all back stacks and create a new back stack with the given [root].
+     *
+     * This should only be used when changing the start destination of the app. For all other cases [showRoot] should
+     * be used.
+     */
+    public fun replaceAllBackStacks(root: NavRoot)
 
     public companion object {
         /**

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStack.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStack.kt
@@ -83,12 +83,9 @@ internal class MultiStack(
         updateVisibleDestinations(notify)
     }
 
-    fun push(root: NavRoot, clearTargetStack: Boolean, notify: Boolean = true) {
+    fun switchStack(root: NavRoot, clearTargetStack: Boolean, notify: Boolean = true) {
         val stack = getBackStack(root)
         currentStack = if (stack != null) {
-            check(currentStack.id != stack.id) {
-                "$root is already the current stack"
-            }
             if (clearTargetStack) {
                 removeBackStack(stack)
                 createBackStack(root)
@@ -100,25 +97,6 @@ internal class MultiStack(
         }
         if (stack?.id == startStack.id) {
             startStack = currentStack
-        }
-        updateVisibleDestinations(notify)
-    }
-
-    fun resetToRoot(root: NavRoot, notify: Boolean = true) {
-        if (root.destinationId == startStack.id) {
-            if (currentStack.id != startStack.id) {
-                removeBackStack(currentStack)
-            }
-            removeBackStack(startStack)
-            val newStack = createBackStack(root)
-            startStack = newStack
-            currentStack = newStack
-        } else if (root.destinationId == currentStack.id) {
-            removeBackStack(currentStack)
-            val newStack = createBackStack(root)
-            currentStack = newStack
-        } else {
-            error("$root is not on the current back stack")
         }
         updateVisibleDestinations(notify)
     }

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackHostNavigator.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackHostNavigator.kt
@@ -47,7 +47,7 @@ internal class MultiStackHostNavigator(
             return false
         }
 
-        stack.resetToRoot(stack.startRoot)
+        stack.switchStack(stack.startRoot, clearTargetStack = true)
 
         deepLinkRoutes.forEachIndexed { index, route ->
             when (route) {
@@ -57,7 +57,7 @@ internal class MultiStackHostNavigator(
                         "$route is the start root which is not allowed to be part of a deep " +
                             "link because it will always be on the back stack"
                     }
-                    stack.push(route, clearTargetStack = true)
+                    stack.switchStack(route, clearTargetStack = true)
                 }
                 is NavRoute -> stack.push(route)
             }
@@ -68,10 +68,6 @@ internal class MultiStackHostNavigator(
 
     override fun navigateTo(route: NavRoute) {
         stack.push(route)
-    }
-
-    override fun navigateToRoot(root: NavRoot, restoreRootState: Boolean) {
-        stack.push(root, clearTargetStack = !restoreRootState)
     }
 
     override fun navigateUp() {
@@ -89,11 +85,15 @@ internal class MultiStackHostNavigator(
         stack.popUpTo(DestinationId(popUpTo), inclusive)
     }
 
-    override fun resetToRoot(root: NavRoot) {
-        stack.resetToRoot(root)
+    override fun switchBackStack(root: NavRoot) {
+        stack.switchStack(root, clearTargetStack = false)
     }
 
-    override fun replaceAll(root: NavRoot) {
+    override fun showRoot(root: NavRoot) {
+        stack.switchStack(root, clearTargetStack = true)
+    }
+
+    override fun replaceAllBackStacks(root: NavRoot) {
         stack.replaceAll(root)
     }
 
@@ -141,10 +141,6 @@ internal class MultiStackHostNavigator(
             stack.push(route, notify = false)
         }
 
-        override fun navigateToRoot(root: NavRoot, restoreRootState: Boolean) {
-            stack.push(root, clearTargetStack = !restoreRootState, notify = false)
-        }
-
         override fun navigateUp() {
             stack.popCurrentStack(notify = false)
         }
@@ -157,11 +153,15 @@ internal class MultiStackHostNavigator(
             stack.popUpTo(DestinationId(popUpTo), inclusive, notify = false)
         }
 
-        override fun resetToRoot(root: NavRoot) {
-            stack.resetToRoot(root, notify = false)
+        override fun switchBackStack(root: NavRoot) {
+            stack.switchStack(root, clearTargetStack = false, notify = false)
         }
 
-        override fun replaceAll(root: NavRoot) {
+        override fun showRoot(root: NavRoot) {
+            stack.switchStack(root, clearTargetStack = true, notify = false)
+        }
+
+        override fun replaceAllBackStacks(root: NavRoot) {
             stack.replaceAll(root, notify = false)
         }
     }

--- a/sample/simple/feature/new-root/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/newroot/NewRootNavigator.kt
+++ b/sample/simple/feature/new-root/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/newroot/NewRootNavigator.kt
@@ -30,6 +30,6 @@ class NewRootNavigator @Inject constructor(hostNavigator: HostNavigator) : Desti
     }
 
     fun navigateToRoot() {
-        navigateToRoot(RootRoute)
+        showRoot(RootRoute)
     }
 }

--- a/sample/simple/feature/root/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/root/RootNavigator.kt
+++ b/sample/simple/feature/root/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/root/RootNavigator.kt
@@ -30,6 +30,6 @@ class RootNavigator @Inject constructor(hostNavigator: HostNavigator) : Destinat
     }
 
     fun replaceAllWithNewRoot() {
-        replaceAll(NewRootRoute)
+        replaceAllBackStacks(NewRootRoute)
     }
 }

--- a/sample/simple/feature/screen/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/screen/ScreenNavigator.kt
+++ b/sample/simple/feature/screen/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/screen/ScreenNavigator.kt
@@ -37,7 +37,7 @@ class ScreenNavigator @Inject constructor(
     }
 
     fun replaceAllWithNewRoot() {
-        replaceAll(NewRootRoute)
+        replaceAllBackStacks(NewRootRoute)
     }
 
     fun navigateToScreenForResult() {


### PR DESCRIPTION
To reduce confusion and the potential for mistakes/crashes this changes the naming and behavior of `NavRoot` navigation methods.

**Before**
* `navigateToRoot(root: NavRoot, restoreRootState: Boolean = false)`
    * if no back stack for `root` exists, a new one is created and will be made the current back stack
    * if a back stack for `root` exists, it will be made the current back stack
        * if `restoreRootState` is `false` the found existing back stack will be cleared so that it only contains `root`
        * if `restoreRootState` is `true` the found existing back stack will be shown as is (this is what the bottom nav uses when switching tabs)
    * calling this with the current back stack will result in a crash since we’re already in the right back stack
* `resetToRoot(root: NavRoot)`
    * clears the back stack so that `root` is shown
    * `root` needs to be the root of the current back stack or the start back stack
    * calling this with a `root` that doesn’t match either will result in a crash
* `replaceAll(root: NavRoot)`
    * removes all back stacks and creates a new one with `root`
    * used when switching between logged in and logged out

**New**
* `switchBackStack(root: NavRoot)`
    * equivalent to `navigateToRoot(root, restoreRootState = true)`
* `showRoot(root: NavRoot)`
    * equivalent to `resetToRoot(root)` when `root` is the current back stack at it’s root
    * equivalent to `navigateToRoot(root, restoreRootState = false)` when `root` is not the current back stack
* `replaceAllBackStacks(root: NavRoot)`
    * equivalent to `replaceAll(root)`

It's the same amount of methods but they are focusing more on the outcome, previously the 2 cases that `showRoot` was covering effectively both “I want to see root” but you needed to choose the right method based on the current state. This could lead to crashes or unneeded complexity, especially for screens that could be used in multiple stacks. Compared to before none of these crash for any combination of current back stack and given `root`.