### PR TITLE
use transition to complete back animation

### DIFF
--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackSnapshot.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackSnapshot.kt
@@ -21,6 +21,13 @@ public class StackSnapshot internal constructor(
     internal val current: StackEntry<*>
         get() = entries.last()
 
+    internal val size: Int
+        get() = if (root.id != startStackRootEntry.id) {
+            entries.size + 1
+        } else {
+            entries.size
+        }
+
     internal val previous: StackEntry<*>?
         get() = entries.getOrNull(entries.lastIndex - 1)
             ?: startStackRootEntry.takeIf { current.id != it.id }


### PR DESCRIPTION
At the end of the back gesture we called `backProgress.tryAnimateTo(1f)` to finish the animation and only afterwards called `navigateBack` on the `HostNavigator` to update the state. This delay in the state update (~600ms) caused multiple noticeable UX issues:
- the callback has a delay and when something like showing/hiding bottom nav is done from there it's visually delayed
- the screen you're going back to is not interactive during this period
- if you manage to start another back gesture during this period you're visually going back again from the screen that you already left

This removes `backProgress.tryAnimateTo(1f)`. Instead the state change is done immediately and the `NavHost` is using a `Transition` to gracefully finish the animation.