### PR TITLE
remove internal intermediate ContentDestination type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Change Log
 
 ### Navigation
 
+- `NavDestination` is now `NavDestination<T : BaseRoute>`, from a consumer perspective
+  the only change is that it now needs to be referenced as `NavDestination<*>`.
+
 ### Codegen
 
 - Optimize performance by avoiding unneeded lookups of classes.

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationCodegenTest.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationCodegenTest.kt
@@ -183,7 +183,7 @@ internal class NavDestinationCodegenTest {
               @Provides
               @IntoSet
               @OptIn(InternalNavigationCodegenApi::class)
-              public fun provideTestNavDestination(): NavDestination = ScreenDestination<TestRoute, TestParentRoute>(KhonshuTestGraphProvider) { snapshot, route ->
+              public fun provideTestNavDestination(): NavDestination<*> = ScreenDestination<TestRoute, TestParentRoute>(KhonshuTestGraphProvider) { snapshot, route ->
                 KhonshuTest(snapshot, route)
               }
             }
@@ -338,7 +338,7 @@ internal class NavDestinationCodegenTest {
               @Provides
               @IntoSet
               @OptIn(InternalNavigationCodegenApi::class)
-              public fun provideTestNavDestination(): NavDestination = ScreenDestination<TestRoute>(KhonshuTestGraphProvider) { snapshot, route ->
+              public fun provideTestNavDestination(): NavDestination<*> = ScreenDestination<TestRoute>(KhonshuTestGraphProvider) { snapshot, route ->
                 KhonshuTest(snapshot, route)
               }
             }
@@ -496,7 +496,7 @@ internal class NavDestinationCodegenTest {
               @Provides
               @IntoSet
               @OptIn(InternalNavigationCodegenApi::class)
-              public fun provideTestNavDestination(): NavDestination = OverlayDestination<TestOverlayRoute, TestParentRoute>(KhonshuTestGraphProvider) { snapshot, route ->
+              public fun provideTestNavDestination(): NavDestination<*> = OverlayDestination<TestOverlayRoute, TestParentRoute>(KhonshuTestGraphProvider) { snapshot, route ->
                 KhonshuTest(snapshot, route)
               }
             }
@@ -692,7 +692,7 @@ internal class NavDestinationCodegenTest {
               @Provides
               @IntoSet
               @OptIn(InternalNavigationCodegenApi::class)
-              public fun provideTest2NavDestination(): NavDestination = ScreenDestination<TestRoute, TestParentRoute>(KhonshuTest2GraphProvider) { snapshot, route ->
+              public fun provideTest2NavDestination(): NavDestination<*> = ScreenDestination<TestRoute, TestParentRoute>(KhonshuTest2GraphProvider) { snapshot, route ->
                 KhonshuTest2(snapshot, route)
               }
             }
@@ -836,7 +836,7 @@ internal class NavDestinationCodegenTest {
               @Provides
               @IntoSet
               @OptIn(InternalNavigationCodegenApi::class)
-              public fun provideTestNavDestination(): NavDestination = ScreenDestination<TestRoute, TestParentRoute>(KhonshuTestGraphProvider) { snapshot, route ->
+              public fun provideTestNavDestination(): NavDestination<*> = ScreenDestination<TestRoute, TestParentRoute>(KhonshuTestGraphProvider) { snapshot, route ->
                 KhonshuTest(snapshot, route)
               }
             }
@@ -987,7 +987,7 @@ internal class NavDestinationCodegenTest {
               @Provides
               @IntoSet
               @OptIn(InternalNavigationCodegenApi::class)
-              public fun provideTestNavDestination(): NavDestination = ScreenDestination<TestRoute, TestParentRoute>(KhonshuTestGraphProvider) { snapshot, route ->
+              public fun provideTestNavDestination(): NavDestination<*> = ScreenDestination<TestRoute, TestParentRoute>(KhonshuTestGraphProvider) { snapshot, route ->
                 KhonshuTest(snapshot, route)
               }
             }
@@ -1134,7 +1134,7 @@ internal class NavDestinationCodegenTest {
               @Provides
               @IntoSet
               @OptIn(InternalNavigationCodegenApi::class)
-              public fun provideTestNavDestination(): NavDestination = ScreenDestination<TestRoute, TestParentRoute>(KhonshuTestGraphProvider) { snapshot, route ->
+              public fun provideTestNavDestination(): NavDestination<*> = ScreenDestination<TestRoute, TestParentRoute>(KhonshuTestGraphProvider) { snapshot, route ->
                 KhonshuTest(snapshot, route)
               }
             }

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavHostActivityCodegenTest.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/NavHostActivityCodegenTest.kt
@@ -160,7 +160,7 @@ internal class NavHostActivityCodegenTest {
             @ContributesTo(TestScreen::class)
             public interface KhonshuTestActivityGraph {
               @Provides
-              public fun provideImmutableNavDestinations(destinations: Set<NavDestination>): ImmutableSet<NavDestination> = destinations.toImmutableSet()
+              public fun provideImmutableNavDestinations(destinations: Set<NavDestination<*>>): ImmutableSet<NavDestination<*>> = destinations.toImmutableSet()
 
               @Provides
               @SingleIn(TestScreen::class)
@@ -168,7 +168,7 @@ internal class NavHostActivityCodegenTest {
               public fun provideHostNavigator(
                 viewModel: StackEntryStoreViewModel,
                 startRoot: NavRoot,
-                destinations: ImmutableSet<NavDestination>,
+                destinations: ImmutableSet<NavDestination<*>>,
               ): HostNavigator = createHostNavigator(viewModel, startRoot, destinations)
             }
 
@@ -345,7 +345,7 @@ internal class NavHostActivityCodegenTest {
             @ContributesTo(ActivityScope::class)
             public interface KhonshuTestActivityGraph {
               @Provides
-              public fun provideImmutableNavDestinations(destinations: Set<NavDestination>): ImmutableSet<NavDestination> = destinations.toImmutableSet()
+              public fun provideImmutableNavDestinations(destinations: Set<NavDestination<*>>): ImmutableSet<NavDestination<*>> = destinations.toImmutableSet()
 
               @Provides
               @SingleIn(ActivityScope::class)
@@ -353,7 +353,7 @@ internal class NavHostActivityCodegenTest {
               public fun provideHostNavigator(
                 viewModel: StackEntryStoreViewModel,
                 startRoot: NavRoot,
-                destinations: ImmutableSet<NavDestination>,
+                destinations: ImmutableSet<NavDestination<*>>,
               ): HostNavigator = createHostNavigator(viewModel, startRoot, destinations)
             }
 
@@ -565,7 +565,7 @@ internal class NavHostActivityCodegenTest {
             @ContributesTo(TestScreen::class)
             public interface KhonshuTest2ActivityGraph {
               @Provides
-              public fun provideImmutableNavDestinations(destinations: Set<NavDestination>): ImmutableSet<NavDestination> = destinations.toImmutableSet()
+              public fun provideImmutableNavDestinations(destinations: Set<NavDestination<*>>): ImmutableSet<NavDestination<*>> = destinations.toImmutableSet()
 
               @Provides
               @SingleIn(TestScreen::class)
@@ -573,7 +573,7 @@ internal class NavHostActivityCodegenTest {
               public fun provideHostNavigator(
                 viewModel: StackEntryStoreViewModel,
                 startRoot: NavRoot,
-                destinations: ImmutableSet<NavDestination>,
+                destinations: ImmutableSet<NavDestination<*>>,
               ): HostNavigator = createHostNavigator(viewModel, startRoot, destinations)
             }
 
@@ -754,7 +754,7 @@ internal class NavHostActivityCodegenTest {
             @ContributesTo(TestScreen::class)
             public interface KhonshuTestActivityGraph {
               @Provides
-              public fun provideImmutableNavDestinations(destinations: Set<NavDestination>): ImmutableSet<NavDestination> = destinations.toImmutableSet()
+              public fun provideImmutableNavDestinations(destinations: Set<NavDestination<*>>): ImmutableSet<NavDestination<*>> = destinations.toImmutableSet()
 
               @Provides
               @SingleIn(TestScreen::class)
@@ -762,7 +762,7 @@ internal class NavHostActivityCodegenTest {
               public fun provideHostNavigator(
                 viewModel: StackEntryStoreViewModel,
                 startRoot: NavRoot,
-                destinations: ImmutableSet<NavDestination>,
+                destinations: ImmutableSet<NavDestination<*>>,
               ): HostNavigator = createHostNavigator(viewModel, startRoot, destinations)
             }
 
@@ -933,7 +933,7 @@ internal class NavHostActivityCodegenTest {
             @ContributesTo(TestScreen::class)
             public interface KhonshuTestActivityGraph {
               @Provides
-              public fun provideImmutableNavDestinations(destinations: Set<NavDestination>): ImmutableSet<NavDestination> = destinations.toImmutableSet()
+              public fun provideImmutableNavDestinations(destinations: Set<NavDestination<*>>): ImmutableSet<NavDestination<*>> = destinations.toImmutableSet()
 
               @Provides
               @SingleIn(TestScreen::class)
@@ -941,7 +941,7 @@ internal class NavHostActivityCodegenTest {
               public fun provideHostNavigator(
                 viewModel: StackEntryStoreViewModel,
                 startRoot: NavRoot,
-                destinations: ImmutableSet<NavDestination>,
+                destinations: ImmutableSet<NavDestination<*>>,
               ): HostNavigator = createHostNavigator(viewModel, startRoot, destinations)
             }
 
@@ -1117,7 +1117,7 @@ internal class NavHostActivityCodegenTest {
             @ContributesTo(TestScreen::class)
             public interface KhonshuTestActivityGraph {
               @Provides
-              public fun provideImmutableNavDestinations(destinations: Set<NavDestination>): ImmutableSet<NavDestination> = destinations.toImmutableSet()
+              public fun provideImmutableNavDestinations(destinations: Set<NavDestination<*>>): ImmutableSet<NavDestination<*>> = destinations.toImmutableSet()
 
               @Provides
               @SingleIn(TestScreen::class)
@@ -1125,7 +1125,7 @@ internal class NavHostActivityCodegenTest {
               public fun provideHostNavigator(
                 viewModel: StackEntryStoreViewModel,
                 startRoot: NavRoot,
-                destinations: ImmutableSet<NavDestination>,
+                destinations: ImmutableSet<NavDestination<*>>,
               ): HostNavigator = createHostNavigator(viewModel, startRoot, destinations)
             }
 

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/Data.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/Data.kt
@@ -1,6 +1,5 @@
 package com.freeletics.khonshu.codegen
 
-import com.freeletics.khonshu.codegen.util.navigationDestination
 import com.freeletics.khonshu.codegen.util.overlayDestination
 import com.freeletics.khonshu.codegen.util.screenDestination
 import com.squareup.kotlinpoet.ClassName
@@ -64,8 +63,6 @@ public data class Navigation(
     private val overlay: Boolean,
     val destinationScope: ClassName,
 ) {
-    val destinationClass: ClassName = navigationDestination
-
     val destinationMethod: MemberName = when (overlay) {
         false -> screenDestination
         true -> overlayDestination

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationGraphGenerator.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/codegen/NavDestinationGraphGenerator.kt
@@ -4,6 +4,7 @@ import com.freeletics.khonshu.codegen.BaseData
 import com.freeletics.khonshu.codegen.util.contributesTo
 import com.freeletics.khonshu.codegen.util.internalNavigatorApi
 import com.freeletics.khonshu.codegen.util.intoSet
+import com.freeletics.khonshu.codegen.util.navigationDestination
 import com.freeletics.khonshu.codegen.util.optIn
 import com.freeletics.khonshu.codegen.util.provides
 import com.squareup.kotlinpoet.CodeBlock
@@ -28,7 +29,7 @@ internal class NavDestinationGraphGenerator(
             .addAnnotation(provides())
             .addAnnotation(intoSet())
             .addAnnotation(optIn(internalNavigatorApi))
-            .returns(data.navigation!!.destinationClass)
+            .returns(navigationDestination)
             .addCode(providesDestinationCode())
             .build()
     }

--- a/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/util/External.kt
+++ b/codegen-compiler/src/main/kotlin/com/freeletics/khonshu/codegen/util/External.kt
@@ -1,10 +1,12 @@
 package com.freeletics.khonshu.codegen.util
 
+import com.squareup.kotlinpoet.ANY
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.UNIT
+import com.squareup.kotlinpoet.WildcardTypeName
 
 // Codegen Public API
 internal val overlay = ClassName("com.freeletics.khonshu.codegen", "Overlay")
@@ -32,7 +34,10 @@ internal val multiStackHostNavigatorViewModel =
     ClassName("com.freeletics.khonshu.navigation.internal", "StackEntryStoreViewModel")
 internal val navHost = MemberName("com.freeletics.khonshu.navigation", "NavHost")
 internal val navigationSetup = MemberName("com.freeletics.khonshu.navigation", "NavigationSetup")
-internal val navigationDestination = ClassName("com.freeletics.khonshu.navigation", "NavDestination")
+internal val navigationDestination = ClassName(
+    "com.freeletics.khonshu.navigation",
+    "NavDestination",
+).parameterizedBy(WildcardTypeName.producerOf(ANY.copy(nullable = true)))
 internal val screenDestination = MemberName("com.freeletics.khonshu.navigation", "ScreenDestination")
 internal val overlayDestination = MemberName("com.freeletics.khonshu.navigation", "OverlayDestination")
 internal val internalNavigatorApi =

--- a/navigation/api/android/navigation.api
+++ b/navigation/api/android/navigation.api
@@ -32,7 +32,8 @@ public final class com/freeletics/khonshu/navigation/HostNavigatorKt {
 	public static final fun rememberHostNavigator (Lcom/freeletics/khonshu/navigation/NavRoot;Lkotlinx/collections/immutable/ImmutableSet;Lkotlinx/collections/immutable/ImmutableSet;Lkotlinx/collections/immutable/ImmutableSet;Landroidx/compose/runtime/Composer;II)Lcom/freeletics/khonshu/navigation/HostNavigator;
 }
 
-public abstract interface class com/freeletics/khonshu/navigation/NavDestination {
+public abstract class com/freeletics/khonshu/navigation/NavDestination {
+	public static final field $stable I
 }
 
 public final class com/freeletics/khonshu/navigation/NavHostKt {
@@ -81,8 +82,7 @@ public abstract interface class com/freeletics/khonshu/navigation/Navigator {
 public final class com/freeletics/khonshu/navigation/Navigator$Companion {
 }
 
-public final class com/freeletics/khonshu/navigation/OverlayDestination {
-	public static final field $stable I
+public final class com/freeletics/khonshu/navigation/OverlayDestination : com/freeletics/khonshu/navigation/NavDestination {
 	public static final field $stable I
 	public synthetic fun <init> (Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;Ljava/lang/Object;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
@@ -95,8 +95,7 @@ public abstract interface class com/freeletics/khonshu/navigation/ResultNavigato
 public final class com/freeletics/khonshu/navigation/ResultNavigator$Companion {
 }
 
-public final class com/freeletics/khonshu/navigation/ScreenDestination {
-	public static final field $stable I
+public final class com/freeletics/khonshu/navigation/ScreenDestination : com/freeletics/khonshu/navigation/NavDestination {
 	public static final field $stable I
 	public synthetic fun <init> (Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;Ljava/lang/Object;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/HostNavigator.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/HostNavigator.kt
@@ -65,7 +65,7 @@ public abstract class HostNavigator @InternalNavigationTestingApi constructor() 
 @Composable
 public fun rememberHostNavigator(
     startRoot: NavRoot,
-    destinations: ImmutableSet<NavDestination>,
+    destinations: ImmutableSet<NavDestination<*>>,
     deepLinkHandlers: ImmutableSet<DeepLinkHandler> = persistentSetOf(),
     deepLinkPrefixes: ImmutableSet<DeepLinkHandler.Prefix> = persistentSetOf(),
 ): HostNavigator {

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavDestination.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavDestination.kt
@@ -9,77 +9,89 @@ import com.freeletics.khonshu.navigation.internal.StackSnapshot
 /**
  * A destination that can be navigated to. See `NavHost` for how to configure a `NavGraph` with it.
  */
-public sealed interface NavDestination
-
-internal sealed class ContentDestination<T : BaseRoute> : NavDestination {
-    internal abstract val id: DestinationId<T>
+public sealed class NavDestination<Route : BaseRoute> {
+    internal abstract val id: DestinationId<Route>
     internal abstract val parent: DestinationId<*>?
     internal abstract val extra: Any?
-    internal abstract val content: @Composable (StackSnapshot, StackEntry<T>) -> Unit
+    internal abstract val content: @Composable (StackSnapshot, StackEntry<Route>) -> Unit
 }
 
 /**
- * Creates a new [NavDestination] that represents a full screen. The class of [T] will be used
+ * Creates a new [NavDestination] that represents a full screen. The class of [Route] will be used
  * as a unique identifier. The given [content] will be shown when the screen is being
- * navigated to using an instance of [T].
+ * navigated to using an instance of [Route].
  */
 @Suppress("FunctionName")
-public inline fun <reified T : BaseRoute> ScreenDestination(
-    noinline content: @Composable (T) -> Unit,
-): NavDestination = ScreenDestination(DestinationId(T::class), null, null) { _, entry -> content(entry.route) }
+public inline fun <reified Route : BaseRoute> ScreenDestination(
+    noinline content: @Composable (Route) -> Unit,
+): NavDestination<Route> = ScreenDestination(DestinationId(Route::class), null, null) { _, entry ->
+    content(entry.route)
+}
 
 @InternalNavigationCodegenApi
 @Suppress("FunctionName")
-public inline fun <reified T : BaseRoute> ScreenDestination(
+public inline fun <reified Route : BaseRoute> ScreenDestination(
     extra: Any,
-    noinline content: @Composable (StackSnapshot, StackEntry<T>) -> Unit,
-): NavDestination = ScreenDestination(DestinationId(T::class), null, extra, content)
+    noinline content: @Composable (StackSnapshot, StackEntry<Route>) -> Unit,
+): NavDestination<Route> = ScreenDestination(DestinationId(Route::class), null, extra, content)
 
 @InternalNavigationCodegenApi
 @Suppress("FunctionName")
 @JvmName("ScreenWithParentDestination")
-public inline fun <reified T : BaseRoute, reified P : BaseRoute> ScreenDestination(
+public inline fun <reified Route : BaseRoute, reified ParentRoute : BaseRoute> ScreenDestination(
     extra: Any,
-    noinline content: @Composable (StackSnapshot, StackEntry<T>) -> Unit,
-): NavDestination = ScreenDestination(DestinationId(T::class), DestinationId(P::class), extra, content)
+    noinline content: @Composable (StackSnapshot, StackEntry<Route>) -> Unit,
+): NavDestination<Route> = ScreenDestination(
+    id = DestinationId(Route::class),
+    parent = DestinationId(ParentRoute::class),
+    extra = extra,
+    content = content,
+)
 
 @PublishedApi
-internal class ScreenDestination<T : BaseRoute>(
-    override val id: DestinationId<T>,
+internal class ScreenDestination<Route : BaseRoute>(
+    override val id: DestinationId<Route>,
     override val parent: DestinationId<*>?,
     override val extra: Any?,
-    override val content: @Composable (StackSnapshot, StackEntry<T>) -> Unit,
-) : ContentDestination<T>()
+    override val content: @Composable (StackSnapshot, StackEntry<Route>) -> Unit,
+) : NavDestination<Route>()
 
 /**
  * Creates a new [NavDestination] that is shown on top a [ScreenDestination], for example a dialog or bottom sheet. The
- * class of [T] will be used as a unique identifier. The given [content] will be shown inside the dialog window when
- * navigating to it by using an instance of [T].
+ * class of [Route] will be used as a unique identifier. The given [content] will be shown inside the dialog window when
+ * navigating to it by using an instance of [Route].
  */
 @Suppress("FunctionName")
-public inline fun <reified T : NavRoute> OverlayDestination(
-    noinline content: @Composable (T) -> Unit,
-): NavDestination = OverlayDestination(DestinationId(T::class), null, null) { _, entry -> content(entry.route) }
+public inline fun <reified Route : NavRoute> OverlayDestination(
+    noinline content: @Composable (Route) -> Unit,
+): NavDestination<Route> = OverlayDestination(DestinationId(Route::class), null, null) { _, entry ->
+    content(entry.route)
+}
 
 @InternalNavigationCodegenApi
 @Suppress("FunctionName")
-public inline fun <reified T : NavRoute> OverlayDestination(
+public inline fun <reified Route : NavRoute> OverlayDestination(
     extra: Any,
-    noinline content: @Composable (StackSnapshot, StackEntry<T>) -> Unit,
-): NavDestination = OverlayDestination(DestinationId(T::class), null, extra, content)
+    noinline content: @Composable (StackSnapshot, StackEntry<Route>) -> Unit,
+): NavDestination<Route> = OverlayDestination(DestinationId(Route::class), null, extra, content)
 
 @InternalNavigationCodegenApi
 @Suppress("FunctionName")
 @JvmName("OverlayWithParentDestination")
-public inline fun <reified T : NavRoute, reified P : BaseRoute> OverlayDestination(
+public inline fun <reified Route : NavRoute, reified ParentRoute : BaseRoute> OverlayDestination(
     extra: Any,
-    noinline content: @Composable (StackSnapshot, StackEntry<T>) -> Unit,
-): NavDestination = OverlayDestination(DestinationId(T::class), DestinationId(P::class), extra, content)
+    noinline content: @Composable (StackSnapshot, StackEntry<Route>) -> Unit,
+): NavDestination<Route> = OverlayDestination(
+    id = DestinationId(Route::class),
+    parent = DestinationId(ParentRoute::class),
+    extra = extra,
+    content = content,
+)
 
 @PublishedApi
-internal class OverlayDestination<T : NavRoute>(
-    override val id: DestinationId<T>,
+internal class OverlayDestination<Route : NavRoute>(
+    override val id: DestinationId<Route>,
     override val parent: DestinationId<*>?,
     override val extra: Any?,
-    override val content: @Composable (StackSnapshot, StackEntry<T>) -> Unit,
-) : ContentDestination<T>()
+    override val content: @Composable (StackSnapshot, StackEntry<Route>) -> Unit,
+) : NavDestination<Route>()

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavHost.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavHost.kt
@@ -49,7 +49,7 @@ import kotlinx.coroutines.CancellationException
 @Composable
 public fun NavHost(
     startRoute: NavRoot,
-    destinations: ImmutableSet<NavDestination>,
+    destinations: ImmutableSet<NavDestination<*>>,
     modifier: Modifier = Modifier,
     deepLinkHandlers: ImmutableSet<DeepLinkHandler> = persistentSetOf(),
     deepLinkPrefixes: ImmutableSet<DeepLinkHandler.Prefix> = persistentSetOf(),

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackHostNavigatorBuilder.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackHostNavigatorBuilder.kt
@@ -1,7 +1,6 @@
 package com.freeletics.khonshu.navigation.internal
 
 import android.os.Bundle
-import com.freeletics.khonshu.navigation.ContentDestination
 import com.freeletics.khonshu.navigation.HostNavigator
 import com.freeletics.khonshu.navigation.NavDestination
 import com.freeletics.khonshu.navigation.NavRoot
@@ -12,10 +11,10 @@ import kotlinx.collections.immutable.ImmutableSet
 public fun createHostNavigator(
     viewModel: StackEntryStoreViewModel,
     startRoot: NavRoot,
-    destinations: ImmutableSet<NavDestination>,
+    destinations: ImmutableSet<NavDestination<*>>,
     startRootOverridesSavedRoot: Boolean = false,
 ): HostNavigator {
-    val contentDestinations = destinations.filterIsInstance<ContentDestination<*>>()
+    val contentDestinations = destinations.filterIsInstance<NavDestination<*>>()
     val factory = StackEntryFactory(contentDestinations, viewModel)
 
     val navState = viewModel.globalSavedStateHandle.get<Bundle>(SAVED_STATE_STACK)

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackEntry.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackEntry.kt
@@ -7,7 +7,7 @@ import androidx.compose.runtime.movableContentOf
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.SavedStateHandle
 import com.freeletics.khonshu.navigation.BaseRoute
-import com.freeletics.khonshu.navigation.ContentDestination
+import com.freeletics.khonshu.navigation.NavDestination
 import com.freeletics.khonshu.navigation.NavRoot
 import com.freeletics.khonshu.navigation.NavRoute
 import com.freeletics.khonshu.navigation.OverlayDestination
@@ -19,7 +19,7 @@ import dev.drewhamilton.poko.Poko
 public class StackEntry<T : BaseRoute> internal constructor(
     internal val id: Id,
     public val route: T,
-    private val destination: ContentDestination<T>,
+    private val destination: NavDestination<T>,
     public val savedStateHandle: SavedStateHandle,
     public val store: StackEntryStore,
 ) {

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackEntryFactory.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackEntryFactory.kt
@@ -2,11 +2,11 @@ package com.freeletics.khonshu.navigation.internal
 
 import androidx.lifecycle.SavedStateHandle
 import com.freeletics.khonshu.navigation.BaseRoute
-import com.freeletics.khonshu.navigation.ContentDestination
+import com.freeletics.khonshu.navigation.NavDestination
 import java.util.UUID
 
 internal class StackEntryFactory(
-    private val destinations: List<ContentDestination<*>>,
+    private val destinations: List<NavDestination<*>>,
     private val viewModel: StackEntryStoreViewModel,
     private val idGenerator: () -> StackEntry.Id = { StackEntry.Id(UUID.randomUUID().toString()) },
 ) {
@@ -16,7 +16,7 @@ internal class StackEntryFactory(
 
     fun <T : BaseRoute> create(route: T, id: StackEntry.Id, savedStateHandle: SavedStateHandle): StackEntry<T> {
         @Suppress("UNCHECKED_CAST")
-        val destination = destinations.find { it.id == route.destinationId } as ContentDestination<T>
+        val destination = destinations.find { it.id == route.destinationId } as NavDestination<T>
         return StackEntry(id, route, destination, savedStateHandle, viewModel.provideStore(id))
     }
 }

--- a/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/TestStackEntryFactory.kt
+++ b/navigation/src/androidUnitTest/kotlin/com/freeletics/khonshu/navigation/test/TestStackEntryFactory.kt
@@ -2,7 +2,7 @@ package com.freeletics.khonshu.navigation.test
 
 import androidx.lifecycle.SavedStateHandle
 import com.freeletics.khonshu.navigation.BaseRoute
-import com.freeletics.khonshu.navigation.ContentDestination
+import com.freeletics.khonshu.navigation.NavDestination
 import com.freeletics.khonshu.navigation.internal.StackEntry
 import com.freeletics.khonshu.navigation.internal.StackEntryStore
 import com.freeletics.khonshu.navigation.internal.destinationId
@@ -21,7 +21,7 @@ internal class TestStackEntryFactory {
 
     @Suppress("UNCHECKED_CAST")
     fun <T : BaseRoute> create(id: StackEntry.Id, route: T): StackEntry<T> {
-        val destination = destinations.find { it.id == route.destinationId } as ContentDestination<T>
+        val destination = destinations.find { it.id == route.destinationId } as NavDestination<T>
         val handle = handles.getOrPut(id) { SavedStateHandle() }
         val store = stores.getOrPut(id) { StackEntryStore { closedEntries.add(id) } }
         return StackEntry(id, route, destination, handle, store)


### PR DESCRIPTION
It's not really neccessary to have this extra type and just complicates things by needing casts internally. We also don't have `ActivityDestination` which wouldn't be a `ContentDestination` anymore. From a user perspective the only real change is that you now need to use `NavDestination<*>` instead of just `NavDestination`. Since it already was sealed the interface to class change doesn't make a difference to consumers and the rest is internal.