### PR TITLE
make handleDeepLink fully testable

### DIFF
--- a/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/TestHostNavigator.kt
+++ b/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/TestHostNavigator.kt
@@ -15,7 +15,9 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.parcelize.Parcelize
 
-public class TestHostNavigator() : HostNavigator() {
+public class TestHostNavigator(
+    override var startRoot: NavRoot = DummyRoot,
+) : HostNavigator() {
     @InternalNavigationCodegenApi
     private val fakeEntry = StackEntry.create(StackEntry.Id(""), DummyRoute)
 
@@ -61,6 +63,7 @@ public class TestHostNavigator() : HostNavigator() {
     }
 
     override fun replaceAllBackStacks(root: NavRoot) {
+        startRoot = root
         eventTurbine += ReplaceAllBackStacksEvent(root)
     }
 
@@ -75,6 +78,9 @@ public class TestHostNavigator() : HostNavigator() {
     override fun getEntryFor(id: StackEntry.Id): StackEntry<*> {
         return fakeEntry
     }
+
+    @Parcelize
+    private object DummyRoot : NavRoot
 
     @Parcelize
     private object DummyRoute : NavRoute

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/HostNavigator.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/HostNavigator.kt
@@ -25,6 +25,9 @@ public abstract class HostNavigator @InternalNavigationTestingApi constructor() 
     @InternalNavigationTestingApi
     public abstract val snapshot: State<StackSnapshot>
 
+    @InternalNavigationTestingApi
+    public abstract val startRoot: NavRoot
+
     /**
      * Allows to group multiple navigation actions and execute them atomically. The state of this [HostNavigator] will
      * only be updated after running all actions. This should be used when navigating multiple times, for example

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/deeplinks/HandleDeeplink.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/deeplinks/HandleDeeplink.kt
@@ -36,7 +36,7 @@ public fun HostNavigator.handleDeepLink(
 }
 
 private fun HostNavigator.handleDeepLink(deepLinkRoutes: List<BaseRoute>): Boolean {
-    val root = snapshot.value.startRoot.route
+    val root = startRoot
     navigate {
         showRoot(root)
 

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackHostNavigator.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackHostNavigator.kt
@@ -14,6 +14,8 @@ internal class MultiStackHostNavigator(
 ) : HostNavigator() {
     override val snapshot: State<StackSnapshot>
         get() = stack.snapshot
+    override val startRoot: NavRoot
+        get() = snapshot.value.startRoot.route
 
     init {
         viewModel.globalSavedStateHandle.setSavedStateProvider(SAVED_STATE_STACK) {


### PR DESCRIPTION
`TestHostNavigator` does not provide a `snapshot` which was used by the deep link API. This instead adds an internal API that provides the `startRoot` directly and exposes this API publicly in `TestHostNavigator`.