### PR TITLE
cleanup duplicated test helpers

### DIFF
--- a/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavigationResultTesting.kt
+++ b/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavigationResultTesting.kt
@@ -1,43 +1,8 @@
 package com.freeletics.khonshu.navigation
 
 import android.os.Parcelable
-import com.freeletics.khonshu.navigation.activity.ActivityResultRequest
-import com.freeletics.khonshu.navigation.activity.PermissionsResultRequest
-import com.freeletics.khonshu.navigation.activity.PermissionsResultRequest.PermissionResult
 import com.freeletics.khonshu.navigation.internal.DestinationId
 import com.freeletics.khonshu.navigation.internal.InternalNavigationCodegenApi
-
-/**
- * Send a fake result to collectors of this request. Can be used to test the result handling
- * logic.
- */
-public fun <O> ActivityResultRequest<*, O>.sendResult(result: O) {
-    onResult(result)
-}
-
-/**
- * Send a fake result to collectors of this request. Can be used to test the result handling
- * logic.
- */
-public fun PermissionsResultRequest.sendResult(permission: String, result: PermissionResult) {
-    onResult(mapOf(permission to result))
-}
-
-/**
- * Send a fake result to collectors of this request. Can be used to test the result handling
- * logic.
- */
-public fun PermissionsResultRequest.sendResult(vararg pairs: Pair<String, PermissionResult>) {
-    onResult(mapOf(*pairs))
-}
-
-/**
- * Send a fake result to collectors of this request. Can be used to test the result handling
- * logic.
- */
-public fun PermissionsResultRequest.sendResult(result: Map<String, PermissionResult>) {
-    onResult(result)
-}
 
 /**
  * Send a fake result to collectors of this request. Can be used to test the result handling
@@ -52,7 +17,7 @@ public fun <R : Parcelable> NavigationResultRequest<R>.sendResult(result: R) {
  * testing the result sender that retrieves a key as part of its argument.
  *
  * To test the result receiver use a real key from a request obtained by
- * [ResultNavigator.registerForNavigationResult].
+ * [registerForNavigationResult].
  */
 @OptIn(InternalNavigationCodegenApi::class)
 public inline fun <reified R : Parcelable> fakeNavigationResultKey(): NavigationResultRequest.Key<R> {


### PR DESCRIPTION
Missed removing these in #1119, these are now in `ActivityResultContractTesting`.