### PR TITLE
validate that parent is on back stack when navigating to destination

### DIFF
--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationCodegenTest.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationCodegenTest.kt
@@ -187,7 +187,7 @@ internal class NavDestinationCodegenTest {
               @Provides
               @IntoSet
               @OptIn(InternalNavigationCodegenApi::class)
-              public fun provideTestNavDestination(): NavDestination = ScreenDestination<TestRoute>(KhonshuTestGraphProvider) { snapshot, route ->
+              public fun provideTestNavDestination(): NavDestination = ScreenDestination<TestRoute, TestParentRoute>(KhonshuTestGraphProvider) { snapshot, route ->
                 KhonshuTest(snapshot, route)
               }
             }
@@ -508,7 +508,7 @@ internal class NavDestinationCodegenTest {
               @Provides
               @IntoSet
               @OptIn(InternalNavigationCodegenApi::class)
-              public fun provideTestNavDestination(): NavDestination = OverlayDestination<TestOverlayRoute>(KhonshuTestGraphProvider) { snapshot, route ->
+              public fun provideTestNavDestination(): NavDestination = OverlayDestination<TestOverlayRoute, TestParentRoute>(KhonshuTestGraphProvider) { snapshot, route ->
                 KhonshuTest(snapshot, route)
               }
             }
@@ -708,7 +708,7 @@ internal class NavDestinationCodegenTest {
               @Provides
               @IntoSet
               @OptIn(InternalNavigationCodegenApi::class)
-              public fun provideTest2NavDestination(): NavDestination = ScreenDestination<TestRoute>(KhonshuTest2GraphProvider) { snapshot, route ->
+              public fun provideTest2NavDestination(): NavDestination = ScreenDestination<TestRoute, TestParentRoute>(KhonshuTest2GraphProvider) { snapshot, route ->
                 KhonshuTest2(snapshot, route)
               }
             }
@@ -856,7 +856,7 @@ internal class NavDestinationCodegenTest {
               @Provides
               @IntoSet
               @OptIn(InternalNavigationCodegenApi::class)
-              public fun provideTestNavDestination(): NavDestination = ScreenDestination<TestRoute>(KhonshuTestGraphProvider) { snapshot, route ->
+              public fun provideTestNavDestination(): NavDestination = ScreenDestination<TestRoute, TestParentRoute>(KhonshuTestGraphProvider) { snapshot, route ->
                 KhonshuTest(snapshot, route)
               }
             }
@@ -1011,7 +1011,7 @@ internal class NavDestinationCodegenTest {
               @Provides
               @IntoSet
               @OptIn(InternalNavigationCodegenApi::class)
-              public fun provideTestNavDestination(): NavDestination = ScreenDestination<TestRoute>(KhonshuTestGraphProvider) { snapshot, route ->
+              public fun provideTestNavDestination(): NavDestination = ScreenDestination<TestRoute, TestParentRoute>(KhonshuTestGraphProvider) { snapshot, route ->
                 KhonshuTest(snapshot, route)
               }
             }
@@ -1162,7 +1162,7 @@ internal class NavDestinationCodegenTest {
               @Provides
               @IntoSet
               @OptIn(InternalNavigationCodegenApi::class)
-              public fun provideTestNavDestination(): NavDestination = ScreenDestination<TestRoute>(KhonshuTestGraphProvider) { snapshot, route ->
+              public fun provideTestNavDestination(): NavDestination = ScreenDestination<TestRoute, TestParentRoute>(KhonshuTestGraphProvider) { snapshot, route ->
                 KhonshuTest(snapshot, route)
               }
             }

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationGraphGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationGraphGenerator.kt
@@ -37,9 +37,14 @@ internal class NavDestinationGraphGenerator(
         val navigation = data.navigation!!
         return CodeBlock.builder()
             .beginControlFlow(
-                "return %M<%T>(%T) { snapshot, route ->",
+                "return %M<%T%L>(%T) { snapshot, route ->",
                 navigation.destinationMethod,
                 navigation.route,
+                if (navigation.parentScopeIsRoute) {
+                    CodeBlock.builder().add(", %T", data.parentScope).build()
+                } else {
+                    ""
+                },
                 graphProviderClassName,
             )
             .addStatement("%L(snapshot, route)", composableName)

--- a/navigation/api/android/navigation.api
+++ b/navigation/api/android/navigation.api
@@ -118,7 +118,7 @@ public final class com/freeletics/khonshu/navigation/Navigator$Companion {
 public final class com/freeletics/khonshu/navigation/OverlayDestination {
 	public static final field $stable I
 	public static final field $stable I
-	public synthetic fun <init> (Lkotlin/reflect/KClass;Ljava/lang/Object;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;Ljava/lang/Object;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/freeletics/khonshu/navigation/PermissionsResultRequest : com/freeletics/khonshu/navigation/ContractResultOwner {
@@ -161,7 +161,7 @@ public abstract interface class com/freeletics/khonshu/navigation/ResultOwner {
 public final class com/freeletics/khonshu/navigation/ScreenDestination {
 	public static final field $stable I
 	public static final field $stable I
-	public synthetic fun <init> (Lkotlin/reflect/KClass;Ljava/lang/Object;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;Ljava/lang/Object;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/freeletics/khonshu/navigation/deeplinks/AndroidDeepLinkExtensionsKt {

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavDestination.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavDestination.kt
@@ -13,6 +13,7 @@ public sealed interface NavDestination
 
 internal sealed class ContentDestination<T : BaseRoute> : NavDestination {
     internal abstract val id: DestinationId<T>
+    internal abstract val parent: DestinationId<*>?
     internal abstract val extra: Any?
     internal abstract val content: @Composable (StackSnapshot, StackEntry<T>) -> Unit
 }
@@ -25,18 +26,27 @@ internal sealed class ContentDestination<T : BaseRoute> : NavDestination {
 @Suppress("FunctionName")
 public inline fun <reified T : BaseRoute> ScreenDestination(
     noinline content: @Composable (T) -> Unit,
-): NavDestination = ScreenDestination(DestinationId(T::class), null) { _, entry -> content(entry.route) }
+): NavDestination = ScreenDestination(DestinationId(T::class), null, null) { _, entry -> content(entry.route) }
 
 @InternalNavigationCodegenApi
 @Suppress("FunctionName")
 public inline fun <reified T : BaseRoute> ScreenDestination(
     extra: Any,
     noinline content: @Composable (StackSnapshot, StackEntry<T>) -> Unit,
-): NavDestination = ScreenDestination(DestinationId(T::class), extra, content)
+): NavDestination = ScreenDestination(DestinationId(T::class), null, extra, content)
+
+@InternalNavigationCodegenApi
+@Suppress("FunctionName")
+@JvmName("ScreenWithParentDestination")
+public inline fun <reified T : BaseRoute, reified P : BaseRoute> ScreenDestination(
+    extra: Any,
+    noinline content: @Composable (StackSnapshot, StackEntry<T>) -> Unit,
+): NavDestination = ScreenDestination(DestinationId(T::class), DestinationId(P::class), extra, content)
 
 @PublishedApi
 internal class ScreenDestination<T : BaseRoute>(
     override val id: DestinationId<T>,
+    override val parent: DestinationId<*>?,
     override val extra: Any?,
     override val content: @Composable (StackSnapshot, StackEntry<T>) -> Unit,
 ) : ContentDestination<T>()
@@ -49,18 +59,27 @@ internal class ScreenDestination<T : BaseRoute>(
 @Suppress("FunctionName")
 public inline fun <reified T : NavRoute> OverlayDestination(
     noinline content: @Composable (T) -> Unit,
-): NavDestination = OverlayDestination(DestinationId(T::class), null) { _, entry -> content(entry.route) }
+): NavDestination = OverlayDestination(DestinationId(T::class), null, null) { _, entry -> content(entry.route) }
 
 @InternalNavigationCodegenApi
 @Suppress("FunctionName")
 public inline fun <reified T : NavRoute> OverlayDestination(
     extra: Any,
     noinline content: @Composable (StackSnapshot, StackEntry<T>) -> Unit,
-): NavDestination = OverlayDestination(DestinationId(T::class), extra, content)
+): NavDestination = OverlayDestination(DestinationId(T::class), null, extra, content)
+
+@InternalNavigationCodegenApi
+@Suppress("FunctionName")
+@JvmName("OverlayWithParentDestination")
+public inline fun <reified T : NavRoute, reified P : BaseRoute> OverlayDestination(
+    extra: Any,
+    noinline content: @Composable (StackSnapshot, StackEntry<T>) -> Unit,
+): NavDestination = OverlayDestination(DestinationId(T::class), DestinationId(P::class), extra, content)
 
 @PublishedApi
 internal class OverlayDestination<T : NavRoute>(
     override val id: DestinationId<T>,
+    override val parent: DestinationId<*>?,
     override val extra: Any?,
     override val content: @Composable (StackSnapshot, StackEntry<T>) -> Unit,
 ) : ContentDestination<T>()

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/Stack.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/Stack.kt
@@ -28,7 +28,14 @@ internal class Stack private constructor(
     }
 
     fun push(route: NavRoute) {
-        stack.add(createEntry(route))
+        val entry = createEntry(route)
+        stack.add(entry)
+        if (entry.parentDesintationId != null) {
+            check(stack.any { it.destinationId == entry.parentDesintationId }) {
+                "Navigated to $route with parent ${entry.parentDesintationId} but did not find the parent on " +
+                    "the current stack: ${stack.joinToString(separator = ", ") { it.route.toString() }}"
+            }
+        }
     }
 
     fun pop() {

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackEntry.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackEntry.kt
@@ -29,6 +29,9 @@ public class StackEntry<T : BaseRoute> internal constructor(
     internal val isOverlay
         get() = destination is OverlayDestination<*>
 
+    internal val parentDesintationId: DestinationId<*>?
+        get() = destination.parent
+
     @InternalNavigationCodegenApi
     public val extra: Any?
         get() = destination.extra

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/StackTest.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/StackTest.kt
@@ -1,5 +1,6 @@
 package com.freeletics.khonshu.navigation.internal
 
+import com.freeletics.khonshu.navigation.test.FourthRoute
 import com.freeletics.khonshu.navigation.test.OtherRoute
 import com.freeletics.khonshu.navigation.test.SimpleRoot
 import com.freeletics.khonshu.navigation.test.SimpleRoute
@@ -97,6 +98,35 @@ internal class StackTest {
                 factory.create(StackEntry.Id("101"), ThirdRoute(4)),
             )
             .inOrder()
+
+        assertThat(removed).isEmpty()
+    }
+
+    @Test
+    fun `push with a destination that has a parent`() {
+        val stack = Stack.createWith(SimpleRoot(1), factory::create)
+        stack.push(SimpleRoute(2))
+        stack.push(FourthRoute(3))
+
+        assertThat(stack.snapshot(stack.rootEntry).visibleEntries)
+            .containsExactly(
+                factory.create(StackEntry.Id("102"), FourthRoute(3)),
+            )
+            .inOrder()
+
+        assertThat(removed).isEmpty()
+    }
+
+    @Test
+    fun `push with a destination that has a parent and parent isn't present in stack`() {
+        val stack = Stack.createWith(SimpleRoot(1), factory::create)
+
+        val exception = assertThrows(IllegalStateException::class.java) {
+            stack.push(FourthRoute(3))
+        }
+        assertThat(exception).hasMessageThat().isEqualTo("Navigated to FourthRoute(number=3) with parent " +
+            "DestinationId(route=class com.freeletics.khonshu.navigation.test.SimpleRoute (Kotlin reflection is not " +
+            "available)) but did not find the parent on the current stack: SimpleRoot(number=1), FourthRoute(number=3)")
 
         assertThat(removed).isEmpty()
     }

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/StackTest.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/internal/StackTest.kt
@@ -124,9 +124,11 @@ internal class StackTest {
         val exception = assertThrows(IllegalStateException::class.java) {
             stack.push(FourthRoute(3))
         }
-        assertThat(exception).hasMessageThat().isEqualTo("Navigated to FourthRoute(number=3) with parent " +
-            "DestinationId(route=class com.freeletics.khonshu.navigation.test.SimpleRoute (Kotlin reflection is not " +
-            "available)) but did not find the parent on the current stack: SimpleRoot(number=1), FourthRoute(number=3)")
+        assertThat(exception).hasMessageThat().isEqualTo(
+            "Navigated to FourthRoute(number=3) with parent DestinationId(route=class " +
+                "com.freeletics.khonshu.navigation.test.SimpleRoute (Kotlin reflection is not available)) but " +
+                "did not find the parent on the current stack: SimpleRoot(number=1), FourthRoute(number=3)",
+        )
 
         assertThat(removed).isEmpty()
     }

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/Destinations.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/Destinations.kt
@@ -9,7 +9,8 @@ internal val otherRootDestination = ScreenDestination(DestinationId(OtherRoot::c
 internal val simpleRouteDestination = ScreenDestination(DestinationId(SimpleRoute::class), null, null) { _, _ -> }
 internal val otherRouteDestination = OverlayDestination(DestinationId(OtherRoute::class), null, null) { _, _ -> }
 internal val thirdRouteDestination = OverlayDestination(DestinationId(ThirdRoute::class), null, null) { _, _ -> }
-internal val fourthRouteDestination = ScreenDestination(DestinationId(FourthRoute::class), DestinationId(SimpleRoute::class), null) { _, _ -> }
+internal val fourthRouteDestination =
+    ScreenDestination(DestinationId(FourthRoute::class), DestinationId(SimpleRoute::class), null) { _, _ -> }
 
 internal val destinations = listOf(
     simpleRootDestination,

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/Destinations.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/Destinations.kt
@@ -4,11 +4,12 @@ import com.freeletics.khonshu.navigation.OverlayDestination
 import com.freeletics.khonshu.navigation.ScreenDestination
 import com.freeletics.khonshu.navigation.internal.DestinationId
 
-internal val simpleRootDestination = ScreenDestination(DestinationId(SimpleRoot::class), null) { _, _ -> }
-internal val otherRootDestination = ScreenDestination(DestinationId(OtherRoot::class), null) { _, _ -> }
-internal val simpleRouteDestination = ScreenDestination(DestinationId(SimpleRoute::class), null) { _, _ -> }
-internal val otherRouteDestination = OverlayDestination(DestinationId(OtherRoute::class), null) { _, _ -> }
-internal val thirdRouteDestination = OverlayDestination(DestinationId(ThirdRoute::class), null) { _, _ -> }
+internal val simpleRootDestination = ScreenDestination(DestinationId(SimpleRoot::class), null, null) { _, _ -> }
+internal val otherRootDestination = ScreenDestination(DestinationId(OtherRoot::class), null, null) { _, _ -> }
+internal val simpleRouteDestination = ScreenDestination(DestinationId(SimpleRoute::class), null, null) { _, _ -> }
+internal val otherRouteDestination = OverlayDestination(DestinationId(OtherRoute::class), null, null) { _, _ -> }
+internal val thirdRouteDestination = OverlayDestination(DestinationId(ThirdRoute::class), null, null) { _, _ -> }
+internal val fourthRouteDestination = ScreenDestination(DestinationId(FourthRoute::class), DestinationId(SimpleRoute::class), null) { _, _ -> }
 
 internal val destinations = listOf(
     simpleRootDestination,
@@ -16,4 +17,5 @@ internal val destinations = listOf(
     simpleRouteDestination,
     otherRouteDestination,
     thirdRouteDestination,
+    fourthRouteDestination,
 )

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/Routes.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/Routes.kt
@@ -24,6 +24,10 @@ internal class ThirdRoute(val number: Int) : NavRoute, Parcelable
 
 @Poko
 @Parcelize
+internal class FourthRoute(val number: Int) : NavRoute, Parcelable
+
+@Poko
+@Parcelize
 internal class DeepLinkRoute(
     val pathParameters: Map<String, String>,
     val queryParameters: Map<String, String>,


### PR DESCRIPTION
This allows attaching the `DestinationId` of the `parentScope` to the destinations when generating them. If a `Destination` has a parent attached to it navigating to that destination will validate that the parent is actually present on the back stack. This would already crash when displaying the destination afterwards and looking up the parent entry. The advantage of this approach is that the crash happens on navigation which gives a clear stack trace. The current crash would happen on the first re-composition after the navigation, so the stack trace has no information about how we got into this state.