### PR TITLE
move Box inside movableContentOf to fix weird graphicsLayer interaction

### DIFF
--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavHost.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavHost.kt
@@ -106,7 +106,7 @@ public fun NavHost(
 
     // Remember the movableContent functions from the individual entries so that we avoid blinking at the end of
     // the predictive back animations.
-    val entryComposables = remember { mutableMapOf<StackEntry.Id, @Composable () -> Unit>() }
+    val entryComposables = remember { mutableMapOf<StackEntry.Id, @Composable (Modifier) -> Unit>() }
     // build list of show-able entries that are visible in this composition
     val entries = snapshot.getShowableEntries(
         entryComposables,
@@ -150,7 +150,7 @@ private data class TransitionState(
 }
 
 private fun StackSnapshot.getShowableEntries(
-    entryComposables: MutableMap<StackEntry.Id, @Composable () -> Unit>,
+    entryComposables: MutableMap<StackEntry.Id, @Composable (Modifier) -> Unit>,
     showPreviousEntry: Boolean,
     inTransition: Modifier,
     outTransition: Modifier,
@@ -186,7 +186,7 @@ private fun StackSnapshot.getShowableEntries(
 private data class ShowableStackEntry<T : BaseRoute>(
     val entry: StackEntry<T>,
     val modifier: Modifier,
-    val content: @Composable () -> Unit,
+    val content: @Composable (Modifier) -> Unit,
 )
 
 @Composable
@@ -207,9 +207,7 @@ private fun <T : BaseRoute> Show(
     saveableCloseable.saveableStateHolderRef = WeakReference(saveableStateHolder)
 
     saveableStateHolder.SaveableStateProvider(entry.entry.id.value) {
-        Box(modifier = entry.modifier) {
-            entry.content()
-        }
+        entry.content(entry.modifier)
     }
 }
 
@@ -303,7 +301,7 @@ private fun systemBackHandling(snapshot: StackSnapshot, navigator: HostNavigator
                 backProgress.snapTo(backEvent.progress)
             }
             navigator.tryNavigateBack()
-        } catch (e: CancellationException) {
+        } catch (_: CancellationException) {
             backProgress.tryAnimateTo(0f)
         }
     }

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackEntry.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackEntry.kt
@@ -1,8 +1,10 @@
 package com.freeletics.khonshu.navigation.internal
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.movableContentOf
+import androidx.compose.ui.Modifier
 import androidx.lifecycle.SavedStateHandle
 import com.freeletics.khonshu.navigation.BaseRoute
 import com.freeletics.khonshu.navigation.ContentDestination
@@ -39,8 +41,10 @@ public class StackEntry<T : BaseRoute> internal constructor(
             is NavRoot -> false
         }
 
-    internal fun content(snapshot: StackSnapshot): @Composable () -> Unit = movableContentOf {
-        destination.content(snapshot, this)
+    internal fun content(snapshot: StackSnapshot): @Composable (Modifier) -> Unit = movableContentOf<Modifier> {
+        Box(modifier = it) {
+            destination.content(snapshot, this@StackEntry)
+        }
     }
 
     internal fun close() {


### PR DESCRIPTION
When migrating 2 screens in our app to FlowRedux 2 I ran into the weird issue that when going to a migrated screen the UI would just stop updating, so you would still see the previous screen. Compositions of the new screen happened and the non visible elements where actually interactive but nothing was drawn. It would only start drawing if something would trigger a re-composition, for example when starting the back gesture or if the state machine emits another state. This explains why FlowRedux 2 triggered the issue because before we started with `state` in the composable being `null` until the first emission, so you automatically had a re-composition when opening a screen.

I narrowed this down to the `Modifier.outTransition`, not applying it fixed the issue. `outTransition` is just using `Modifier.graphicsLayer` and modifies transititon/scale/alpha values. Those values themselves looked good, so the bug wasn't that and also just using an empty `Modifier.graphicsLayer {}` was triggering the issue as well. In the end I managed to resolved it by moving the `Box` with the `graphicsLayer` modifier inside `movableContentOf`.

In a nutshell it seems to be.

Broken
```kotlin
Box(Modifier.graphicsLayer { }) {
    movableContentOf { 
         // ui
    }
}
```

Working
```kotlin
movableContentOf { 
    Box(Modifier.graphicsLayer { }) {
         // ui
    }
}
```

I'll try to create a standalone reproducer and open a bug in compose but from the Khonshu perspective this fix is completely fine and can stay as is even if something is fixed on the compose side.
