### PR TITLE
rename modules to graph

### DIFF
--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationCodegenTest.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationCodegenTest.kt
@@ -182,7 +182,7 @@ internal class NavDestinationCodegenTest {
 
             @OptIn(InternalCodegenApi::class)
             @ContributesTo(TestDestinationScope::class)
-            public interface KhonshuTestNavDestinationModule {
+            public interface KhonshuTestNavDestinationGraph {
               @Provides
               @IntoSet
               @OptIn(InternalNavigationCodegenApi::class)
@@ -341,7 +341,7 @@ internal class NavDestinationCodegenTest {
 
             @OptIn(InternalCodegenApi::class)
             @ContributesTo(AppScope::class)
-            public interface KhonshuTestNavDestinationModule {
+            public interface KhonshuTestNavDestinationGraph {
               @Provides
               @IntoSet
               @OptIn(InternalNavigationCodegenApi::class)
@@ -503,7 +503,7 @@ internal class NavDestinationCodegenTest {
 
             @OptIn(InternalCodegenApi::class)
             @ContributesTo(TestDestinationScope::class)
-            public interface KhonshuTestNavDestinationModule {
+            public interface KhonshuTestNavDestinationGraph {
               @Provides
               @IntoSet
               @OptIn(InternalNavigationCodegenApi::class)
@@ -703,7 +703,7 @@ internal class NavDestinationCodegenTest {
 
             @OptIn(InternalCodegenApi::class)
             @ContributesTo(TestDestinationScope::class)
-            public interface KhonshuTest2NavDestinationModule {
+            public interface KhonshuTest2NavDestinationGraph {
               @Provides
               @IntoSet
               @OptIn(InternalNavigationCodegenApi::class)
@@ -851,7 +851,7 @@ internal class NavDestinationCodegenTest {
 
             @OptIn(InternalCodegenApi::class)
             @ContributesTo(TestDestinationScope::class)
-            public interface KhonshuTestNavDestinationModule {
+            public interface KhonshuTestNavDestinationGraph {
               @Provides
               @IntoSet
               @OptIn(InternalNavigationCodegenApi::class)
@@ -1006,7 +1006,7 @@ internal class NavDestinationCodegenTest {
 
             @OptIn(InternalCodegenApi::class)
             @ContributesTo(TestDestinationScope::class)
-            public interface KhonshuTestNavDestinationModule {
+            public interface KhonshuTestNavDestinationGraph {
               @Provides
               @IntoSet
               @OptIn(InternalNavigationCodegenApi::class)

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavHostActivityCodegenTest.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavHostActivityCodegenTest.kt
@@ -161,7 +161,7 @@ internal class NavHostActivityCodegenTest {
             }
 
             @ContributesTo(TestScreen::class)
-            public interface KhonshuTestActivityModule {
+            public interface KhonshuTestActivityGraph {
               @Provides
               public fun provideImmutableNavDestinations(destinations: @JvmSuppressWildcards Set<NavDestination>): ImmutableSet<NavDestination> = destinations.toImmutableSet()
 
@@ -350,7 +350,7 @@ internal class NavHostActivityCodegenTest {
             }
 
             @ContributesTo(ActivityScope::class)
-            public interface KhonshuTestActivityModule {
+            public interface KhonshuTestActivityGraph {
               @Provides
               public fun provideImmutableNavDestinations(destinations: @JvmSuppressWildcards Set<NavDestination>): ImmutableSet<NavDestination> = destinations.toImmutableSet()
 
@@ -574,7 +574,7 @@ internal class NavHostActivityCodegenTest {
             }
 
             @ContributesTo(TestScreen::class)
-            public interface KhonshuTest2ActivityModule {
+            public interface KhonshuTest2ActivityGraph {
               @Provides
               public fun provideImmutableNavDestinations(destinations: @JvmSuppressWildcards Set<NavDestination>): ImmutableSet<NavDestination> = destinations.toImmutableSet()
 
@@ -767,7 +767,7 @@ internal class NavHostActivityCodegenTest {
             }
 
             @ContributesTo(TestScreen::class)
-            public interface KhonshuTestActivityModule {
+            public interface KhonshuTestActivityGraph {
               @Provides
               public fun provideImmutableNavDestinations(destinations: @JvmSuppressWildcards Set<NavDestination>): ImmutableSet<NavDestination> = destinations.toImmutableSet()
 
@@ -950,7 +950,7 @@ internal class NavHostActivityCodegenTest {
             }
 
             @ContributesTo(TestScreen::class)
-            public interface KhonshuTestActivityModule {
+            public interface KhonshuTestActivityGraph {
               @Provides
               public fun provideImmutableNavDestinations(destinations: @JvmSuppressWildcards Set<NavDestination>): ImmutableSet<NavDestination> = destinations.toImmutableSet()
 
@@ -1138,7 +1138,7 @@ internal class NavHostActivityCodegenTest {
             }
 
             @ContributesTo(TestScreen::class)
-            public interface KhonshuTestActivityModule {
+            public interface KhonshuTestActivityGraph {
               @Provides
               public fun provideImmutableNavDestinations(destinations: @JvmSuppressWildcards Set<NavDestination>): ImmutableSet<NavDestination> = destinations.toImmutableSet()
 

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/ActivityGraphGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/ActivityGraphGenerator.kt
@@ -20,10 +20,10 @@ import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.SET
 import com.squareup.kotlinpoet.TypeSpec
 
-internal class ActivityModuleGenerator(
+internal class ActivityGraphGenerator(
     override val data: NavHostActivityData,
 ) : Generator<BaseData>() {
-    private val moduleClassName = ClassName("Khonshu${data.baseName}ActivityModule")
+    private val moduleClassName = ClassName("Khonshu${data.baseName}ActivityGraph")
 
     internal fun generate(): TypeSpec {
         return TypeSpec.interfaceBuilder(moduleClassName)

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/FileGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/FileGenerator.kt
@@ -18,7 +18,7 @@ public class FileGenerator {
         val graphProvider = NavDestinationGraphProviderGenerator(data)
         val destinationComposable = NavDestinationComposableGenerator(data)
         val graphComposable = GraphComposableGenerator(data)
-        val destinationModule = NavDestinationModuleGenerator(data)
+        val destinationModule = NavDestinationGraphGenerator(data)
 
         return FileSpec.builder(data.packageName, "Khonshu${data.baseName}")
             .addType(graph.generate())
@@ -32,7 +32,7 @@ public class FileGenerator {
     public fun generate(data: NavHostActivityData): FileSpec {
         val graph = GraphGenerator(data)
         val graphProvider = ActivityGraphProviderGenerator(data)
-        val activityModule = ActivityModuleGenerator(data)
+        val activityModule = ActivityGraphGenerator(data)
         val activity = ActivityGenerator(data)
         val graphComposable = GraphComposableGenerator(data)
 

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationGraphGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationGraphGenerator.kt
@@ -10,10 +10,10 @@ import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.TypeSpec
 
-internal class NavDestinationModuleGenerator(
+internal class NavDestinationGraphGenerator(
     override val data: BaseData,
 ) : Generator<BaseData>() {
-    private val moduleClassName = ClassName("Khonshu${data.baseName}NavDestinationModule")
+    private val moduleClassName = ClassName("Khonshu${data.baseName}NavDestinationGraph")
 
     internal fun generate(): TypeSpec {
         return TypeSpec.interfaceBuilder(moduleClassName)


### PR DESCRIPTION
Metro doesn't have modules and the naming was a leftover from before.