### PR TITLE
fix declaration look ups in KspParser

### DIFF
--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/KhonshuSymbolProcessor.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/KhonshuSymbolProcessor.kt
@@ -30,10 +30,10 @@ public class KhonshuSymbolProcessor(
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
         resolver.generateCodeForAnnotation<NavDestination> {
-            toComposeScreenDestinationData(it, resolver, logger)
+            toComposeScreenDestinationData(it, logger)
         }
         resolver.generateCodeForAnnotation<NavHostActivity> {
-            toNavHostActivityData(it, resolver, logger)
+            toNavHostActivityData(it, logger)
         }
         return emptyList()
     }
@@ -48,8 +48,8 @@ public class KhonshuSymbolProcessor(
                     return@forEach
                 }
 
-                it.annotations.filter {
-                    it.annotationType.resolve().declaration.qualifiedName?.asString() == A::class.qualifiedName
+                it.annotations.filter { annotation ->
+                    annotation.annotationType.resolve().declaration.qualifiedName?.asString() == A::class.qualifiedName
                 }.forEach annotation@{ annotation ->
                     val data = parser(it, annotation) ?: return@annotation
                     val file = fileGenerator.generate(data)

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/GraphComposableGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/GraphComposableGenerator.kt
@@ -4,6 +4,7 @@ import com.freeletics.khonshu.codegen.BaseData
 import com.freeletics.khonshu.codegen.NavHostActivityData
 import com.freeletics.khonshu.codegen.util.asComposeState
 import com.freeletics.khonshu.codegen.util.composable
+import com.freeletics.khonshu.codegen.util.khonshuStateMachine
 import com.freeletics.khonshu.codegen.util.launch
 import com.freeletics.khonshu.codegen.util.navHostParameter
 import com.freeletics.khonshu.codegen.util.optIn
@@ -11,7 +12,6 @@ import com.freeletics.khonshu.codegen.util.produceStateMachine
 import com.freeletics.khonshu.codegen.util.propertyName
 import com.freeletics.khonshu.codegen.util.remember
 import com.freeletics.khonshu.codegen.util.rememberCoroutineScope
-import com.freeletics.khonshu.codegen.util.stateMachine
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier.PRIVATE
@@ -33,7 +33,7 @@ internal class GraphComposableGenerator(
         return FunSpec.builder(composableName)
             .addAnnotation(composable)
             .addAnnotation(
-                if (data.stateMachineClass == stateMachine) {
+                if (data.stateMachineClass == khonshuStateMachine) {
                     optIn()
                 } else {
                     optIn(
@@ -60,7 +60,7 @@ internal class GraphComposableGenerator(
                 }
             }
             .apply {
-                if (data.stateMachineClass == stateMachine) {
+                if (data.stateMachineClass == khonshuStateMachine) {
                     addStatement("val stateMachine = %M { graph.%L }", remember, data.stateMachine.propertyName)
                     if (data.sendActionParameter != null) {
                         addStatement("val scope = %M()", rememberCoroutineScope)
@@ -107,7 +107,7 @@ internal class GraphComposableGenerator(
             }
             .addStatement(")")
             .apply {
-                if (data.stateMachineClass == stateMachine) {
+                if (data.stateMachineClass == khonshuStateMachine) {
                     endControlFlow()
                 }
             }

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/util/External.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/util/External.kt
@@ -52,7 +52,7 @@ internal val simpleNavHostLambda = LambdaTypeName.get(
 )
 
 // StateMachine
-internal val stateMachine = ClassName("com.freeletics.khonshu.statemachine", "StateMachine")
+internal val khonshuStateMachine = ClassName("com.freeletics.khonshu.statemachine", "StateMachine")
 internal val stateMachineFactory = ClassName("com.freeletics.flowredux2", "FlowReduxStateMachineFactory")
 internal val produceStateMachine = MemberName("com.freeletics.flowredux2", "produceStateMachine")
 

--- a/codegen-compiler/src/test/kotlin/com/freeletics/khonshu/codegen/parser/ksp/AllSuperTypesTest.kt
+++ b/codegen-compiler/src/test/kotlin/com/freeletics/khonshu/codegen/parser/ksp/AllSuperTypesTest.kt
@@ -5,7 +5,7 @@ package com.freeletics.khonshu.codegen.parser.ksp
 import com.freeletics.khonshu.codegen.KhonshuCompilation.Companion.kspCompilation
 import com.freeletics.khonshu.codegen.parser.allSuperTypes
 import com.freeletics.khonshu.codegen.simpleSymbolProcessor
-import com.freeletics.khonshu.codegen.util.stateMachine
+import com.freeletics.khonshu.codegen.util.khonshuStateMachine
 import com.google.common.truth.Truth.assertThat
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.squareup.kotlinpoet.BOOLEAN
@@ -114,7 +114,7 @@ internal class AllSuperTypesTest {
             symbolProcessors = listOf(
                 simpleSymbolProcessor { resolver ->
                     resolver.getClassDeclarationByName("com.freeletics.test.CreateCustomActivityStateMachine")!!.also {
-                        val superType = it.allSuperTypes(true).find(stateMachine)
+                        val superType = it.allSuperTypes(true).find(khonshuStateMachine)
                         assertThat(superType!!.typeArguments[0])
                             .isEqualTo(ClassName("com.freeletics.test", "CreateCustomActivityState"))
                         assertThat(superType.typeArguments[1])


### PR DESCRIPTION
Primarily changes all declaration lookups to directly use `KSType.declaration` instead. This avoids issues where when we previously went from `KSType` to `ClassName` to `resolver. getClassDeclarationByName` it could lead to failures if the package name contains soft keywords. This should also be a bit more performant since we don't do extra lookups.

While I was changing this I also added some more explicit failure messages for unexpected errors. The package name issue was just a NPE with no extra info, so if something happens again it should be easier to figure it out.