### PR TITLE
make TextResource Serializable

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 flowredux = "2.0.0-alpha1"
 kotlin = "2.2.21"
 coroutines = "1.10.2"
+serialization = "1.9.0"
 
 java-target= "11"
 java-toolchain = "24"
@@ -73,7 +74,8 @@ androidx-viewmodel-savedstate = { module = "androidx.lifecycle:lifecycle-viewmod
 
 uri = { module = "com.eygraber:uri-kmp", version.ref = "uri" }
 toml = { module = "net.peanuuutz.tomlkt:tomlkt", version = "0.5.0" }
-kotlinx-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version = "1.9.0" }
+kotlinx-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "serialization" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
 
 metro = { module = "dev.zacsweers.metro:runtime", version.ref = "metro"}
 ksp-api = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }

--- a/text-resource/api/text-resource.api
+++ b/text-resource/api/text-resource.api
@@ -9,6 +9,7 @@ public final class com/freeletics/khonshu/text/LoadingTextResource : com/freelet
 	public synthetic fun format (Landroidx/compose/runtime/Composer;I)Ljava/lang/String;
 	public fun format (Landroidx/compose/runtime/Composer;I)Ljava/lang/Void;
 	public fun hashCode ()I
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 	public fun toString ()Ljava/lang/String;
 	public final fun writeToParcel (Landroid/os/Parcel;I)V
 }
@@ -16,10 +17,12 @@ public final class com/freeletics/khonshu/text/LoadingTextResource : com/freelet
 public abstract class com/freeletics/khonshu/text/TextResource : android/os/Parcelable {
 	public static final field $stable I
 	public static final field Companion Lcom/freeletics/khonshu/text/TextResource$Companion;
+	public synthetic fun <init> (ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
 	public abstract fun format (Landroid/content/Context;)Ljava/lang/String;
 	public abstract fun format (Landroidx/compose/runtime/Composer;I)Ljava/lang/String;
 	public static final fun join (Ljava/util/List;)Lcom/freeletics/khonshu/text/TextResource;
 	public static final fun join (Ljava/util/List;Ljava/lang/String;)Lcom/freeletics/khonshu/text/TextResource;
+	public static final synthetic fun write$Self (Lcom/freeletics/khonshu/text/TextResource;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class com/freeletics/khonshu/text/TextResource$Companion {
@@ -30,6 +33,7 @@ public final class com/freeletics/khonshu/text/TextResource$Companion {
 	public final fun join (Ljava/util/List;)Lcom/freeletics/khonshu/text/TextResource;
 	public final fun join (Ljava/util/List;Ljava/lang/String;)Lcom/freeletics/khonshu/text/TextResource;
 	public static synthetic fun join$default (Lcom/freeletics/khonshu/text/TextResource$Companion;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lcom/freeletics/khonshu/text/TextResource;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/freeletics/khonshu/text/TextResourcesKt {

--- a/text-resource/src/test/kotlin/com/freeletics/khonshu/text/TextResourceTest.kt
+++ b/text-resource/src/test/kotlin/com/freeletics/khonshu/text/TextResourceTest.kt
@@ -1,0 +1,44 @@
+package com.freeletics.khonshu.text
+
+import com.google.common.truth.Truth.assertThat
+import kotlin.test.Test
+import kotlinx.serialization.json.Json
+
+class TextResourceTest {
+    val textResource = TextResource.join(
+        listOf(
+            TextResource(""),
+            TextResource(0, "a", 0, 0L, 0.0f, 0.0, TextResource("")),
+            TextResource.createWithQuantity(0, 1, "a", 0, 0L, 0.0f, 0.0, TextResource("")),
+        ),
+    )
+
+    val json = "{\"type\":\"com.freeletics.khonshu.text.CompositeTextResource\",\"elements\":[" +
+        "{\"type\":\"com.freeletics.khonshu.text.SimpleTextResource\",\"text\":\"\"}," +
+        "{\"type\":\"com.freeletics.khonshu.text.StringTextResource\",\"id\":0,\"args\":[" +
+        "{\"type\":\"com.freeletics.khonshu.text.StringArg\",\"value\":\"a\"}," +
+        "{\"type\":\"com.freeletics.khonshu.text.IntArg\",\"value\":0}," +
+        "{\"type\":\"com.freeletics.khonshu.text.LongArg\",\"value\":0}," +
+        "{\"type\":\"com.freeletics.khonshu.text.FloatArg\",\"value\":0.0}," +
+        "{\"type\":\"com.freeletics.khonshu.text.DoubleArg\",\"value\":0.0}," +
+        "{\"type\":\"com.freeletics.khonshu.text.TextResourceArg\",\"value\":" +
+        "{\"type\":\"com.freeletics.khonshu.text.SimpleTextResource\",\"text\":\"\"}}]}," +
+        "{\"type\":\"com.freeletics.khonshu.text.PluralTextResource\",\"id\":0,\"quantity\":1,\"args\":[" +
+        "{\"type\":\"com.freeletics.khonshu.text.StringArg\",\"value\":\"a\"}," +
+        "{\"type\":\"com.freeletics.khonshu.text.IntArg\",\"value\":0}," +
+        "{\"type\":\"com.freeletics.khonshu.text.LongArg\",\"value\":0}," +
+        "{\"type\":\"com.freeletics.khonshu.text.FloatArg\",\"value\":0.0}," + "" +
+        "{\"type\":\"com.freeletics.khonshu.text.DoubleArg\",\"value\":0.0}," +
+        "{\"type\":\"com.freeletics.khonshu.text.TextResourceArg\",\"value\":" +
+        "{\"type\":\"com.freeletics.khonshu.text.SimpleTextResource\",\"text\":\"\"}}]}],\"separator\":\", \"}"
+
+    @Test
+    fun serialize() {
+        assertThat(Json.encodeToString(textResource)).isEqualTo(json)
+    }
+
+    @Test
+    fun deserialize() {
+        assertThat(Json.decodeFromString<TextResource>(json)).isEqualTo(textResource)
+    }
+}

--- a/text-resource/text-resource.gradle.kts
+++ b/text-resource/text-resource.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 freeletics {
     useCompose()
     usePoko()
+    useSerialization()
 
     android {
         enableParcelize()
@@ -19,4 +20,8 @@ dependencies {
     implementation(libs.kotlin.parcelize)
 
     compileOnly(libs.androidx.annotations)
+
+    testImplementation(libs.kotlin.test)
+    testImplementation(libs.truth)
+    testImplementation(libs.kotlinx.serialization.json)
 }


### PR DESCRIPTION
The implementation with wrapping the args isn't ideal, but since the possible types are very limited and the serialization does only happen for state saving/restoration it should be ok.