### PR TITLE
fix NavigationResult wrapper not considered for test helper

### DIFF
--- a/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavigatorTurbine.kt
+++ b/navigation-testing/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavigatorTurbine.kt
@@ -327,7 +327,9 @@ internal class DefaultNavigatorTurbine(
         key: NavigationResultRequest.Key<O>,
         result: O,
     ) {
-        val turbine = savedStateHandle.getStateFlow<O?>(key.requestKey, null)
+        val turbine = savedStateHandle.getStateFlow<NavigationResult<O>?>(key.requestKey, null)
+            .filterNotNull()
+            .map { it.value }
             .filterNotNull()
             .testIn(scope)
         Truth.assertThat(turbine.awaitItem()).isEqualTo(result)


### PR DESCRIPTION
The test API for `deliverNavigationResult` was not considering the `NavigationResult` wrapper which caused it to always fail in tests.