### PR TITLE
fix awaitNavigate

### DIFF
--- a/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/TestEvent.kt
+++ b/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/TestEvent.kt
@@ -1,11 +1,10 @@
 package com.freeletics.khonshu.navigation
 
 import android.os.Parcelable
-import app.cash.turbine.Event
-import app.cash.turbine.Turbine
 import com.freeletics.khonshu.navigation.internal.ActivityEvent
 import dev.drewhamilton.poko.Poko
 import kotlin.reflect.KClass
+import kotlinx.coroutines.channels.Channel
 
 internal sealed interface TestEvent
 
@@ -67,15 +66,14 @@ internal fun toTestEvent(event: ActivityEvent): TestEvent {
     }
 }
 
-internal fun Turbine<TestEvent>.toTestEvent(): BatchEvent {
-    close()
+internal fun Channel<TestEvent>.toTestEvent(): BatchEvent {
     val events = buildList {
         do {
-            val event = takeEvent()
-            if (event is Event.Item) {
-                add(event.value)
+            val event = tryReceive().getOrNull()
+            if (event != null) {
+                add(event)
             }
-        } while (event is Event.Item)
+        } while (event != null)
     }
     return BatchEvent(events)
 }

--- a/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/TestHostNavigator.kt
+++ b/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/TestHostNavigator.kt
@@ -57,7 +57,7 @@ public class TestHostNavigator(
     }
 
     override fun navigate(block: Navigator.() -> Unit) {
-        eventTurbine += TestHostNavigator().apply(block).eventTurbine.toTestEvent()
+        eventTurbine += TestHostNavigator().apply(block).eventTurbine.asChannel().toTestEvent()
     }
 
     override fun navigateTo(route: NavRoute) {


### PR DESCRIPTION
Turbine's `takeEvent()` has a check that's it's not called from a suspending function. We don't do that (`fun navigate(block: Navigator.() -> Unit)` is not suspending), however we can still trigger the check when `navigate` is called from a suspending function. That's because `takeEvent` just checks whether `invokeSuspend` appears in the stacktrace. To avoid this issue we're not reading the events from the internal channel.