### PR TITLE
remove usages of kotlinx.collections.immutable

### DIFF
--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/HostActivityCodegenTest.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/HostActivityCodegenTest.kt
@@ -115,8 +115,6 @@ internal class HostActivityCodegenTest {
             import kotlin.Unit
             import kotlin.collections.Set
             import kotlin.reflect.KClass
-            import kotlinx.collections.immutable.ImmutableSet
-            import kotlinx.collections.immutable.toImmutableSet
             import kotlinx.coroutines.launch
 
             @OptIn(InternalCodegenApi::class)
@@ -165,10 +163,7 @@ internal class HostActivityCodegenTest {
             @ContributesTo(TestScreen::class)
             public interface KhonshuTestActivityGraph {
               @Provides
-              public fun provideImmutableNavDestinations(destinations: Set<NavDestination<*>>): ImmutableSet<NavDestination<*>> = destinations.toImmutableSet()
-
-              @Provides
-              public fun provideLaunchInfo(intent: Intent, destinations: ImmutableSet<NavDestination<*>>): LaunchInfo = intent.asLaunchInfo(destinations)
+              public fun provideLaunchInfo(intent: Intent, destinations: Set<NavDestination<*>>): LaunchInfo = intent.asLaunchInfo(destinations)
 
               @Provides
               @SingleIn(TestScreen::class)
@@ -177,7 +172,7 @@ internal class HostActivityCodegenTest {
                 startRoot: NavRoot,
                 storeHolder: StackEntryStoreHolder,
                 @ForScope(TestScreen::class) savedStateHandle: SavedStateHandle,
-                destinations: ImmutableSet<NavDestination<*>>,
+                destinations: Set<NavDestination<*>>,
               ): HostNavigator = createHostNavigator(startRoot, destinations, storeHolder, savedStateHandle)
             }
 
@@ -312,8 +307,6 @@ internal class HostActivityCodegenTest {
             import kotlin.Unit
             import kotlin.collections.Set
             import kotlin.reflect.KClass
-            import kotlinx.collections.immutable.ImmutableSet
-            import kotlinx.collections.immutable.toImmutableSet
             import kotlinx.coroutines.launch
 
             @OptIn(InternalCodegenApi::class)
@@ -362,10 +355,7 @@ internal class HostActivityCodegenTest {
             @ContributesTo(ActivityScope::class)
             public interface KhonshuTestActivityGraph {
               @Provides
-              public fun provideImmutableNavDestinations(destinations: Set<NavDestination<*>>): ImmutableSet<NavDestination<*>> = destinations.toImmutableSet()
-
-              @Provides
-              public fun provideLaunchInfo(intent: Intent, destinations: ImmutableSet<NavDestination<*>>): LaunchInfo = intent.asLaunchInfo(destinations)
+              public fun provideLaunchInfo(intent: Intent, destinations: Set<NavDestination<*>>): LaunchInfo = intent.asLaunchInfo(destinations)
 
               @Provides
               @SingleIn(ActivityScope::class)
@@ -374,7 +364,7 @@ internal class HostActivityCodegenTest {
                 startRoot: NavRoot,
                 storeHolder: StackEntryStoreHolder,
                 @ForScope(ActivityScope::class) savedStateHandle: SavedStateHandle,
-                destinations: ImmutableSet<NavDestination<*>>,
+                destinations: Set<NavDestination<*>>,
               ): HostNavigator = createHostNavigator(startRoot, destinations, storeHolder, savedStateHandle)
             }
 
@@ -536,8 +526,6 @@ internal class HostActivityCodegenTest {
             import kotlin.collections.Map
             import kotlin.collections.Set
             import kotlin.reflect.KClass
-            import kotlinx.collections.immutable.ImmutableSet
-            import kotlinx.collections.immutable.toImmutableSet
             import kotlinx.coroutines.launch
 
             @OptIn(InternalCodegenApi::class)
@@ -594,10 +582,7 @@ internal class HostActivityCodegenTest {
             @ContributesTo(TestScreen::class)
             public interface KhonshuTest2ActivityGraph {
               @Provides
-              public fun provideImmutableNavDestinations(destinations: Set<NavDestination<*>>): ImmutableSet<NavDestination<*>> = destinations.toImmutableSet()
-
-              @Provides
-              public fun provideLaunchInfo(intent: Intent, destinations: ImmutableSet<NavDestination<*>>): LaunchInfo = intent.asLaunchInfo(destinations)
+              public fun provideLaunchInfo(intent: Intent, destinations: Set<NavDestination<*>>): LaunchInfo = intent.asLaunchInfo(destinations)
 
               @Provides
               @SingleIn(TestScreen::class)
@@ -606,7 +591,7 @@ internal class HostActivityCodegenTest {
                 startRoot: NavRoot,
                 storeHolder: StackEntryStoreHolder,
                 @ForScope(TestScreen::class) savedStateHandle: SavedStateHandle,
-                destinations: ImmutableSet<NavDestination<*>>,
+                destinations: Set<NavDestination<*>>,
               ): HostNavigator = createHostNavigator(startRoot, destinations, storeHolder, savedStateHandle)
             }
 
@@ -746,8 +731,6 @@ internal class HostActivityCodegenTest {
             import kotlin.OptIn
             import kotlin.collections.Set
             import kotlin.reflect.KClass
-            import kotlinx.collections.immutable.ImmutableSet
-            import kotlinx.collections.immutable.toImmutableSet
 
             @OptIn(InternalCodegenApi::class)
             @GraphExtension(TestScreen::class)
@@ -795,10 +778,7 @@ internal class HostActivityCodegenTest {
             @ContributesTo(TestScreen::class)
             public interface KhonshuTestActivityGraph {
               @Provides
-              public fun provideImmutableNavDestinations(destinations: Set<NavDestination<*>>): ImmutableSet<NavDestination<*>> = destinations.toImmutableSet()
-
-              @Provides
-              public fun provideLaunchInfo(intent: Intent, destinations: ImmutableSet<NavDestination<*>>): LaunchInfo = intent.asLaunchInfo(destinations)
+              public fun provideLaunchInfo(intent: Intent, destinations: Set<NavDestination<*>>): LaunchInfo = intent.asLaunchInfo(destinations)
 
               @Provides
               @SingleIn(TestScreen::class)
@@ -807,7 +787,7 @@ internal class HostActivityCodegenTest {
                 startRoot: NavRoot,
                 storeHolder: StackEntryStoreHolder,
                 @ForScope(TestScreen::class) savedStateHandle: SavedStateHandle,
-                destinations: ImmutableSet<NavDestination<*>>,
+                destinations: Set<NavDestination<*>>,
               ): HostNavigator = createHostNavigator(startRoot, destinations, storeHolder, savedStateHandle)
             }
 
@@ -936,8 +916,6 @@ internal class HostActivityCodegenTest {
             import kotlin.Unit
             import kotlin.collections.Set
             import kotlin.reflect.KClass
-            import kotlinx.collections.immutable.ImmutableSet
-            import kotlinx.collections.immutable.toImmutableSet
             import kotlinx.coroutines.launch
 
             @OptIn(InternalCodegenApi::class)
@@ -986,10 +964,7 @@ internal class HostActivityCodegenTest {
             @ContributesTo(TestScreen::class)
             public interface KhonshuTestActivityGraph {
               @Provides
-              public fun provideImmutableNavDestinations(destinations: Set<NavDestination<*>>): ImmutableSet<NavDestination<*>> = destinations.toImmutableSet()
-
-              @Provides
-              public fun provideLaunchInfo(intent: Intent, destinations: ImmutableSet<NavDestination<*>>): LaunchInfo = intent.asLaunchInfo(destinations)
+              public fun provideLaunchInfo(intent: Intent, destinations: Set<NavDestination<*>>): LaunchInfo = intent.asLaunchInfo(destinations)
 
               @Provides
               @SingleIn(TestScreen::class)
@@ -998,7 +973,7 @@ internal class HostActivityCodegenTest {
                 startRoot: NavRoot,
                 storeHolder: StackEntryStoreHolder,
                 @ForScope(TestScreen::class) savedStateHandle: SavedStateHandle,
-                destinations: ImmutableSet<NavDestination<*>>,
+                destinations: Set<NavDestination<*>>,
               ): HostNavigator = createHostNavigator(startRoot, destinations, storeHolder, savedStateHandle)
             }
 
@@ -1132,8 +1107,6 @@ internal class HostActivityCodegenTest {
             import kotlin.Unit
             import kotlin.collections.Set
             import kotlin.reflect.KClass
-            import kotlinx.collections.immutable.ImmutableSet
-            import kotlinx.collections.immutable.toImmutableSet
             import kotlinx.coroutines.launch
 
             @OptIn(InternalCodegenApi::class)
@@ -1182,10 +1155,7 @@ internal class HostActivityCodegenTest {
             @ContributesTo(TestScreen::class)
             public interface KhonshuTestActivityGraph {
               @Provides
-              public fun provideImmutableNavDestinations(destinations: Set<NavDestination<*>>): ImmutableSet<NavDestination<*>> = destinations.toImmutableSet()
-
-              @Provides
-              public fun provideLaunchInfo(intent: Intent, destinations: ImmutableSet<NavDestination<*>>): LaunchInfo = intent.asLaunchInfo(destinations)
+              public fun provideLaunchInfo(intent: Intent, destinations: Set<NavDestination<*>>): LaunchInfo = intent.asLaunchInfo(destinations)
 
               @Provides
               @SingleIn(TestScreen::class)
@@ -1194,7 +1164,7 @@ internal class HostActivityCodegenTest {
                 startRoot: NavRoot,
                 storeHolder: StackEntryStoreHolder,
                 @ForScope(TestScreen::class) savedStateHandle: SavedStateHandle,
-                destinations: ImmutableSet<NavDestination<*>>,
+                destinations: Set<NavDestination<*>>,
               ): HostNavigator = createHostNavigator(startRoot, destinations, storeHolder, savedStateHandle)
             }
 

--- a/codegen-compiler/src/jvmMain/kotlin/com/freeletics/khonshu/codegen/codegen/HostGraphContributionGenerator.kt
+++ b/codegen-compiler/src/jvmMain/kotlin/com/freeletics/khonshu/codegen/codegen/HostGraphContributionGenerator.kt
@@ -7,7 +7,6 @@ import com.freeletics.khonshu.codegen.util.contributesTo
 import com.freeletics.khonshu.codegen.util.createHostNavigator
 import com.freeletics.khonshu.codegen.util.forScope
 import com.freeletics.khonshu.codegen.util.hostNavigator
-import com.freeletics.khonshu.codegen.util.immutableSet
 import com.freeletics.khonshu.codegen.util.intent
 import com.freeletics.khonshu.codegen.util.internalNavigatorApi
 import com.freeletics.khonshu.codegen.util.launchInfo
@@ -18,7 +17,6 @@ import com.freeletics.khonshu.codegen.util.provides
 import com.freeletics.khonshu.codegen.util.savedStateHandle
 import com.freeletics.khonshu.codegen.util.singleIn
 import com.freeletics.khonshu.codegen.util.stackEntryStoreHolder
-import com.freeletics.khonshu.codegen.util.toImmutableSet
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
@@ -33,18 +31,8 @@ internal class HostGraphContributionGenerator(
     internal fun generate(): TypeSpec {
         return TypeSpec.interfaceBuilder(moduleClassName)
             .addAnnotation(contributesTo(data.scope))
-            .addFunction(provideImmutableNavDestinationsFunction())
             .addFunction(provideLaunchInfo())
             .addFunction(provideHostNavigator())
-            .build()
-    }
-
-    private fun provideImmutableNavDestinationsFunction(): FunSpec {
-        return FunSpec.builder("provideImmutableNavDestinations")
-            .addAnnotation(provides())
-            .addParameter("destinations", SET.parameterizedBy(navigationDestination))
-            .returns(immutableSet.parameterizedBy(navigationDestination))
-            .addStatement("return destinations.%M()", toImmutableSet)
             .build()
     }
 
@@ -52,7 +40,7 @@ internal class HostGraphContributionGenerator(
         return FunSpec.builder("provideLaunchInfo")
             .addAnnotation(provides())
             .addParameter("intent", intent)
-            .addParameter("destinations", immutableSet.parameterizedBy(navigationDestination))
+            .addParameter("destinations", SET.parameterizedBy(navigationDestination))
             .returns(launchInfo)
             .addStatement("return intent.%M(destinations)", asLaunchInfo)
             .build()
@@ -68,7 +56,7 @@ internal class HostGraphContributionGenerator(
             .addParameter(
                 ParameterSpec.builder("savedStateHandle", savedStateHandle).addAnnotation(forScope(data.scope)).build(),
             )
-            .addParameter("destinations", immutableSet.parameterizedBy(navigationDestination))
+            .addParameter("destinations", SET.parameterizedBy(navigationDestination))
             .returns(hostNavigator)
             .addStatement(
                 "return %M(startRoot, destinations, storeHolder, savedStateHandle)",

--- a/codegen-compiler/src/jvmMain/kotlin/com/freeletics/khonshu/codegen/util/External.kt
+++ b/codegen-compiler/src/jvmMain/kotlin/com/freeletics/khonshu/codegen/util/External.kt
@@ -75,10 +75,6 @@ internal val function3 = ClassName("kotlin", "Function3")
 // Coroutines
 internal val launch = MemberName("kotlinx.coroutines", "launch")
 
-// Collections Immutable
-internal val immutableSet = ClassName("kotlinx.collections.immutable", "ImmutableSet")
-internal val toImmutableSet = MemberName("kotlinx.collections.immutable", "toImmutableSet")
-
 // AndroidX
 internal val componentActivity = ClassName("androidx.activity", "ComponentActivity")
 internal val viewModelStoreOwner = ClassName("androidx.lifecycle", "ViewModelStoreOwner")

--- a/docs/navigation/deeplinks.md
+++ b/docs/navigation/deeplinks.md
@@ -43,7 +43,7 @@ class UserProfileDeepLinkHandler : DeepLinkHandler {
 }
 ```
 
-To bring everything together an `ImmutableSet<DeepLinkHandler>` needs to be passed to `rememberHostNavigator`:
+To bring everything together an `Set<DeepLinkHandler>` needs to be passed to `rememberHostNavigator`:
 
 
 ```kotlin

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,8 +50,6 @@ kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotl
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 
-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version = "0.4.0"}
-
 compose-compiler = { module = "org.jetbrains.kotlin:kotlin-compose-compiler-plugin-embeddable", version.ref = "kotlin" }
 
 androidx-compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "androidx-compose-runtime" }

--- a/navigation/api/android/navigation.api
+++ b/navigation/api/android/navigation.api
@@ -20,7 +20,7 @@ public abstract class com/freeletics/khonshu/navigation/HostNavigator : com/free
 }
 
 public final class com/freeletics/khonshu/navigation/HostNavigatorKt {
-	public static final fun rememberHostNavigator (Lcom/freeletics/khonshu/navigation/NavRoot;Lkotlinx/collections/immutable/ImmutableSet;Lkotlinx/collections/immutable/ImmutableSet;Lkotlinx/collections/immutable/ImmutableSet;Landroidx/compose/runtime/Composer;II)Lcom/freeletics/khonshu/navigation/HostNavigator;
+	public static final fun rememberHostNavigator (Lcom/freeletics/khonshu/navigation/NavRoot;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Landroidx/compose/runtime/Composer;II)Lcom/freeletics/khonshu/navigation/HostNavigator;
 }
 
 public abstract class com/freeletics/khonshu/navigation/NavDestination {
@@ -29,7 +29,7 @@ public abstract class com/freeletics/khonshu/navigation/NavDestination {
 
 public final class com/freeletics/khonshu/navigation/NavHostKt {
 	public static final fun NavHost (Lcom/freeletics/khonshu/navigation/HostNavigator;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
-	public static final fun NavHost (Lcom/freeletics/khonshu/navigation/NavRoot;Lkotlinx/collections/immutable/ImmutableSet;Landroidx/compose/ui/Modifier;Lkotlinx/collections/immutable/ImmutableSet;Lkotlinx/collections/immutable/ImmutableSet;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun NavHost (Lcom/freeletics/khonshu/navigation/NavRoot;Ljava/util/Set;Landroidx/compose/ui/Modifier;Ljava/util/Set;Ljava/util/Set;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 }
 
 public abstract interface class com/freeletics/khonshu/navigation/NavRoot : com/freeletics/khonshu/navigation/BaseRoute {
@@ -218,18 +218,18 @@ public final class com/freeletics/khonshu/navigation/deeplinks/DeepLinkKt {
 }
 
 public final class com/freeletics/khonshu/navigation/deeplinks/DeepLink_androidKt {
-	public static final fun buildIntent (Lcom/freeletics/khonshu/navigation/deeplinks/DeepLink;Landroid/content/Context;Lkotlinx/collections/immutable/ImmutableSet;)Landroid/content/Intent;
-	public static final fun buildPendingIntent (Lcom/freeletics/khonshu/navigation/deeplinks/DeepLink;Landroid/content/Context;Lkotlinx/collections/immutable/ImmutableSet;I)Landroid/app/PendingIntent;
-	public static synthetic fun buildPendingIntent$default (Lcom/freeletics/khonshu/navigation/deeplinks/DeepLink;Landroid/content/Context;Lkotlinx/collections/immutable/ImmutableSet;IILjava/lang/Object;)Landroid/app/PendingIntent;
-	public static final fun buildTaskStack (Lcom/freeletics/khonshu/navigation/deeplinks/DeepLink;Landroid/content/Context;Lkotlinx/collections/immutable/ImmutableSet;)Landroidx/core/app/TaskStackBuilder;
+	public static final fun buildIntent (Lcom/freeletics/khonshu/navigation/deeplinks/DeepLink;Landroid/content/Context;Ljava/util/Set;)Landroid/content/Intent;
+	public static final fun buildPendingIntent (Lcom/freeletics/khonshu/navigation/deeplinks/DeepLink;Landroid/content/Context;Ljava/util/Set;I)Landroid/app/PendingIntent;
+	public static synthetic fun buildPendingIntent$default (Lcom/freeletics/khonshu/navigation/deeplinks/DeepLink;Landroid/content/Context;Ljava/util/Set;IILjava/lang/Object;)Landroid/app/PendingIntent;
+	public static final fun buildTaskStack (Lcom/freeletics/khonshu/navigation/deeplinks/DeepLink;Landroid/content/Context;Ljava/util/Set;)Landroidx/core/app/TaskStackBuilder;
 }
 
 public final class com/freeletics/khonshu/navigation/deeplinks/HandleDeeplinkKt {
-	public static final fun handleDeepLink (Lcom/freeletics/khonshu/navigation/HostNavigator;Lcom/freeletics/khonshu/navigation/deeplinks/LaunchInfo;Lkotlinx/collections/immutable/ImmutableSet;Lkotlinx/collections/immutable/ImmutableSet;)Z
+	public static final fun handleDeepLink (Lcom/freeletics/khonshu/navigation/HostNavigator;Lcom/freeletics/khonshu/navigation/deeplinks/LaunchInfo;Ljava/util/Set;Ljava/util/Set;)Z
 }
 
 public final class com/freeletics/khonshu/navigation/deeplinks/HandleDeeplink_androidKt {
-	public static final fun handleDeepLink (Lcom/freeletics/khonshu/navigation/HostNavigator;Landroid/content/Intent;Lkotlinx/collections/immutable/ImmutableSet;Lkotlinx/collections/immutable/ImmutableSet;Lkotlinx/collections/immutable/ImmutableSet;)Z
+	public static final fun handleDeepLink (Lcom/freeletics/khonshu/navigation/HostNavigator;Landroid/content/Intent;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;)Z
 }
 
 public final class com/freeletics/khonshu/navigation/deeplinks/LaunchInfo {
@@ -243,7 +243,7 @@ public final class com/freeletics/khonshu/navigation/deeplinks/LaunchInfo {
 }
 
 public final class com/freeletics/khonshu/navigation/deeplinks/LaunchInfo_androidKt {
-	public static final fun asLaunchInfo (Landroid/content/Intent;Lkotlinx/collections/immutable/ImmutableSet;)Lcom/freeletics/khonshu/navigation/deeplinks/LaunchInfo;
+	public static final fun asLaunchInfo (Landroid/content/Intent;Ljava/util/Set;)Lcom/freeletics/khonshu/navigation/deeplinks/LaunchInfo;
 }
 
 public final class com/freeletics/khonshu/navigation/internal/ComposableSingletons$StackEntryKt {

--- a/navigation/navigation.gradle.kts
+++ b/navigation/navigation.gradle.kts
@@ -39,7 +39,6 @@ kotlin {
 
 dependencies {
     "commonMainApi"(libs.androidx.compose.runtime)
-    "commonMainApi"(libs.collections.immutable)
     "commonMainApi"(libs.uri)
 
     "androidMainApi"(libs.androidx.compose.foundation)

--- a/navigation/src/androidHostTest/kotlin/com/freeletics/khonshu/navigation/deeplinks/HandleDeepLinkTest.kt
+++ b/navigation/src/androidHostTest/kotlin/com/freeletics/khonshu/navigation/deeplinks/HandleDeepLinkTest.kt
@@ -13,7 +13,6 @@ import com.freeletics.khonshu.navigation.test.TestStackEntryFactory
 import com.freeletics.khonshu.navigation.test.ThirdRoute
 import com.freeletics.khonshu.navigation.test.visibleEntries
 import com.google.common.truth.Truth.assertThat
-import kotlinx.collections.immutable.persistentSetOf
 import org.junit.Assert.assertThrows
 import org.junit.Test
 
@@ -28,8 +27,8 @@ internal class HandleDeepLinkTest {
     private fun HostNavigator.testHandleDeepLink(routes: List<BaseRoute>?): Boolean {
         return handleDeepLink(
             launchInfo = LaunchInfo(routes, null),
-            deepLinkHandlers = persistentSetOf(),
-            deepLinkPrefixes = persistentSetOf(),
+            deepLinkHandlers = setOf(),
+            deepLinkPrefixes = setOf(),
         )
     }
 

--- a/navigation/src/androidHostTest/kotlin/com/freeletics/khonshu/navigation/test/VisibleEntries.kt
+++ b/navigation/src/androidHostTest/kotlin/com/freeletics/khonshu/navigation/test/VisibleEntries.kt
@@ -2,12 +2,10 @@ package com.freeletics.khonshu.navigation.test
 
 import com.freeletics.khonshu.navigation.internal.StackEntry
 import com.freeletics.khonshu.navigation.internal.StackSnapshot
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.toImmutableList
 
-internal val StackSnapshot.visibleEntries: ImmutableList<StackEntry<*>>
+internal val StackSnapshot.visibleEntries: List<StackEntry<*>>
     get() {
         val entries = mutableListOf<StackEntry<*>>()
         forEachVisibleDestination { entries.add(it) }
-        return entries.toImmutableList()
+        return entries
     }

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/HostNavigator.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/HostNavigator.kt
@@ -20,8 +20,6 @@ import com.freeletics.khonshu.navigation.internal.StackEntryStoreHolder
 import com.freeletics.khonshu.navigation.internal.StackSnapshot
 import com.freeletics.khonshu.navigation.internal.createMultiStack
 import com.freeletics.khonshu.navigation.internal.rememberMultiStack
-import kotlinx.collections.immutable.ImmutableSet
-import kotlinx.collections.immutable.persistentSetOf
 
 public abstract class HostNavigator @InternalNavigationTestingApi constructor() : Navigator {
     @InternalNavigationTestingApi
@@ -51,9 +49,9 @@ public abstract class HostNavigator @InternalNavigationTestingApi constructor() 
 @Composable
 public fun rememberHostNavigator(
     startRoot: NavRoot,
-    destinations: ImmutableSet<NavDestination<*>>,
-    deepLinkHandlers: ImmutableSet<DeepLinkHandler> = persistentSetOf(),
-    deepLinkPrefixes: ImmutableSet<DeepLinkHandler.Prefix> = persistentSetOf(),
+    destinations: Set<NavDestination<*>>,
+    deepLinkHandlers: Set<DeepLinkHandler> = setOf(),
+    deepLinkPrefixes: Set<DeepLinkHandler.Prefix> = setOf(),
 ): HostNavigator {
     val context = LocalContext.current
     val multiStack by rememberMultiStack(startRoot, destinations)
@@ -81,7 +79,7 @@ internal val LocalHostNavigator: ProvidableCompositionLocal<HostNavigator> =
 @InternalNavigationCodegenApi
 public fun createHostNavigator(
     startRoot: NavRoot,
-    destinations: ImmutableSet<NavDestination<*>>,
+    destinations: Set<NavDestination<*>>,
     storeHolder: StackEntryStoreHolder,
     savedStateHandle: SavedStateHandle,
 ): HostNavigator {

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavHost.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/NavHost.kt
@@ -26,10 +26,6 @@ import com.freeletics.khonshu.navigation.deeplinks.DeepLinkHandler
 import com.freeletics.khonshu.navigation.internal.StackEntry
 import com.freeletics.khonshu.navigation.internal.StackSnapshot
 import java.lang.ref.WeakReference
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.ImmutableSet
-import kotlinx.collections.immutable.persistentSetOf
-import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CancellationException
 
 /**
@@ -49,10 +45,10 @@ import kotlinx.coroutines.CancellationException
 @Composable
 public fun NavHost(
     startRoute: NavRoot,
-    destinations: ImmutableSet<NavDestination<*>>,
+    destinations: Set<NavDestination<*>>,
     modifier: Modifier = Modifier,
-    deepLinkHandlers: ImmutableSet<DeepLinkHandler> = persistentSetOf(),
-    deepLinkPrefixes: ImmutableSet<DeepLinkHandler.Prefix> = persistentSetOf(),
+    deepLinkHandlers: Set<DeepLinkHandler> = setOf(),
+    deepLinkPrefixes: Set<DeepLinkHandler.Prefix> = setOf(),
     destinationChangedCallback: ((NavRoot, BaseRoute) -> Unit)? = null,
 ) {
     val navigator = rememberHostNavigator(startRoute, destinations, deepLinkHandlers, deepLinkPrefixes)
@@ -154,7 +150,7 @@ private fun StackSnapshot.getShowableEntries(
     showPreviousEntry: Boolean,
     inTransition: Modifier,
     outTransition: Modifier,
-): ImmutableList<ShowableStackEntry<*>> {
+): List<ShowableStackEntry<*>> {
     val entries = mutableListOf<ShowableStackEntry<*>>()
     val previous = previous
     // only add previous to composition while a back gesture is ongoing
@@ -176,10 +172,10 @@ private fun StackSnapshot.getShowableEntries(
     // update entryComposables to remove any entry that left the composition
     entryComposables.clear()
     entries.forEach {
-        entryComposables.put(it.entry.id, it.content)
+        entryComposables[it.entry.id] = it.content
     }
 
-    return entries.toImmutableList()
+    return entries
 }
 
 @Immutable

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/deeplinks/DeepLink.android.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/deeplinks/DeepLink.android.kt
@@ -13,12 +13,11 @@ import androidx.savedstate.serialization.encodeToSavedState
 import com.freeletics.khonshu.navigation.BaseRoute
 import com.freeletics.khonshu.navigation.NavDestination
 import com.freeletics.khonshu.navigation.internal.SavedStateConfiguration
-import kotlinx.collections.immutable.ImmutableSet
 
 /**
  * Creates an [Intent] that can be used to launch this deep link.
  */
-public fun DeepLink.buildIntent(context: Context, destinations: ImmutableSet<NavDestination<*>>): Intent {
+public fun DeepLink.buildIntent(context: Context, destinations: Set<NavDestination<*>>): Intent {
     val intent = if (action != null) {
         Intent(action).setPackage(context.packageName)
     } else {
@@ -35,7 +34,7 @@ public fun DeepLink.buildIntent(context: Context, destinations: ImmutableSet<Nav
 /**
  * Creates a [TaskStackBuilder] that can be used to launch this deep link.
  */
-public fun DeepLink.buildTaskStack(context: Context, destinations: ImmutableSet<NavDestination<*>>): TaskStackBuilder {
+public fun DeepLink.buildTaskStack(context: Context, destinations: Set<NavDestination<*>>): TaskStackBuilder {
     return TaskStackBuilder.create(context).addNextIntent(buildIntent(context, destinations))
 }
 
@@ -44,7 +43,7 @@ public fun DeepLink.buildTaskStack(context: Context, destinations: ImmutableSet<
  */
 public fun DeepLink.buildPendingIntent(
     context: Context,
-    destinations: ImmutableSet<NavDestination<*>>,
+    destinations: Set<NavDestination<*>>,
     flags: Int = FLAG_UPDATE_CURRENT or FLAG_IMMUTABLE,
 ): PendingIntent {
     val requestCode: Int = routes.fold(0) { acc, navDirection ->
@@ -56,7 +55,7 @@ public fun DeepLink.buildPendingIntent(
 
 private const val EXTRA_DEEPLINK_ROUTES: String = "com.freeletics.khonshu.navigation.DEEPLINK_ROUTES"
 
-internal fun Intent.extractDeepLinkRoutes(destinations: ImmutableSet<NavDestination<*>>): List<BaseRoute>? {
+internal fun Intent.extractDeepLinkRoutes(destinations: Set<NavDestination<*>>): List<BaseRoute>? {
     return IntentCompat.getParcelableExtra(this, EXTRA_DEEPLINK_ROUTES, Bundle::class.java)?.let {
         val savedStateConfiguration = SavedStateConfiguration(destinations)
         decodeFromSavedState(it, savedStateConfiguration)

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/deeplinks/HandleDeeplink.android.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/deeplinks/HandleDeeplink.android.kt
@@ -3,7 +3,6 @@ package com.freeletics.khonshu.navigation.deeplinks
 import android.content.Intent
 import com.freeletics.khonshu.navigation.HostNavigator
 import com.freeletics.khonshu.navigation.NavDestination
-import kotlinx.collections.immutable.ImmutableSet
 
 /**
  * If the given [Intent] was created from a [DeepLink] or the `Uri` returned by [Intent.getData]
@@ -14,9 +13,9 @@ import kotlinx.collections.immutable.ImmutableSet
  */
 public fun HostNavigator.handleDeepLink(
     intent: Intent,
-    destinations: ImmutableSet<NavDestination<*>>,
-    deepLinkHandlers: ImmutableSet<DeepLinkHandler>,
-    deepLinkPrefixes: ImmutableSet<DeepLinkHandler.Prefix>,
+    destinations: Set<NavDestination<*>>,
+    deepLinkHandlers: Set<DeepLinkHandler>,
+    deepLinkPrefixes: Set<DeepLinkHandler.Prefix>,
 ): Boolean {
     return handleDeepLink(intent.asLaunchInfo(destinations), deepLinkHandlers, deepLinkPrefixes)
 }

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/deeplinks/HandleDeeplink.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/deeplinks/HandleDeeplink.kt
@@ -5,7 +5,6 @@ import com.freeletics.khonshu.navigation.HostNavigator
 import com.freeletics.khonshu.navigation.NavRoot
 import com.freeletics.khonshu.navigation.NavRoute
 import com.freeletics.khonshu.navigation.internal.destinationId
-import kotlinx.collections.immutable.ImmutableSet
 
 /**
  * If the given [launchInfo] can be handled using [deepLinkHandlers] and [deepLinkPrefixes]
@@ -16,8 +15,8 @@ import kotlinx.collections.immutable.ImmutableSet
  */
 public fun HostNavigator.handleDeepLink(
     launchInfo: LaunchInfo,
-    deepLinkHandlers: ImmutableSet<DeepLinkHandler>,
-    deepLinkPrefixes: ImmutableSet<DeepLinkHandler.Prefix>,
+    deepLinkHandlers: Set<DeepLinkHandler>,
+    deepLinkPrefixes: Set<DeepLinkHandler.Prefix>,
 ): Boolean {
     val deepLinkRoutes = launchInfo.routes
     if (deepLinkRoutes != null) {

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/deeplinks/LaunchInfo.android.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/deeplinks/LaunchInfo.android.kt
@@ -3,11 +3,10 @@ package com.freeletics.khonshu.navigation.deeplinks
 import android.content.Intent
 import com.eygraber.uri.toKmpUri
 import com.freeletics.khonshu.navigation.NavDestination
-import kotlinx.collections.immutable.ImmutableSet
 
 /**
  * Turn this [Intent] into a [LaunchInfo] instance that can be used with [handleDeepLink].
  */
-public fun Intent.asLaunchInfo(destinations: ImmutableSet<NavDestination<*>>): LaunchInfo {
+public fun Intent.asLaunchInfo(destinations: Set<NavDestination<*>>): LaunchInfo {
     return LaunchInfo(extractDeepLinkRoutes(destinations), this.data?.toKmpUri())
 }

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackBuilder.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/MultiStackBuilder.kt
@@ -16,13 +16,12 @@ import androidx.savedstate.serialization.SavedStateConfiguration
 import com.freeletics.khonshu.navigation.BaseRoute
 import com.freeletics.khonshu.navigation.NavDestination
 import com.freeletics.khonshu.navigation.NavRoot
-import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.SerializersModuleBuilder
 
 internal fun createMultiStack(
     startRoot: NavRoot,
-    destinations: ImmutableSet<NavDestination<*>>,
+    destinations: Set<NavDestination<*>>,
     storeHolder: StackEntryStoreHolder,
     savedStateHandle: SavedStateHandle,
 ): MultiStack {
@@ -37,7 +36,7 @@ internal fun createMultiStack(
 @Composable
 internal fun rememberMultiStack(
     startRoot: NavRoot,
-    destinations: ImmutableSet<NavDestination<*>>,
+    destinations: Set<NavDestination<*>>,
 ): MutableState<MultiStack> {
     return key(startRoot, destinations) {
         val storeHolder = retain { StackEntryStoreHolder() }
@@ -50,7 +49,7 @@ internal fun rememberMultiStack(
     }
 }
 
-internal fun SavedStateConfiguration(destinations: ImmutableSet<NavDestination<*>>): SavedStateConfiguration {
+internal fun SavedStateConfiguration(destinations: Set<NavDestination<*>>): SavedStateConfiguration {
     return SavedStateConfiguration {
         serializersModule = SerializersModule {
             destinations.forEach {

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackEntryFactory.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/internal/StackEntryFactory.kt
@@ -3,7 +3,6 @@ package com.freeletics.khonshu.navigation.internal
 import com.freeletics.khonshu.navigation.BaseRoute
 import com.freeletics.khonshu.navigation.NavDestination
 import java.util.UUID
-import kotlinx.collections.immutable.ImmutableSet
 
 internal class StackEntryFactory(
     private val destinations: List<NavDestination<*>>,
@@ -11,7 +10,7 @@ internal class StackEntryFactory(
     private val idGenerator: () -> StackEntry.Id = { StackEntry.Id(UUID.randomUUID().toString()) },
 ) {
     constructor(
-        destinations: ImmutableSet<NavDestination<*>>,
+        destinations: Set<NavDestination<*>>,
         storeHolder: StackEntryStoreHolder,
     ) : this(destinations.toList(), storeHolder)
 


### PR DESCRIPTION
With strong skipping in newer compose versions this isn't needed anymore.