### PR TITLE
replace getSystemService with GlobalGraphProvider interface

### DIFF
--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/HostActivityCodegenTest.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/HostActivityCodegenTest.kt
@@ -86,6 +86,8 @@ internal class HostActivityCodegenTest {
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.compose.runtime.retain.retain
             import androidx.lifecycle.SavedStateHandle
+            import androidx.lifecycle.ViewModelStoreOwner
+            import com.freeletics.khonshu.codegen.GlobalGraphProvider
             import com.freeletics.khonshu.codegen.SimpleNavHost
             import com.freeletics.khonshu.codegen.`internal`.HostGraphProvider
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
@@ -150,11 +152,13 @@ internal class HostActivityCodegenTest {
 
             @OptIn(InternalCodegenApi::class)
             public class KhonshuTestGraphProvider(
-              private val activity: ComponentActivity,
+              private val viewModelStoreOwner: ViewModelStoreOwner,
+              private val globalGraphProvider: GlobalGraphProvider,
               private val stackEntryStoreHolder: StackEntryStoreHolder,
+              private val intent: Intent,
             ) : HostGraphProvider {
-              override fun <C> provide(scope: KClass<*>): C = getGraph(activity, scope, TestScreen::class, TestParentScope::class) { factory: KhonshuTestGraph.Factory, savedStateHandle ->
-                factory.createKhonshuTestGraph(stackEntryStoreHolder, savedStateHandle, activity.intent)
+              override fun <C> provide(scope: KClass<*>): C = getGraph(viewModelStoreOwner, globalGraphProvider, scope, TestScreen::class, TestParentScope::class) { factory: KhonshuTestGraph.Factory, savedStateHandle ->
+                factory.createKhonshuTestGraph(stackEntryStoreHolder, savedStateHandle, intent)
               }
             }
 
@@ -186,7 +190,7 @@ internal class HostActivityCodegenTest {
                     StackEntryStoreHolder()
                   }
                   val graphProvider = remember {
-                    KhonshuTestGraphProvider(this, stackEntryStoreHolder)
+                    KhonshuTestGraphProvider(this, application as GlobalGraphProvider, stackEntryStoreHolder, intent)
                   }
                   val graph = remember(graphProvider) {
                     graphProvider.provide<KhonshuTestGraph>(TestScreen::class)
@@ -278,7 +282,9 @@ internal class HostActivityCodegenTest {
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.compose.runtime.retain.retain
             import androidx.lifecycle.SavedStateHandle
+            import androidx.lifecycle.ViewModelStoreOwner
             import com.freeletics.khonshu.codegen.ActivityScope
+            import com.freeletics.khonshu.codegen.GlobalGraphProvider
             import com.freeletics.khonshu.codegen.SimpleNavHost
             import com.freeletics.khonshu.codegen.`internal`.HostGraphProvider
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
@@ -343,11 +349,13 @@ internal class HostActivityCodegenTest {
 
             @OptIn(InternalCodegenApi::class)
             public class KhonshuTestGraphProvider(
-              private val activity: ComponentActivity,
+              private val viewModelStoreOwner: ViewModelStoreOwner,
+              private val globalGraphProvider: GlobalGraphProvider,
               private val stackEntryStoreHolder: StackEntryStoreHolder,
+              private val intent: Intent,
             ) : HostGraphProvider {
-              override fun <C> provide(scope: KClass<*>): C = getGraph(activity, scope, ActivityScope::class, AppScope::class) { factory: KhonshuTestGraph.Factory, savedStateHandle ->
-                factory.createKhonshuTestGraph(stackEntryStoreHolder, savedStateHandle, activity.intent)
+              override fun <C> provide(scope: KClass<*>): C = getGraph(viewModelStoreOwner, globalGraphProvider, scope, ActivityScope::class, AppScope::class) { factory: KhonshuTestGraph.Factory, savedStateHandle ->
+                factory.createKhonshuTestGraph(stackEntryStoreHolder, savedStateHandle, intent)
               }
             }
 
@@ -379,7 +387,7 @@ internal class HostActivityCodegenTest {
                     StackEntryStoreHolder()
                   }
                   val graphProvider = remember {
-                    KhonshuTestGraphProvider(this, stackEntryStoreHolder)
+                    KhonshuTestGraphProvider(this, application as GlobalGraphProvider, stackEntryStoreHolder, intent)
                   }
                   val graph = remember(graphProvider) {
                     graphProvider.provide<KhonshuTestGraph>(ActivityScope::class)
@@ -495,6 +503,8 @@ internal class HostActivityCodegenTest {
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.compose.runtime.retain.retain
             import androidx.lifecycle.SavedStateHandle
+            import androidx.lifecycle.ViewModelStoreOwner
+            import com.freeletics.khonshu.codegen.GlobalGraphProvider
             import com.freeletics.khonshu.codegen.SimpleNavHost
             import com.freeletics.khonshu.codegen.`internal`.HostGraphProvider
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
@@ -571,11 +581,13 @@ internal class HostActivityCodegenTest {
 
             @OptIn(InternalCodegenApi::class)
             public class KhonshuTest2GraphProvider(
-              private val activity: ComponentActivity,
+              private val viewModelStoreOwner: ViewModelStoreOwner,
+              private val globalGraphProvider: GlobalGraphProvider,
               private val stackEntryStoreHolder: StackEntryStoreHolder,
+              private val intent: Intent,
             ) : HostGraphProvider {
-              override fun <C> provide(scope: KClass<*>): C = getGraph(activity, scope, TestScreen::class, TestParentScope::class) { factory: KhonshuTest2Graph.Factory, savedStateHandle ->
-                factory.createKhonshuTest2Graph(stackEntryStoreHolder, savedStateHandle, activity.intent)
+              override fun <C> provide(scope: KClass<*>): C = getGraph(viewModelStoreOwner, globalGraphProvider, scope, TestScreen::class, TestParentScope::class) { factory: KhonshuTest2Graph.Factory, savedStateHandle ->
+                factory.createKhonshuTest2Graph(stackEntryStoreHolder, savedStateHandle, intent)
               }
             }
 
@@ -607,7 +619,7 @@ internal class HostActivityCodegenTest {
                     StackEntryStoreHolder()
                   }
                   val graphProvider = remember {
-                    KhonshuTest2GraphProvider(this, stackEntryStoreHolder)
+                    KhonshuTest2GraphProvider(this, application as GlobalGraphProvider, stackEntryStoreHolder, intent)
                   }
                   val graph = remember(graphProvider) {
                     graphProvider.provide<KhonshuTest2Graph>(TestScreen::class)
@@ -706,6 +718,8 @@ internal class HostActivityCodegenTest {
             import androidx.compose.runtime.remember
             import androidx.compose.runtime.retain.retain
             import androidx.lifecycle.SavedStateHandle
+            import androidx.lifecycle.ViewModelStoreOwner
+            import com.freeletics.khonshu.codegen.GlobalGraphProvider
             import com.freeletics.khonshu.codegen.SimpleNavHost
             import com.freeletics.khonshu.codegen.`internal`.HostGraphProvider
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
@@ -768,11 +782,13 @@ internal class HostActivityCodegenTest {
 
             @OptIn(InternalCodegenApi::class)
             public class KhonshuTestGraphProvider(
-              private val activity: ComponentActivity,
+              private val viewModelStoreOwner: ViewModelStoreOwner,
+              private val globalGraphProvider: GlobalGraphProvider,
               private val stackEntryStoreHolder: StackEntryStoreHolder,
+              private val intent: Intent,
             ) : HostGraphProvider {
-              override fun <C> provide(scope: KClass<*>): C = getGraph(activity, scope, TestScreen::class, TestParentScope::class) { factory: KhonshuTestGraph.Factory, savedStateHandle ->
-                factory.createKhonshuTestGraph(stackEntryStoreHolder, savedStateHandle, activity.intent)
+              override fun <C> provide(scope: KClass<*>): C = getGraph(viewModelStoreOwner, globalGraphProvider, scope, TestScreen::class, TestParentScope::class) { factory: KhonshuTestGraph.Factory, savedStateHandle ->
+                factory.createKhonshuTestGraph(stackEntryStoreHolder, savedStateHandle, intent)
               }
             }
 
@@ -804,7 +820,7 @@ internal class HostActivityCodegenTest {
                     StackEntryStoreHolder()
                   }
                   val graphProvider = remember {
-                    KhonshuTestGraphProvider(this, stackEntryStoreHolder)
+                    KhonshuTestGraphProvider(this, application as GlobalGraphProvider, stackEntryStoreHolder, intent)
                   }
                   val graph = remember(graphProvider) {
                     graphProvider.provide<KhonshuTestGraph>(TestScreen::class)
@@ -891,6 +907,8 @@ internal class HostActivityCodegenTest {
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.compose.runtime.retain.retain
             import androidx.lifecycle.SavedStateHandle
+            import androidx.lifecycle.ViewModelStoreOwner
+            import com.freeletics.khonshu.codegen.GlobalGraphProvider
             import com.freeletics.khonshu.codegen.SimpleNavHost
             import com.freeletics.khonshu.codegen.`internal`.HostGraphProvider
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
@@ -955,11 +973,13 @@ internal class HostActivityCodegenTest {
 
             @OptIn(InternalCodegenApi::class)
             public class KhonshuTestGraphProvider(
-              private val activity: ComponentActivity,
+              private val viewModelStoreOwner: ViewModelStoreOwner,
+              private val globalGraphProvider: GlobalGraphProvider,
               private val stackEntryStoreHolder: StackEntryStoreHolder,
+              private val intent: Intent,
             ) : HostGraphProvider {
-              override fun <C> provide(scope: KClass<*>): C = getGraph(activity, scope, TestScreen::class, TestParentScope::class) { factory: KhonshuTestGraph.Factory, savedStateHandle ->
-                factory.createKhonshuTestGraph(stackEntryStoreHolder, savedStateHandle, activity.intent)
+              override fun <C> provide(scope: KClass<*>): C = getGraph(viewModelStoreOwner, globalGraphProvider, scope, TestScreen::class, TestParentScope::class) { factory: KhonshuTestGraph.Factory, savedStateHandle ->
+                factory.createKhonshuTestGraph(stackEntryStoreHolder, savedStateHandle, intent)
               }
             }
 
@@ -991,7 +1011,7 @@ internal class HostActivityCodegenTest {
                     StackEntryStoreHolder()
                   }
                   val graphProvider = remember {
-                    KhonshuTestGraphProvider(this, stackEntryStoreHolder)
+                    KhonshuTestGraphProvider(this, application as GlobalGraphProvider, stackEntryStoreHolder, intent)
                   }
                   val graph = remember(graphProvider) {
                     graphProvider.provide<KhonshuTestGraph>(TestScreen::class)
@@ -1083,6 +1103,8 @@ internal class HostActivityCodegenTest {
             import androidx.compose.runtime.rememberCoroutineScope
             import androidx.compose.runtime.retain.retain
             import androidx.lifecycle.SavedStateHandle
+            import androidx.lifecycle.ViewModelStoreOwner
+            import com.freeletics.khonshu.codegen.GlobalGraphProvider
             import com.freeletics.khonshu.codegen.SimpleNavHost
             import com.freeletics.khonshu.codegen.`internal`.HostGraphProvider
             import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
@@ -1147,11 +1169,13 @@ internal class HostActivityCodegenTest {
 
             @OptIn(InternalCodegenApi::class)
             public class KhonshuTestGraphProvider(
-              private val activity: ComponentActivity,
+              private val viewModelStoreOwner: ViewModelStoreOwner,
+              private val globalGraphProvider: GlobalGraphProvider,
               private val stackEntryStoreHolder: StackEntryStoreHolder,
+              private val intent: Intent,
             ) : HostGraphProvider {
-              override fun <C> provide(scope: KClass<*>): C = getGraph(activity, scope, TestScreen::class, TestParentScope::class) { factory: KhonshuTestGraph.Factory, savedStateHandle ->
-                factory.createKhonshuTestGraph(stackEntryStoreHolder, savedStateHandle, activity.intent)
+              override fun <C> provide(scope: KClass<*>): C = getGraph(viewModelStoreOwner, globalGraphProvider, scope, TestScreen::class, TestParentScope::class) { factory: KhonshuTestGraph.Factory, savedStateHandle ->
+                factory.createKhonshuTestGraph(stackEntryStoreHolder, savedStateHandle, intent)
               }
             }
 
@@ -1183,7 +1207,7 @@ internal class HostActivityCodegenTest {
                     StackEntryStoreHolder()
                   }
                   val graphProvider = remember {
-                    KhonshuTestGraphProvider(this, stackEntryStoreHolder)
+                    KhonshuTestGraphProvider(this, application as GlobalGraphProvider, stackEntryStoreHolder, intent)
                   }
                   val graph = remember(graphProvider) {
                     graphProvider.provide<KhonshuTestGraph>(TestScreen::class)

--- a/codegen-compiler/src/jvmMain/kotlin/com/freeletics/khonshu/codegen/codegen/HostActivityGenerator.kt
+++ b/codegen-compiler/src/jvmMain/kotlin/com/freeletics/khonshu/codegen/codegen/HostActivityGenerator.kt
@@ -4,6 +4,7 @@ import com.freeletics.khonshu.codegen.BaseData
 import com.freeletics.khonshu.codegen.HostActivityData
 import com.freeletics.khonshu.codegen.util.bundle
 import com.freeletics.khonshu.codegen.util.compositionLocalProvider
+import com.freeletics.khonshu.codegen.util.globalGraphProvider
 import com.freeletics.khonshu.codegen.util.localHostGraphProvider
 import com.freeletics.khonshu.codegen.util.navHost
 import com.freeletics.khonshu.codegen.util.optIn
@@ -39,7 +40,11 @@ internal class HostActivityGenerator(
             .addStatement("%T()", stackEntryStoreHolder)
             .endControlFlow()
             .beginControlFlow("val graphProvider = %M", remember)
-            .addStatement("%T(this, stackEntryStoreHolder)", graphProviderClassName)
+            .addStatement(
+                "%T(this, application as %T, stackEntryStoreHolder, intent)",
+                graphProviderClassName,
+                globalGraphProvider,
+            )
             .endControlFlow()
             .beginControlFlow("val graph = %M(graphProvider)", remember)
             .addStatement("graphProvider.provide<%T>(%T::class)", graphClassName, data.scope)

--- a/codegen-compiler/src/jvmMain/kotlin/com/freeletics/khonshu/codegen/util/External.kt
+++ b/codegen-compiler/src/jvmMain/kotlin/com/freeletics/khonshu/codegen/util/External.kt
@@ -10,6 +10,7 @@ import com.squareup.kotlinpoet.WildcardTypeName
 
 // Codegen Public API
 internal val overlay = ClassName("com.freeletics.khonshu.codegen", "Overlay")
+internal val globalGraphProvider = ClassName("com.freeletics.khonshu.codegen", "GlobalGraphProvider")
 
 // Codegen Internal API
 internal val asComposeState = MemberName("com.freeletics.khonshu.codegen.internal", "asComposeState")
@@ -80,6 +81,7 @@ internal val toImmutableSet = MemberName("kotlinx.collections.immutable", "toImm
 
 // AndroidX
 internal val componentActivity = ClassName("androidx.activity", "ComponentActivity")
+internal val viewModelStoreOwner = ClassName("androidx.lifecycle", "ViewModelStoreOwner")
 internal val setContent = MemberName("androidx.activity.compose", "setContent")
 internal val savedStateHandle = ClassName("androidx.lifecycle", "SavedStateHandle")
 

--- a/codegen/api/android/codegen.api
+++ b/codegen/api/android/codegen.api
@@ -1,6 +1,10 @@
 public abstract interface class com/freeletics/khonshu/codegen/ActivityScope {
 }
 
+public abstract interface class com/freeletics/khonshu/codegen/GlobalGraphProvider {
+	public abstract fun getGraph (Lkotlin/reflect/KClass;)Ljava/lang/Object;
+}
+
 public abstract interface annotation class com/freeletics/khonshu/codegen/NavDestination : java/lang/annotation/Annotation {
 	public abstract fun destinationScope ()Ljava/lang/Class;
 	public abstract fun parentScope ()Ljava/lang/Class;
@@ -16,10 +20,6 @@ public abstract interface annotation class com/freeletics/khonshu/codegen/NavHos
 }
 
 public abstract interface class com/freeletics/khonshu/codegen/Overlay {
-}
-
-public final class com/freeletics/khonshu/codegen/internal/HostGraphLookupKt {
-	public static final fun findGraphByScope (Landroid/content/Context;Lkotlin/reflect/KClass;)Ljava/lang/Object;
 }
 
 public abstract interface annotation class com/freeletics/khonshu/codegen/internal/InternalCodegenApi : java/lang/annotation/Annotation {

--- a/codegen/api/jvm/codegen.api
+++ b/codegen/api/jvm/codegen.api
@@ -1,6 +1,10 @@
 public abstract interface class com/freeletics/khonshu/codegen/ActivityScope {
 }
 
+public abstract interface class com/freeletics/khonshu/codegen/GlobalGraphProvider {
+	public abstract fun getGraph (Lkotlin/reflect/KClass;)Ljava/lang/Object;
+}
+
 public abstract interface annotation class com/freeletics/khonshu/codegen/NavDestination : java/lang/annotation/Annotation {
 	public abstract fun destinationScope ()Ljava/lang/Class;
 	public abstract fun parentScope ()Ljava/lang/Class;

--- a/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/GlobalGraphProvider.kt
+++ b/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/GlobalGraphProvider.kt
@@ -1,0 +1,7 @@
+package com.freeletics.khonshu.codegen
+
+import kotlin.reflect.KClass
+
+public interface GlobalGraphProvider {
+    public fun <T> getGraph(scope: KClass<*>): T
+}

--- a/sample/simple/app/simple/src/main/kotlin/com/freeletics/khonshu/sample/app/App.kt
+++ b/sample/simple/app/simple/src/main/kotlin/com/freeletics/khonshu/sample/app/App.kt
@@ -1,18 +1,21 @@
 package com.freeletics.khonshu.sample.app
 
 import android.app.Application
+import com.freeletics.khonshu.codegen.GlobalGraphProvider
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.createGraphFactory
+import kotlin.reflect.KClass
 
-class App : Application() {
+class App : Application(), GlobalGraphProvider {
     private val graph by lazy {
         createGraphFactory<AppGraph.Factory>().create()
     }
 
-    override fun getSystemService(name: String): Any? {
-        if (name == AppScope::class.qualifiedName) {
-            return graph
+    @Suppress("UNCHECKED_CAST")
+    override fun <T> getGraph(scope: KClass<*>): T {
+        if (scope == AppScope::class) {
+            return graph as T
         }
-        return super.getSystemService(name)
+        throw IllegalArgumentException("Unknown scope")
     }
 }


### PR DESCRIPTION
Removes the Android specific API. In the Android specific generated code we're making the assumption that `Application` implements the new interface. A nice side effect is that we can use `KClass` directly instead of relying on the qualified name.

Note: The `ViewModelStoreOwner` that is passed around will be replaced in a follow up.