### PR TITLE
fix required opt-in for sendResult test helper

### DIFF
--- a/navigation-testing/api/android/navigation-testing.api
+++ b/navigation-testing/api/android/navigation-testing.api
@@ -33,7 +33,7 @@ public final class com/freeletics/khonshu/navigation/NavigatorTurbineKt {
 }
 
 public final class com/freeletics/khonshu/navigation/ResultOwnerTestingKt {
-	public static final fun sendResult (Lcom/freeletics/khonshu/navigation/ContractResultOwner;Ljava/lang/Object;)V
+	public static final fun sendResult (Lcom/freeletics/khonshu/navigation/ActivityResultRequest;Ljava/lang/Object;)V
 	public static final fun sendResult (Lcom/freeletics/khonshu/navigation/NavigationResultRequest;Landroid/os/Parcelable;)V
 	public static final fun sendResult (Lcom/freeletics/khonshu/navigation/PermissionsResultRequest;Ljava/lang/String;Lcom/freeletics/khonshu/navigation/PermissionsResultRequest$PermissionResult;)V
 	public static final fun sendResult (Lcom/freeletics/khonshu/navigation/PermissionsResultRequest;Ljava/util/Map;)V

--- a/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/ResultOwnerTesting.kt
+++ b/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/ResultOwnerTesting.kt
@@ -9,7 +9,7 @@ import com.freeletics.khonshu.navigation.internal.InternalNavigationCodegenApi
  * Send a fake result to collectors of this request. Can be used to test the result handling
  * logic.
  */
-public fun <O> ContractResultOwner<*, *, O>.sendResult(result: O) {
+public fun <O> ActivityResultRequest<*, O>.sendResult(result: O) {
     onResult(result)
 }
 


### PR DESCRIPTION
Using `ContractResultOwner` requires opt in while `ActivityResultRequest` does not. Since the only other subclass of `ContractResultOwner` is `PermissionsResultRequest` which has separate helpers below this, I've simply changed the class on which the extension is defined.