### PR TITLE
make result APIs extension based, remove ResultNavigator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Change Log
 
 - `NavDestination` is now `NavDestination<T : BaseRoute>`, from a consumer perspective
   the only change is that it now needs to be referenced as `NavDestination<*>`.
+- Moved `com.freeletics.khonshu.navigation.ResultNavigator.Companion.registerForNavigationResult`
+  to `com.freeletics.khonshu.navigation.registerForNavigationResult`.
+- `deliverNavigationResult` is now an extension function and needs to be imported.
 - Improve reliability of navigation result APIs by ensuring that results
   are not delivered to a wrong entry on the back stack with the same
   route class.

--- a/navigation-testing/api/android/navigation-testing.api
+++ b/navigation-testing/api/android/navigation-testing.api
@@ -42,7 +42,6 @@ public final class com/freeletics/khonshu/navigation/TestHostNavigator : com/fre
 	public synthetic fun <init> (Lcom/freeletics/khonshu/navigation/NavRoute;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun backPresses ()Lkotlinx/coroutines/flow/Flow;
 	public fun backPresses (Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public fun deliverNavigationResult (Lcom/freeletics/khonshu/navigation/NavigationResultRequest$Key;Landroid/os/Parcelable;)V
 	public final fun getHandleDeepLinkRoute ()Lcom/freeletics/khonshu/navigation/NavRoute;
 	public fun handleDeepLink (Landroid/content/Intent;Lkotlinx/collections/immutable/ImmutableSet;Lkotlinx/collections/immutable/ImmutableSet;)Z
 	public fun navigate (Lkotlin/jvm/functions/Function1;)V

--- a/navigation-testing/navigation-testing.gradle.kts
+++ b/navigation-testing/navigation-testing.gradle.kts
@@ -1,3 +1,6 @@
+import com.freeletics.gradle.plugin.FreeleticsAndroidExtension
+import org.gradle.kotlin.dsl.configure
+
 plugins {
     id("com.freeletics.gradle.multiplatform")
     id("com.freeletics.gradle.publish.oss")
@@ -11,6 +14,10 @@ freeletics {
     multiplatform {
         addJvmTarget()
         addAndroidTarget()
+    }
+
+    extensions.configure(FreeleticsAndroidExtension::class) {
+        enableParcelize()
     }
 }
 

--- a/navigation/api/android/navigation.api
+++ b/navigation/api/android/navigation.api
@@ -6,12 +6,11 @@ public abstract interface class com/freeletics/khonshu/navigation/BackIntercepto
 public abstract interface class com/freeletics/khonshu/navigation/BaseRoute : android/os/Parcelable {
 }
 
-public abstract class com/freeletics/khonshu/navigation/DestinationNavigator : com/freeletics/khonshu/navigation/activity/ActivityNavigator, com/freeletics/khonshu/navigation/BackInterceptor, com/freeletics/khonshu/navigation/Navigator, com/freeletics/khonshu/navigation/ResultNavigator {
+public abstract class com/freeletics/khonshu/navigation/DestinationNavigator : com/freeletics/khonshu/navigation/activity/ActivityNavigator, com/freeletics/khonshu/navigation/BackInterceptor, com/freeletics/khonshu/navigation/Navigator {
 	public static final field $stable I
 	public fun <init> (Lcom/freeletics/khonshu/navigation/HostNavigator;)V
 	public fun backPresses ()Lkotlinx/coroutines/flow/Flow;
 	public fun backPresses (Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public fun deliverNavigationResult (Lcom/freeletics/khonshu/navigation/NavigationResultRequest$Key;Landroid/os/Parcelable;)V
 	public final fun navigate (Lkotlin/jvm/functions/Function1;)V
 	public fun navigateBack ()V
 	public fun navigateBackTo (Lkotlin/reflect/KClass;Z)V
@@ -22,7 +21,7 @@ public abstract class com/freeletics/khonshu/navigation/DestinationNavigator : c
 	public fun switchBackStack (Lcom/freeletics/khonshu/navigation/NavRoot;)V
 }
 
-public abstract class com/freeletics/khonshu/navigation/HostNavigator : com/freeletics/khonshu/navigation/BackInterceptor, com/freeletics/khonshu/navigation/Navigator, com/freeletics/khonshu/navigation/ResultNavigator {
+public abstract class com/freeletics/khonshu/navigation/HostNavigator : com/freeletics/khonshu/navigation/BackInterceptor, com/freeletics/khonshu/navigation/Navigator {
 	public static final field $stable I
 	public abstract fun handleDeepLink (Landroid/content/Intent;Lkotlinx/collections/immutable/ImmutableSet;Lkotlinx/collections/immutable/ImmutableSet;)Z
 	public abstract fun navigate (Lkotlin/jvm/functions/Function1;)V
@@ -63,6 +62,11 @@ public final class com/freeletics/khonshu/navigation/NavigationResultRequest$Key
 	public final fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
+public final class com/freeletics/khonshu/navigation/NavigationResultsKt {
+	public static final fun deliverNavigationResult (Lcom/freeletics/khonshu/navigation/Navigator;Lcom/freeletics/khonshu/navigation/NavigationResultRequest$Key;Landroid/os/Parcelable;)V
+	public static final fun registerForNavigationResult-G5cFDYM (Lcom/freeletics/khonshu/navigation/Navigator;Lkotlin/reflect/KClass;Ljava/lang/String;)Lcom/freeletics/khonshu/navigation/NavigationResultRequest;
+}
+
 public final class com/freeletics/khonshu/navigation/NavigationSetupKt {
 	public static final fun NavigationSetup (Lcom/freeletics/khonshu/navigation/activity/ActivityNavigator;Landroidx/compose/runtime/Composer;I)V
 }
@@ -85,14 +89,6 @@ public final class com/freeletics/khonshu/navigation/Navigator$Companion {
 public final class com/freeletics/khonshu/navigation/OverlayDestination : com/freeletics/khonshu/navigation/NavDestination {
 	public static final field $stable I
 	public synthetic fun <init> (Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;Ljava/lang/Object;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-}
-
-public abstract interface class com/freeletics/khonshu/navigation/ResultNavigator {
-	public static final field Companion Lcom/freeletics/khonshu/navigation/ResultNavigator$Companion;
-	public abstract fun deliverNavigationResult (Lcom/freeletics/khonshu/navigation/NavigationResultRequest$Key;Landroid/os/Parcelable;)V
-}
-
-public final class com/freeletics/khonshu/navigation/ResultNavigator$Companion {
 }
 
 public final class com/freeletics/khonshu/navigation/ScreenDestination : com/freeletics/khonshu/navigation/NavDestination {
@@ -204,6 +200,12 @@ public final class com/freeletics/khonshu/navigation/deeplinks/DeepLinkKt {
 	public static final fun DeepLink (Ljava/util/List;Ljava/lang/String;)Lcom/freeletics/khonshu/navigation/deeplinks/DeepLink;
 	public static synthetic fun DeepLink$default (Lcom/freeletics/khonshu/navigation/NavRoot;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lcom/freeletics/khonshu/navigation/deeplinks/DeepLink;
 	public static synthetic fun DeepLink$default (Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lcom/freeletics/khonshu/navigation/deeplinks/DeepLink;
+}
+
+public final class com/freeletics/khonshu/navigation/internal/ComposableSingletons$StackEntryKt {
+	public static final field INSTANCE Lcom/freeletics/khonshu/navigation/internal/ComposableSingletons$StackEntryKt;
+	public fun <init> ()V
+	public final fun getLambda$312382450$navigation_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public abstract interface annotation class com/freeletics/khonshu/navigation/internal/InternalNavigationApi : java/lang/annotation/Annotation {

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/DestinationNavigator.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/DestinationNavigator.kt
@@ -11,7 +11,6 @@ public abstract class DestinationNavigator(
     @property:InternalNavigationTestingApi
     public val hostNavigator: HostNavigator,
 ) : Navigator by hostNavigator,
-    ResultNavigator by hostNavigator,
     BackInterceptor by hostNavigator,
     ActivityNavigator() {
     /**

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/HostNavigator.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/HostNavigator.kt
@@ -4,10 +4,10 @@ import android.content.Intent
 import androidx.activity.OnBackPressedCallback
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.freeletics.khonshu.navigation.deeplinks.DeepLink
 import com.freeletics.khonshu.navigation.deeplinks.DeepLinkHandler
 import com.freeletics.khonshu.navigation.internal.InternalNavigationTestingApi
 import com.freeletics.khonshu.navigation.internal.StackEntryStoreViewModel
@@ -23,7 +23,6 @@ import kotlinx.collections.immutable.persistentSetOf
  */
 public abstract class HostNavigator @InternalNavigationTestingApi constructor() :
     Navigator,
-    ResultNavigator,
     BackInterceptor {
         @InternalNavigationTestingApi
         public abstract val snapshot: State<StackSnapshot>

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/Navigator.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/Navigator.kt
@@ -1,6 +1,5 @@
 package com.freeletics.khonshu.navigation
 
-import android.os.Parcelable
 import com.freeletics.khonshu.navigation.internal.DestinationId
 import com.freeletics.khonshu.navigation.internal.InternalNavigationApi
 import com.freeletics.khonshu.navigation.internal.StackEntry
@@ -68,40 +67,6 @@ public interface Navigator {
          */
         public inline fun <reified T : NavRoute> Navigator.navigateBackTo(inclusive: Boolean = false) {
             navigateBackTo(T::class, inclusive)
-        }
-    }
-}
-
-public interface ResultNavigator {
-    /**
-     * Delivers the [result] to the destination that created [key].
-     */
-    public fun <O : Parcelable> deliverNavigationResult(key: NavigationResultRequest.Key<O>, result: O)
-
-    /**
-     * Register for receiving navigation results that were delivered through
-     * [deliverNavigationResult]. [T] is expected to be the [BaseRoute] to the current destination.
-     *
-     * The returned [NavigationResultRequest] has a [NavigationResultRequest.Key]. This `key` should
-     * be passed to the target destination which can then use it to call [deliverNavigationResult].
-     */
-    @InternalNavigationApi
-    public fun <T : BaseRoute, O : Parcelable> registerForNavigationResultInternal(
-        id: DestinationId<T>,
-        resultType: String,
-    ): NavigationResultRequest<O>
-
-    public companion object {
-        /**
-         * Register for receiving navigation results that were delivered through
-         * [deliverNavigationResult]. [T] is expected to be the [BaseRoute] to the current destination.
-         *
-         * The returned [NavigationResultRequest] has a [NavigationResultRequest.Key]. This `key` should
-         * be passed to the target destination which can then use it to call [deliverNavigationResult].
-         */
-        public inline fun <reified T : BaseRoute, reified O : Parcelable> ResultNavigator.registerForNavigationResult():
-            NavigationResultRequest<O> {
-            return registerForNavigationResultInternal(DestinationId(T::class), O::class.qualifiedName!!)
         }
     }
 }

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackHostNavigator.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackHostNavigator.kt
@@ -1,15 +1,12 @@
 package com.freeletics.khonshu.navigation.internal
 
 import android.content.Intent
-import android.os.Parcelable
 import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.State
 import com.freeletics.khonshu.navigation.BaseRoute
 import com.freeletics.khonshu.navigation.HostNavigator
 import com.freeletics.khonshu.navigation.NavRoot
 import com.freeletics.khonshu.navigation.NavRoute
-import com.freeletics.khonshu.navigation.NavigationResult
-import com.freeletics.khonshu.navigation.NavigationResultRequest
 import com.freeletics.khonshu.navigation.Navigator
 import com.freeletics.khonshu.navigation.deeplinks.DeepLinkHandler
 import com.freeletics.khonshu.navigation.deeplinks.extractDeepLinkRoutes
@@ -96,21 +93,6 @@ internal class MultiStackHostNavigator(
 
     override fun replaceAllBackStacks(root: NavRoot) {
         stack.replaceAll(root)
-    }
-
-    override fun <O : Parcelable> deliverNavigationResult(key: NavigationResultRequest.Key<O>, result: O) {
-        val entry = getEntryFor(key.stackEntryId)
-        entry.savedStateHandle[key.requestKey] = NavigationResult(result)
-    }
-
-    override fun <T : BaseRoute, O : Parcelable> registerForNavigationResultInternal(
-        id: DestinationId<T>,
-        resultType: String,
-    ): NavigationResultRequest<O> {
-        val requestKey = "${id.route.qualifiedName!!}-$resultType"
-        val entry = getTopEntryFor(id)
-        val key = NavigationResultRequest.Key<O>(entry.id, requestKey)
-        return NavigationResultRequest(key, entry.savedStateHandle)
     }
 
     override val onBackPressedCallback = DelegatingOnBackPressedCallback()

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackEntry.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackEntry.kt
@@ -11,6 +11,7 @@ import com.freeletics.khonshu.navigation.NavDestination
 import com.freeletics.khonshu.navigation.NavRoot
 import com.freeletics.khonshu.navigation.NavRoute
 import com.freeletics.khonshu.navigation.OverlayDestination
+import com.freeletics.khonshu.navigation.ScreenDestination
 import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
@@ -59,4 +60,18 @@ public class StackEntry<T : BaseRoute> internal constructor(
     @Parcelize
     @InternalNavigationTestingApi
     public value class Id(internal val value: String) : Parcelable
+
+    @InternalNavigationTestingApi
+    public companion object {
+        @InternalNavigationTestingApi
+        public fun create(id: Id, route: BaseRoute): StackEntry<BaseRoute> {
+            return StackEntry(
+                id = id,
+                route = route,
+                destination = ScreenDestination<BaseRoute> {},
+                savedStateHandle = SavedStateHandle(),
+                store = StackEntryStore {},
+            )
+        }
+    }
 }

--- a/sample/simple/feature/screen-with-result/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/screen/result/ScreenWithResultNavigator.kt
+++ b/sample/simple/feature/screen-with-result/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/screen/result/ScreenWithResultNavigator.kt
@@ -3,6 +3,7 @@ package com.freeletics.khonshu.sample.feature.screen.result
 import com.freeletics.khonshu.navigation.DestinationNavigator
 import com.freeletics.khonshu.navigation.HostNavigator
 import com.freeletics.khonshu.navigation.activity.ActivityNavigator
+import com.freeletics.khonshu.navigation.deliverNavigationResult
 import com.freeletics.khonshu.sample.feature.screen.result.nav.Result
 import com.freeletics.khonshu.sample.feature.screen.result.nav.ScreenWithResultRoute
 import dev.zacsweers.metro.ContributesBinding

--- a/sample/simple/feature/screen/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/screen/ScreenNavigator.kt
+++ b/sample/simple/feature/screen/implementation/src/main/kotlin/com/freeletics/khonshu/sample/feature/screen/ScreenNavigator.kt
@@ -2,8 +2,8 @@ package com.freeletics.khonshu.sample.feature.screen
 
 import com.freeletics.khonshu.navigation.DestinationNavigator
 import com.freeletics.khonshu.navigation.HostNavigator
-import com.freeletics.khonshu.navigation.ResultNavigator.Companion.registerForNavigationResult
 import com.freeletics.khonshu.navigation.activity.ActivityNavigator
+import com.freeletics.khonshu.navigation.registerForNavigationResult
 import com.freeletics.khonshu.sample.feature.bottomsheet.nav.BottomSheetRoute
 import com.freeletics.khonshu.sample.feature.dialog.nav.DialogRoute
 import com.freeletics.khonshu.sample.feature.newroot.nav.NewRootRoute


### PR DESCRIPTION
Removes `ResultNavigator` and from the public API and with it the weird API indirection where `registerNavigationResultInternal` without reified generics was defined on the interface and then we had an extension for th refified inline `registerNavigationResult`. Now everything is based on extension building on top of existing `Navigator` APIs.