### PR TITLE
integrate FlowReduxStateMachineFactory

### DIFF
--- a/codegen-compiler-test/codegen-compiler-test.gradle.kts
+++ b/codegen-compiler-test/codegen-compiler-test.gradle.kts
@@ -16,4 +16,5 @@ dependencies {
     testImplementation(libs.kotlin.compile.testing)
     testImplementation(libs.compose.compiler)
     testImplementation(testFixtures(projects.codegenCompiler))
+    testImplementation("com.freeletics.flowredux2:flowredux:1.2.3-SNAPSHOT")
 }

--- a/codegen-compiler-test/codegen-compiler-test.gradle.kts
+++ b/codegen-compiler-test/codegen-compiler-test.gradle.kts
@@ -16,5 +16,5 @@ dependencies {
     testImplementation(libs.kotlin.compile.testing)
     testImplementation(libs.compose.compiler)
     testImplementation(testFixtures(projects.codegenCompiler))
-    testImplementation("com.freeletics.flowredux2:flowredux:1.2.3-SNAPSHOT")
+    testImplementation(libs.flowredux)
 }

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationCodegenTest.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationCodegenTest.kt
@@ -1027,6 +1027,7 @@ internal class NavDestinationCodegenTest {
             stateMachine = ClassName("com.test", "TestStateMachineFactory"),
             stateMachineClass = ClassName("com.freeletics.flowredux2", "FlowReduxStateMachineFactory"),
         )
+
         @Language("kotlin")
         val source =
             """

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationCodegenTest.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationCodegenTest.kt
@@ -36,6 +36,7 @@ internal class NavDestinationCodegenTest {
         stateMachine = ClassName("com.test", "TestStateMachine"),
         navigation = navigation,
         composableParameter = emptyList(),
+        stateMachineClass = ClassName("com.freeletics.khonshu.statemachine", "StateMachine"),
         stateParameter = ComposableParameter("state", ClassName("com.test", "TestState")),
         sendActionParameter = ComposableParameter(
             "sendAction",
@@ -1018,5 +1019,155 @@ internal class NavDestinationCodegenTest {
             """.trimIndent()
 
         test(withoutSendAction, "com/test/Test.kt", source, expected)
+    }
+
+    @Test
+    fun `generates code for ComposeScreenData with FlowReduxStateMachineFactory`() {
+        val withFactory = data.copy(
+            stateMachine = ClassName("com.test", "TestStateMachineFactory"),
+            stateMachineClass = ClassName("com.freeletics.flowredux2", "FlowReduxStateMachineFactory"),
+        )
+        @Language("kotlin")
+        val source =
+            """
+            package com.test
+
+            import androidx.compose.runtime.Composable
+            import com.freeletics.khonshu.codegen.NavDestination
+            import com.test.destination.TestDestinationScope
+            import com.test.parent.TestParentRoute
+
+            @NavDestination(
+              route = TestRoute::class,
+              parentScope = TestParentRoute::class,
+              stateMachine = TestStateMachineFactory::class,
+              destinationScope = TestDestinationScope::class,
+            )
+            @Composable
+            @Suppress("unused_parameter")
+            public fun Test(
+              state: TestState,
+              sendAction: (TestAction) -> Unit
+            ) {}
+            """.trimIndent()
+
+        @Language("kotlin")
+        val expected =
+            """
+            package com.test
+
+            import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.remember
+            import androidx.lifecycle.SavedStateHandle
+            import com.freeletics.flowredux2.produceStateMachine
+            import com.freeletics.khonshu.codegen.`internal`.ActivityGraphProvider
+            import com.freeletics.khonshu.codegen.`internal`.GraphProvider
+            import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
+            import com.freeletics.khonshu.codegen.`internal`.LocalActivityGraphProvider
+            import com.freeletics.khonshu.codegen.`internal`.getGraphFromParentRoute
+            import com.freeletics.khonshu.navigation.ActivityNavigator
+            import com.freeletics.khonshu.navigation.NavDestination
+            import com.freeletics.khonshu.navigation.NavigationSetup
+            import com.freeletics.khonshu.navigation.ScreenDestination
+            import com.freeletics.khonshu.navigation.`internal`.InternalNavigationCodegenApi
+            import com.freeletics.khonshu.navigation.`internal`.StackEntry
+            import com.freeletics.khonshu.navigation.`internal`.StackSnapshot
+            import com.test.destination.TestDestinationScope
+            import com.test.parent.TestParentRoute
+            import dev.zacsweers.metro.ContributesGraphExtension
+            import dev.zacsweers.metro.ContributesTo
+            import dev.zacsweers.metro.ForScope
+            import dev.zacsweers.metro.IntoSet
+            import dev.zacsweers.metro.Multibinds
+            import dev.zacsweers.metro.Provides
+            import dev.zacsweers.metro.SingleIn
+            import kotlin.AutoCloseable
+            import kotlin.OptIn
+            import kotlin.collections.Set
+            import kotlinx.coroutines.ExperimentalCoroutinesApi
+
+            @OptIn(InternalCodegenApi::class)
+            @SingleIn(TestRoute::class)
+            @ContributesGraphExtension(
+              TestRoute::class,
+              isExtendable = true,
+            )
+            public interface KhonshuTestGraph : AutoCloseable {
+              public val testStateMachineFactory: TestStateMachineFactory
+
+              @ForScope(TestRoute::class)
+              public val activityNavigator: ActivityNavigator
+
+              @ForScope(TestRoute::class)
+              public val closeables: Set<AutoCloseable>
+
+              @Multibinds(allowEmpty = true)
+              @ForScope(TestRoute::class)
+              public fun bindCloseables(): Set<AutoCloseable>
+
+              override fun close() {
+                closeables.forEach {
+                  it.close()
+                }
+              }
+
+              @ContributesGraphExtension.Factory(TestParentRoute::class)
+              public interface Factory {
+                public fun createKhonshuTestGraph(@Provides @ForScope(TestRoute::class) savedStateHandle: SavedStateHandle, @Provides testRoute: TestRoute): KhonshuTestGraph
+              }
+            }
+
+            @OptIn(InternalCodegenApi::class)
+            public object KhonshuTestGraphProvider : GraphProvider<TestRoute, KhonshuTestGraph> {
+              @OptIn(InternalNavigationCodegenApi::class)
+              override fun provide(
+                entry: StackEntry<TestRoute>,
+                snapshot: StackSnapshot,
+                provider: ActivityGraphProvider,
+              ): KhonshuTestGraph = getGraphFromParentRoute(entry, snapshot, provider, TestParentRoute::class) { factory: KhonshuTestGraph.Factory ->
+                factory.createKhonshuTestGraph(entry.savedStateHandle, entry.route)
+              }
+            }
+
+            @Composable
+            @OptIn(InternalCodegenApi::class, InternalNavigationCodegenApi::class)
+            public fun KhonshuTest(snapshot: StackSnapshot, entry: StackEntry<TestRoute>) {
+              val provider = LocalActivityGraphProvider.current
+              val graph = remember(entry, snapshot, provider) {
+                KhonshuTestGraphProvider.provide(entry, snapshot, provider)
+              }
+
+              NavigationSetup(graph.activityNavigator)
+
+              KhonshuTest(graph)
+            }
+
+            @Composable
+            @OptIn(ExperimentalCoroutinesApi::class)
+            private fun KhonshuTest(graph: KhonshuTestGraph) {
+              val stateMachineFactory = remember { graph.testStateMachineFactory }
+              val stateMachine = stateMachineFactory.produceStateMachine()
+              val currentState = stateMachine.state.value
+              val sendAction = stateMachine.dispatchAction
+              Test(
+                state = currentState,
+                sendAction = sendAction,
+              )
+            }
+
+            @OptIn(InternalCodegenApi::class)
+            @ContributesTo(TestDestinationScope::class)
+            public interface KhonshuTestNavDestinationGraph {
+              @Provides
+              @IntoSet
+              @OptIn(InternalNavigationCodegenApi::class)
+              public fun provideTestNavDestination(): NavDestination = ScreenDestination<TestRoute>(KhonshuTestGraphProvider) { snapshot, route ->
+                KhonshuTest(snapshot, route)
+              }
+            }
+
+            """.trimIndent()
+
+        test(withFactory, "com/test/Test.kt", source, expected)
     }
 }

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavHostActivityCodegenTest.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavHostActivityCodegenTest.kt
@@ -30,6 +30,7 @@ internal class NavHostActivityCodegenTest {
             "navHost",
             ClassName("com.freeletics.khonshu.codegen", "SimpleNavHost"),
         ),
+        stateMachineClass = ClassName("com.freeletics.khonshu.statemachine", "StateMachine"),
         stateParameter = ComposableParameter("state", ClassName("com.test", "TestState")),
         sendActionParameter = ComposableParameter(
             "sendAction",

--- a/codegen-compiler-test/src/test/kotlin/com/test/TestFixtures.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/test/TestFixtures.kt
@@ -1,10 +1,12 @@
 package com.test
 
 import android.os.Parcel
+import com.freeletics.flowredux2.FlowReduxStateMachineFactory
 import com.freeletics.khonshu.codegen.Overlay
 import com.freeletics.khonshu.navigation.NavRoot
 import com.freeletics.khonshu.navigation.NavRoute
 import com.freeletics.khonshu.statemachine.StateMachine
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 
 public class TestScreen
@@ -37,6 +39,11 @@ public class TestStateMachine : FooStateMachine<TestAction, TestState>() {
         throw UnsupportedOperationException("Not implemented")
     }
 }
+
+@OptIn(ExperimentalCoroutinesApi::class)
+public class TestStateMachineFactory : FlowReduxStateMachineFactory<TestState, TestAction>({
+    throw UnsupportedOperationException("Not implemented")
+})
 
 public abstract class FooStateMachine<A : Any, S : Any> : StateMachine<S, A>
 

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/Data.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/Data.kt
@@ -18,6 +18,7 @@ public sealed interface BaseData {
 
     public val navigation: Navigation?
 
+    public val stateMachineClass: ClassName
     public val stateParameter: ComposableParameter?
     public val sendActionParameter: ComposableParameter?
     public val composableParameter: List<ComposableParameter>
@@ -35,6 +36,7 @@ public data class NavDestinationData(
     override val parentScope: ClassName,
     override val stateMachine: ClassName,
     override val navigation: Navigation,
+    override val stateMachineClass: ClassName,
     override val stateParameter: ComposableParameter?,
     override val sendActionParameter: ComposableParameter?,
     override val composableParameter: List<ComposableParameter>,
@@ -48,6 +50,7 @@ public data class NavHostActivityData(
     override val stateMachine: ClassName,
     public val activityBaseClass: ClassName,
     val navHostParameter: ComposableParameter,
+    override val stateMachineClass: ClassName,
     override val stateParameter: ComposableParameter?,
     override val sendActionParameter: ComposableParameter?,
     override val composableParameter: List<ComposableParameter>,

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/GraphComposableGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/GraphComposableGenerator.kt
@@ -32,7 +32,15 @@ internal class GraphComposableGenerator(
     internal fun generate(): FunSpec {
         return FunSpec.builder(composableName)
             .addAnnotation(composable)
-            .addAnnotation(if (data.stateMachineClass == stateMachine) optIn() else optIn(ExperimentalCoroutinesApi::class.asClassName()))
+            .addAnnotation(
+                if (data.stateMachineClass == stateMachine) {
+                    optIn()
+                } else {
+                    optIn(
+                        ExperimentalCoroutinesApi::class.asClassName(),
+                    )
+                },
+            )
             .addModifiers(PRIVATE)
             .addParameter("graph", graphClassName)
             .also {

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/GraphComposableGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/GraphComposableGenerator.kt
@@ -7,12 +7,16 @@ import com.freeletics.khonshu.codegen.util.composable
 import com.freeletics.khonshu.codegen.util.launch
 import com.freeletics.khonshu.codegen.util.navHostParameter
 import com.freeletics.khonshu.codegen.util.optIn
+import com.freeletics.khonshu.codegen.util.produceStateMachine
 import com.freeletics.khonshu.codegen.util.propertyName
 import com.freeletics.khonshu.codegen.util.remember
 import com.freeletics.khonshu.codegen.util.rememberCoroutineScope
+import com.freeletics.khonshu.codegen.util.stateMachine
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier.PRIVATE
+import com.squareup.kotlinpoet.asClassName
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 internal val Generator<out BaseData>.composableName
     get() = "Khonshu${data.baseName}"
@@ -28,7 +32,7 @@ internal class GraphComposableGenerator(
     internal fun generate(): FunSpec {
         return FunSpec.builder(composableName)
             .addAnnotation(composable)
-            .addAnnotation(optIn())
+            .addAnnotation(if (data.stateMachineClass == stateMachine) optIn() else optIn(ExperimentalCoroutinesApi::class.asClassName()))
             .addModifiers(PRIVATE)
             .addParameter("graph", graphClassName)
             .also {
@@ -47,22 +51,33 @@ internal class GraphComposableGenerator(
                     addStatement("val %L = %M { graph.%L }", parameter.name, remember, parameter.name)
                 }
             }
-            .addStatement("val stateMachine = %M { graph.%L }", remember, data.stateMachine.propertyName)
             .apply {
-                if (data.sendActionParameter != null) {
-                    addStatement("val scope = %M()", rememberCoroutineScope)
-                        .beginControlFlow(
-                            "val sendAction: %T = %M(stateMachine, scope)",
-                            data.sendActionParameter!!.typeName,
-                            remember,
-                        )
-                        .addStatement("{ scope.%M { stateMachine.dispatch(it) } }", launch)
-                        .endControlFlow()
+                if (data.stateMachineClass == stateMachine) {
+                    addStatement("val stateMachine = %M { graph.%L }", remember, data.stateMachine.propertyName)
+                    if (data.sendActionParameter != null) {
+                        addStatement("val scope = %M()", rememberCoroutineScope)
+                            .beginControlFlow(
+                                "val sendAction: %T = %M(stateMachine, scope)",
+                                data.sendActionParameter!!.typeName,
+                                remember,
+                            )
+                            .addStatement("{ scope.%M { stateMachine.dispatch(it) } }", launch)
+                            .endControlFlow()
+                    }
+                    addStatement("val state = stateMachine.%M()", asComposeState)
+                    addStatement("val currentState = state.value")
+                    beginControlFlow("if (currentState != null)")
+                } else {
+                    addStatement("val stateMachineFactory = %M { graph.%L }", remember, data.stateMachine.propertyName)
+                    addStatement("val stateMachine = stateMachineFactory.%M()", produceStateMachine)
+                    if (data.stateParameter != null) {
+                        addStatement("val currentState = stateMachine.state.value")
+                    }
+                    if (data.sendActionParameter != null) {
+                        addStatement("val sendAction = stateMachine.dispatchAction")
+                    }
                 }
             }
-            .addStatement("val state = stateMachine.%M()", asComposeState)
-            .addStatement("val currentState = state.value")
-            .beginControlFlow("if (currentState != null)")
             .addStatement("%L(", data.baseName)
             .apply {
                 data.composableParameter.forEach { parameter ->
@@ -83,7 +98,11 @@ internal class GraphComposableGenerator(
                 }
             }
             .addStatement(")")
-            .endControlFlow()
+            .apply {
+                if (data.stateMachineClass == stateMachine) {
+                    endControlFlow()
+                }
+            }
             .build()
     }
 }

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/KspParser.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/KspParser.kt
@@ -12,6 +12,7 @@ import com.freeletics.khonshu.codegen.util.simpleNavHost
 import com.freeletics.khonshu.codegen.util.simpleNavHostLambda
 import com.freeletics.khonshu.codegen.util.simpleNavHostParameterized
 import com.freeletics.khonshu.codegen.util.stateMachine
+import com.freeletics.khonshu.codegen.util.stateMachineFactory
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
@@ -37,8 +38,8 @@ internal fun KSFunctionDeclaration.toComposeScreenDestinationData(
     resolver: Resolver,
     logger: KSPLogger,
 ): NavDestinationData? {
-    val (stateParameter, actionParameter) = annotation.stateMachine.stateMachineParameters(resolver, logger)
-        ?: return null
+    val (stateMachineClass, stateParameter, actionParameter) =
+        annotation.stateMachine.stateMachineParameters(resolver, logger) ?: return null
 
     val navigation = Navigation(
         route = annotation.route,
@@ -55,6 +56,7 @@ internal fun KSFunctionDeclaration.toComposeScreenDestinationData(
         stateMachine = annotation.stateMachine,
         navigation = navigation,
         composableParameter = getInjectedParameters(stateParameter, actionParameter),
+        stateMachineClass = stateMachineClass,
         stateParameter = this.getParameterWithType(stateParameter),
         sendActionParameter = this.getParameterWithType(actionParameter),
     )
@@ -65,8 +67,8 @@ internal fun KSFunctionDeclaration.toNavHostActivityData(
     resolver: Resolver,
     logger: KSPLogger,
 ): NavHostActivityData? {
-    val (stateParameter, actionParameter) = annotation.stateMachine.stateMachineParameters(resolver, logger)
-        ?: return null
+    val (stateMachineClass, stateParameter, actionParameter) =
+        annotation.stateMachine.stateMachineParameters(resolver, logger) ?: return null
 
     val navHostParameter = navHostParameter(logger) ?: return null
 
@@ -79,6 +81,7 @@ internal fun KSFunctionDeclaration.toNavHostActivityData(
         activityBaseClass = annotation.activityBaseClass,
         navHostParameter = navHostParameter,
         composableParameter = getInjectedParameters(stateParameter, actionParameter, navHostParameter.typeName),
+        stateMachineClass = stateMachineClass,
         stateParameter = getParameterWithType(stateParameter),
         sendActionParameter = getParameterWithType(actionParameter),
     )
@@ -136,20 +139,21 @@ private fun KSFunctionDeclaration.navHostParameter(logger: KSPLogger): Composabl
     return parameter
 }
 
-private fun ClassName.stateMachineParameters(resolver: Resolver, logger: KSPLogger): Pair<TypeName, TypeName>? {
+private fun ClassName.stateMachineParameters(resolver: Resolver, logger: KSPLogger): Triple<ClassName, TypeName, TypeName>? {
     val stateMachineDeclaration = resolver.getClassDeclarationByName(toString())!!
 
     val stateMachineType = stateMachineDeclaration.allSuperTypes(true).firstNotNullOfOrNull { superType ->
-        superType.asParameterized()?.takeIf { it.rawType == stateMachine }
+        superType.asParameterized()?.takeIf { it.rawType == stateMachine || it.rawType == stateMachineFactory }
     }
     if (stateMachineType == null) {
-        logger.error("Could not find StateMachine super type for $this")
+        logger.error("$this does not extend $stateMachine or $stateMachineFactory")
         return null
     }
 
+    val stateMachineClass = stateMachineType.rawType
     val stateParameter = stateMachineType.typeArguments[0]
     val actionParameter = stateMachineType.typeArguments[1].asLambdaParameter()
-    return stateParameter to actionParameter
+    return Triple(stateMachineClass, stateParameter, actionParameter)
 }
 
 private fun ClassName.extendsBaseRoute(resolver: Resolver): Boolean {

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/KspParser.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/parser/KspParser.kt
@@ -139,7 +139,10 @@ private fun KSFunctionDeclaration.navHostParameter(logger: KSPLogger): Composabl
     return parameter
 }
 
-private fun ClassName.stateMachineParameters(resolver: Resolver, logger: KSPLogger): Triple<ClassName, TypeName, TypeName>? {
+private fun ClassName.stateMachineParameters(
+    resolver: Resolver,
+    logger: KSPLogger,
+): Triple<ClassName, TypeName, TypeName>? {
     val stateMachineDeclaration = resolver.getClassDeclarationByName(toString())!!
 
     val stateMachineType = stateMachineDeclaration.allSuperTypes(true).firstNotNullOfOrNull { superType ->

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/util/External.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/util/External.kt
@@ -53,6 +53,8 @@ internal val simpleNavHostLambda = LambdaTypeName.get(
 
 // StateMachine
 internal val stateMachine = ClassName("com.freeletics.khonshu.statemachine", "StateMachine")
+internal val stateMachineFactory = ClassName("com.freeletics.flowredux2", "FlowReduxStateMachineFactory")
+internal val produceStateMachine = MemberName("com.freeletics.flowredux2", "produceStateMachine")
 
 // Kotlin
 internal val autoCloseable = ClassName("kotlin", "AutoCloseable")

--- a/codegen-compiler/src/test/kotlin/com/freeletics/khonshu/codegen/parser/TestStateMachine.kt
+++ b/codegen-compiler/src/test/kotlin/com/freeletics/khonshu/codegen/parser/TestStateMachine.kt
@@ -1,9 +1,9 @@
 package com.freeletics.khonshu.codegen.parser
 
-import com.freeletics.flowredux.dsl.FlowReduxStateMachine
+import com.freeletics.flowredux2.LegacyFlowReduxStateMachine
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 @OptIn(ExperimentalCoroutinesApi::class)
 public abstract class TestStateMachine<S : Any, A : Any>(
     initial: S,
-) : FlowReduxStateMachine<S, A>(initial)
+) : LegacyFlowReduxStateMachine<S, A>(initial)

--- a/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/NavDestination.kt
+++ b/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/NavDestination.kt
@@ -20,6 +20,6 @@ import kotlin.reflect.KClass
 public annotation class NavDestination(
     val route: KClass<out BaseRoute>,
     val parentScope: KClass<*> = ActivityScope::class,
-    val stateMachine: KClass<out StateMachine<*, *>>,
+    val stateMachine: KClass<*>,
     val destinationScope: KClass<*> = AppScope::class,
 )

--- a/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/NavHostActivity.kt
+++ b/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/NavHostActivity.kt
@@ -24,7 +24,7 @@ import kotlin.reflect.KClass
 public annotation class NavHostActivity(
     val scope: KClass<*> = ActivityScope::class,
     val parentScope: KClass<*> = AppScope::class,
-    val stateMachine: KClass<out StateMachine<*, *>>,
+    val stateMachine: KClass<*>,
     val activityBaseClass: KClass<*>,
 )
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+flowredux = "2.0.0-alpha1"
 kotlin = "2.2.0"
 coroutines = "1.10.2"
 
@@ -79,7 +80,7 @@ kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinpoet" }
 kotlinpoet-ksp = { module = "com.squareup:kotlinpoet-ksp", version.ref = "kotlinpoet" }
 auto-service-annotations = { module = "com.google.auto.service:auto-service-annotations", version.ref = "auto-service" }
 auto-service-compiler = { module = "dev.zacsweers.autoservice:auto-service-ksp", version.ref = "auto-service-ksp" }
-flowredux = { module = "com.freeletics.flowredux:flowredux", version = "1.2.2" }
+flowredux = { module = "com.freeletics.flowredux2:flowredux", version = "2.0.0-alpha1" }
 
 junit = { module = "junit:junit", version.ref = "junit" }
 truth = { module = "com.google.truth:truth", version.ref = "truth" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -31,3 +31,7 @@ plugins {
 }
 
 rootProject.name = "khonshu"
+
+freeletics {
+    snapshots()
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -31,4 +31,3 @@ plugins {
 }
 
 rootProject.name = "khonshu"
-

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -32,6 +32,3 @@ plugins {
 
 rootProject.name = "khonshu"
 
-freeletics {
-    snapshots()
-}


### PR DESCRIPTION
Allows using FlowReduxStateMachineFactory with the `produceStateMachine` function. Will wait for cutting a first release of flowredux2 before merging so that we don't use a snapshot.