### PR TITLE
resolve Metro warnings in generated code

### DIFF
--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/DestinationCodegenTest.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/DestinationCodegenTest.kt
@@ -118,6 +118,8 @@ internal class DestinationCodegenTest {
               @ForScope(TestRoute::class)
               public val destinationNavigator: DestinationNavigator
 
+              public val stackEntry: StackEntry<TestRoute>
+
               @ForScope(TestRoute::class)
               public val closeables: Set<AutoCloseable>
 
@@ -133,19 +135,19 @@ internal class DestinationCodegenTest {
 
               @Provides
               @ForScope(TestRoute::class)
-              public fun provideSavedStateHandle(@ForScope(TestRoute::class) stackEntry: StackEntry<TestRoute>): SavedStateHandle = stackEntry.savedStateHandle
+              public fun provideSavedStateHandle(stackEntry: StackEntry<TestRoute>): SavedStateHandle = stackEntry.savedStateHandle
 
               @Provides
-              public fun provideRoute(@ForScope(TestRoute::class) stackEntry: StackEntry<TestRoute>): TestRoute = stackEntry.route
+              public fun provideRoute(stackEntry: StackEntry<TestRoute>): TestRoute = stackEntry.route
 
               @Provides
               @ForScope(TestRoute::class)
-              public fun provideStackEntryState(@ForScope(TestRoute::class) stackEntry: StackEntry<TestRoute>): StackEntryState = stackEntry.state
+              public fun provideStackEntryState(stackEntry: StackEntry<TestRoute>): StackEntryState = stackEntry.state
 
               @ContributesTo(TestParentRoute::class)
               @GraphExtension.Factory
               public interface Factory {
-                public fun createKhonshuTestGraph(@Provides @ForScope(TestRoute::class) stackEntry: StackEntry<TestRoute>): KhonshuTestGraph
+                public fun createKhonshuTestGraph(@Provides stackEntry: StackEntry<TestRoute>): KhonshuTestGraph
               }
             }
 
@@ -195,6 +197,8 @@ internal class DestinationCodegenTest {
             @OptIn(InternalCodegenApi::class)
             @ContributesTo(TestDestinationScope::class)
             public interface KhonshuTestNavDestinationGraph {
+              public val destinations: Set<NavDestination<*>>
+
               @Provides
               @IntoSet
               @OptIn(InternalNavigationCodegenApi::class)
@@ -288,6 +292,8 @@ internal class DestinationCodegenTest {
               @ForScope(TestRoute::class)
               public val destinationNavigator: DestinationNavigator
 
+              public val stackEntry: StackEntry<TestRoute>
+
               @ForScope(TestRoute::class)
               public val closeables: Set<AutoCloseable>
 
@@ -303,19 +309,19 @@ internal class DestinationCodegenTest {
 
               @Provides
               @ForScope(TestRoute::class)
-              public fun provideSavedStateHandle(@ForScope(TestRoute::class) stackEntry: StackEntry<TestRoute>): SavedStateHandle = stackEntry.savedStateHandle
+              public fun provideSavedStateHandle(stackEntry: StackEntry<TestRoute>): SavedStateHandle = stackEntry.savedStateHandle
 
               @Provides
-              public fun provideRoute(@ForScope(TestRoute::class) stackEntry: StackEntry<TestRoute>): TestRoute = stackEntry.route
+              public fun provideRoute(stackEntry: StackEntry<TestRoute>): TestRoute = stackEntry.route
 
               @Provides
               @ForScope(TestRoute::class)
-              public fun provideStackEntryState(@ForScope(TestRoute::class) stackEntry: StackEntry<TestRoute>): StackEntryState = stackEntry.state
+              public fun provideStackEntryState(stackEntry: StackEntry<TestRoute>): StackEntryState = stackEntry.state
 
               @ContributesTo(ActivityScope::class)
               @GraphExtension.Factory
               public interface Factory {
-                public fun createKhonshuTestGraph(@Provides @ForScope(TestRoute::class) stackEntry: StackEntry<TestRoute>): KhonshuTestGraph
+                public fun createKhonshuTestGraph(@Provides stackEntry: StackEntry<TestRoute>): KhonshuTestGraph
               }
             }
 
@@ -365,6 +371,8 @@ internal class DestinationCodegenTest {
             @OptIn(InternalCodegenApi::class)
             @ContributesTo(AppScope::class)
             public interface KhonshuTestNavDestinationGraph {
+              public val destinations: Set<NavDestination<*>>
+
               @Provides
               @IntoSet
               @OptIn(InternalNavigationCodegenApi::class)
@@ -461,6 +469,8 @@ internal class DestinationCodegenTest {
               @ForScope(TestOverlayRoute::class)
               public val destinationNavigator: DestinationNavigator
 
+              public val stackEntry: StackEntry<TestOverlayRoute>
+
               @ForScope(TestOverlayRoute::class)
               public val closeables: Set<AutoCloseable>
 
@@ -476,19 +486,19 @@ internal class DestinationCodegenTest {
 
               @Provides
               @ForScope(TestOverlayRoute::class)
-              public fun provideSavedStateHandle(@ForScope(TestOverlayRoute::class) stackEntry: StackEntry<TestOverlayRoute>): SavedStateHandle = stackEntry.savedStateHandle
+              public fun provideSavedStateHandle(stackEntry: StackEntry<TestOverlayRoute>): SavedStateHandle = stackEntry.savedStateHandle
 
               @Provides
-              public fun provideRoute(@ForScope(TestOverlayRoute::class) stackEntry: StackEntry<TestOverlayRoute>): TestOverlayRoute = stackEntry.route
+              public fun provideRoute(stackEntry: StackEntry<TestOverlayRoute>): TestOverlayRoute = stackEntry.route
 
               @Provides
               @ForScope(TestOverlayRoute::class)
-              public fun provideStackEntryState(@ForScope(TestOverlayRoute::class) stackEntry: StackEntry<TestOverlayRoute>): StackEntryState = stackEntry.state
+              public fun provideStackEntryState(stackEntry: StackEntry<TestOverlayRoute>): StackEntryState = stackEntry.state
 
               @ContributesTo(TestParentRoute::class)
               @GraphExtension.Factory
               public interface Factory {
-                public fun createKhonshuTestGraph(@Provides @ForScope(TestOverlayRoute::class) stackEntry: StackEntry<TestOverlayRoute>): KhonshuTestGraph
+                public fun createKhonshuTestGraph(@Provides stackEntry: StackEntry<TestOverlayRoute>): KhonshuTestGraph
               }
             }
 
@@ -538,6 +548,8 @@ internal class DestinationCodegenTest {
             @OptIn(InternalCodegenApi::class)
             @ContributesTo(TestDestinationScope::class)
             public interface KhonshuTestNavDestinationGraph {
+              public val destinations: Set<NavDestination<*>>
+
               @Provides
               @IntoSet
               @OptIn(InternalNavigationCodegenApi::class)
@@ -656,6 +668,8 @@ internal class DestinationCodegenTest {
               @ForScope(TestRoute::class)
               public val destinationNavigator: DestinationNavigator
 
+              public val stackEntry: StackEntry<TestRoute>
+
               public val testClass: TestClass
 
               public val jvmTest: TestClass2
@@ -679,19 +693,19 @@ internal class DestinationCodegenTest {
 
               @Provides
               @ForScope(TestRoute::class)
-              public fun provideSavedStateHandle(@ForScope(TestRoute::class) stackEntry: StackEntry<TestRoute>): SavedStateHandle = stackEntry.savedStateHandle
+              public fun provideSavedStateHandle(stackEntry: StackEntry<TestRoute>): SavedStateHandle = stackEntry.savedStateHandle
 
               @Provides
-              public fun provideRoute(@ForScope(TestRoute::class) stackEntry: StackEntry<TestRoute>): TestRoute = stackEntry.route
+              public fun provideRoute(stackEntry: StackEntry<TestRoute>): TestRoute = stackEntry.route
 
               @Provides
               @ForScope(TestRoute::class)
-              public fun provideStackEntryState(@ForScope(TestRoute::class) stackEntry: StackEntry<TestRoute>): StackEntryState = stackEntry.state
+              public fun provideStackEntryState(stackEntry: StackEntry<TestRoute>): StackEntryState = stackEntry.state
 
               @ContributesTo(TestParentRoute::class)
               @GraphExtension.Factory
               public interface Factory {
-                public fun createKhonshuTest2Graph(@Provides @ForScope(TestRoute::class) stackEntry: StackEntry<TestRoute>): KhonshuTest2Graph
+                public fun createKhonshuTest2Graph(@Provides stackEntry: StackEntry<TestRoute>): KhonshuTest2Graph
               }
             }
 
@@ -749,6 +763,8 @@ internal class DestinationCodegenTest {
             @OptIn(InternalCodegenApi::class)
             @ContributesTo(TestDestinationScope::class)
             public interface KhonshuTest2NavDestinationGraph {
+              public val destinations: Set<NavDestination<*>>
+
               @Provides
               @IntoSet
               @OptIn(InternalNavigationCodegenApi::class)
@@ -836,6 +852,8 @@ internal class DestinationCodegenTest {
               @ForScope(TestRoute::class)
               public val destinationNavigator: DestinationNavigator
 
+              public val stackEntry: StackEntry<TestRoute>
+
               @ForScope(TestRoute::class)
               public val closeables: Set<AutoCloseable>
 
@@ -851,19 +869,19 @@ internal class DestinationCodegenTest {
 
               @Provides
               @ForScope(TestRoute::class)
-              public fun provideSavedStateHandle(@ForScope(TestRoute::class) stackEntry: StackEntry<TestRoute>): SavedStateHandle = stackEntry.savedStateHandle
+              public fun provideSavedStateHandle(stackEntry: StackEntry<TestRoute>): SavedStateHandle = stackEntry.savedStateHandle
 
               @Provides
-              public fun provideRoute(@ForScope(TestRoute::class) stackEntry: StackEntry<TestRoute>): TestRoute = stackEntry.route
+              public fun provideRoute(stackEntry: StackEntry<TestRoute>): TestRoute = stackEntry.route
 
               @Provides
               @ForScope(TestRoute::class)
-              public fun provideStackEntryState(@ForScope(TestRoute::class) stackEntry: StackEntry<TestRoute>): StackEntryState = stackEntry.state
+              public fun provideStackEntryState(stackEntry: StackEntry<TestRoute>): StackEntryState = stackEntry.state
 
               @ContributesTo(TestParentRoute::class)
               @GraphExtension.Factory
               public interface Factory {
-                public fun createKhonshuTestGraph(@Provides @ForScope(TestRoute::class) stackEntry: StackEntry<TestRoute>): KhonshuTestGraph
+                public fun createKhonshuTestGraph(@Provides stackEntry: StackEntry<TestRoute>): KhonshuTestGraph
               }
             }
 
@@ -908,6 +926,8 @@ internal class DestinationCodegenTest {
             @OptIn(InternalCodegenApi::class)
             @ContributesTo(TestDestinationScope::class)
             public interface KhonshuTestNavDestinationGraph {
+              public val destinations: Set<NavDestination<*>>
+
               @Provides
               @IntoSet
               @OptIn(InternalNavigationCodegenApi::class)
@@ -998,6 +1018,8 @@ internal class DestinationCodegenTest {
               @ForScope(TestRoute::class)
               public val destinationNavigator: DestinationNavigator
 
+              public val stackEntry: StackEntry<TestRoute>
+
               @ForScope(TestRoute::class)
               public val closeables: Set<AutoCloseable>
 
@@ -1013,19 +1035,19 @@ internal class DestinationCodegenTest {
 
               @Provides
               @ForScope(TestRoute::class)
-              public fun provideSavedStateHandle(@ForScope(TestRoute::class) stackEntry: StackEntry<TestRoute>): SavedStateHandle = stackEntry.savedStateHandle
+              public fun provideSavedStateHandle(stackEntry: StackEntry<TestRoute>): SavedStateHandle = stackEntry.savedStateHandle
 
               @Provides
-              public fun provideRoute(@ForScope(TestRoute::class) stackEntry: StackEntry<TestRoute>): TestRoute = stackEntry.route
+              public fun provideRoute(stackEntry: StackEntry<TestRoute>): TestRoute = stackEntry.route
 
               @Provides
               @ForScope(TestRoute::class)
-              public fun provideStackEntryState(@ForScope(TestRoute::class) stackEntry: StackEntry<TestRoute>): StackEntryState = stackEntry.state
+              public fun provideStackEntryState(stackEntry: StackEntry<TestRoute>): StackEntryState = stackEntry.state
 
               @ContributesTo(TestParentRoute::class)
               @GraphExtension.Factory
               public interface Factory {
-                public fun createKhonshuTestGraph(@Provides @ForScope(TestRoute::class) stackEntry: StackEntry<TestRoute>): KhonshuTestGraph
+                public fun createKhonshuTestGraph(@Provides stackEntry: StackEntry<TestRoute>): KhonshuTestGraph
               }
             }
 
@@ -1074,6 +1096,8 @@ internal class DestinationCodegenTest {
             @OptIn(InternalCodegenApi::class)
             @ContributesTo(TestDestinationScope::class)
             public interface KhonshuTestNavDestinationGraph {
+              public val destinations: Set<NavDestination<*>>
+
               @Provides
               @IntoSet
               @OptIn(InternalNavigationCodegenApi::class)
@@ -1163,6 +1187,8 @@ internal class DestinationCodegenTest {
               @ForScope(TestRoute::class)
               public val destinationNavigator: DestinationNavigator
 
+              public val stackEntry: StackEntry<TestRoute>
+
               @ForScope(TestRoute::class)
               public val closeables: Set<AutoCloseable>
 
@@ -1178,19 +1204,19 @@ internal class DestinationCodegenTest {
 
               @Provides
               @ForScope(TestRoute::class)
-              public fun provideSavedStateHandle(@ForScope(TestRoute::class) stackEntry: StackEntry<TestRoute>): SavedStateHandle = stackEntry.savedStateHandle
+              public fun provideSavedStateHandle(stackEntry: StackEntry<TestRoute>): SavedStateHandle = stackEntry.savedStateHandle
 
               @Provides
-              public fun provideRoute(@ForScope(TestRoute::class) stackEntry: StackEntry<TestRoute>): TestRoute = stackEntry.route
+              public fun provideRoute(stackEntry: StackEntry<TestRoute>): TestRoute = stackEntry.route
 
               @Provides
               @ForScope(TestRoute::class)
-              public fun provideStackEntryState(@ForScope(TestRoute::class) stackEntry: StackEntry<TestRoute>): StackEntryState = stackEntry.state
+              public fun provideStackEntryState(stackEntry: StackEntry<TestRoute>): StackEntryState = stackEntry.state
 
               @ContributesTo(TestParentRoute::class)
               @GraphExtension.Factory
               public interface Factory {
-                public fun createKhonshuTestGraph(@Provides @ForScope(TestRoute::class) stackEntry: StackEntry<TestRoute>): KhonshuTestGraph
+                public fun createKhonshuTestGraph(@Provides stackEntry: StackEntry<TestRoute>): KhonshuTestGraph
               }
             }
 
@@ -1235,6 +1261,8 @@ internal class DestinationCodegenTest {
             @OptIn(InternalCodegenApi::class)
             @ContributesTo(TestDestinationScope::class)
             public interface KhonshuTestNavDestinationGraph {
+              public val destinations: Set<NavDestination<*>>
+
               @Provides
               @IntoSet
               @OptIn(InternalNavigationCodegenApi::class)

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/HostActivityCodegenTest.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/HostActivityCodegenTest.kt
@@ -124,6 +124,8 @@ internal class HostActivityCodegenTest {
 
               public val hostNavigator: HostNavigator
 
+              public val launchInfo: LaunchInfo
+
               @ForScope(TestScreen::class)
               public val savedStateHandle: SavedStateHandle
 
@@ -322,6 +324,8 @@ internal class HostActivityCodegenTest {
               public val testStateMachine: TestStateMachine
 
               public val hostNavigator: HostNavigator
+
+              public val launchInfo: LaunchInfo
 
               @ForScope(TestScreen::class)
               public val savedStateHandle: SavedStateHandle
@@ -550,6 +554,8 @@ internal class HostActivityCodegenTest {
 
               public val hostNavigator: HostNavigator
 
+              public val launchInfo: LaunchInfo
+
               @ForScope(TestScreen::class)
               public val savedStateHandle: SavedStateHandle
 
@@ -762,6 +768,8 @@ internal class HostActivityCodegenTest {
 
               public val hostNavigator: HostNavigator
 
+              public val launchInfo: LaunchInfo
+
               @ForScope(TestScreen::class)
               public val savedStateHandle: SavedStateHandle
 
@@ -955,6 +963,8 @@ internal class HostActivityCodegenTest {
               public val testStateMachine: TestStateMachine
 
               public val hostNavigator: HostNavigator
+
+              public val launchInfo: LaunchInfo
 
               @ForScope(TestScreen::class)
               public val savedStateHandle: SavedStateHandle
@@ -1154,6 +1164,8 @@ internal class HostActivityCodegenTest {
               public val testStateMachine: TestStateMachine
 
               public val hostNavigator: HostNavigator
+
+              public val launchInfo: LaunchInfo
 
               @ForScope(TestScreen::class)
               public val savedStateHandle: SavedStateHandle

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/HostWindowCodegenTest.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/HostWindowCodegenTest.kt
@@ -117,6 +117,8 @@ internal class HostWindowCodegenTest {
 
               public val hostNavigator: HostNavigator
 
+              public val launchInfo: LaunchInfo
+
               @ForScope(TestScreen::class)
               public val savedStateHandle: SavedStateHandle
 
@@ -301,6 +303,8 @@ internal class HostWindowCodegenTest {
               public val testStateMachine: TestStateMachine
 
               public val hostNavigator: HostNavigator
+
+              public val launchInfo: LaunchInfo
 
               @ForScope(TestScreen::class)
               public val savedStateHandle: SavedStateHandle
@@ -515,6 +519,8 @@ internal class HostWindowCodegenTest {
 
               public val hostNavigator: HostNavigator
 
+              public val launchInfo: LaunchInfo
+
               @ForScope(TestScreen::class)
               public val savedStateHandle: SavedStateHandle
 
@@ -714,6 +720,8 @@ internal class HostWindowCodegenTest {
 
               public val hostNavigator: HostNavigator
 
+              public val launchInfo: LaunchInfo
+
               @ForScope(TestScreen::class)
               public val savedStateHandle: SavedStateHandle
 
@@ -893,6 +901,8 @@ internal class HostWindowCodegenTest {
               public val testStateMachine: TestStateMachine
 
               public val hostNavigator: HostNavigator
+
+              public val launchInfo: LaunchInfo
 
               @ForScope(TestScreen::class)
               public val savedStateHandle: SavedStateHandle
@@ -1078,6 +1088,8 @@ internal class HostWindowCodegenTest {
               public val testStateMachine: TestStateMachine
 
               public val hostNavigator: HostNavigator
+
+              public val launchInfo: LaunchInfo
 
               @ForScope(TestScreen::class)
               public val savedStateHandle: SavedStateHandle

--- a/codegen-compiler/src/jvmMain/kotlin/com/freeletics/khonshu/codegen/codegen/DestinationGraphContributionGenerator.kt
+++ b/codegen-compiler/src/jvmMain/kotlin/com/freeletics/khonshu/codegen/codegen/DestinationGraphContributionGenerator.kt
@@ -9,6 +9,8 @@ import com.freeletics.khonshu.codegen.util.optIn
 import com.freeletics.khonshu.codegen.util.provides
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.SET
 import com.squareup.kotlinpoet.TypeSpec
 
 internal class DestinationGraphContributionGenerator(
@@ -20,6 +22,7 @@ internal class DestinationGraphContributionGenerator(
         return TypeSpec.interfaceBuilder(moduleClassName)
             .addAnnotation(optIn())
             .addAnnotation(contributesTo(data.navigation!!.destinationScope))
+            .addProperty("destinations", SET.parameterizedBy(navigationDestination))
             .addFunction(providesDestination())
             .build()
     }

--- a/codegen-compiler/src/jvmMain/kotlin/com/freeletics/khonshu/codegen/codegen/GraphGenerator.kt
+++ b/codegen-compiler/src/jvmMain/kotlin/com/freeletics/khonshu/codegen/codegen/GraphGenerator.kt
@@ -5,7 +5,6 @@ import com.freeletics.khonshu.codegen.DestinationData
 import com.freeletics.khonshu.codegen.HostData
 import com.freeletics.khonshu.codegen.util.InternalCodegenApi
 import com.freeletics.khonshu.codegen.util.asClassName
-import com.freeletics.khonshu.codegen.util.asParameter
 import com.freeletics.khonshu.codegen.util.autoCloseable
 import com.freeletics.khonshu.codegen.util.contributesGraphExtension
 import com.freeletics.khonshu.codegen.util.contributesGraphExtensionFactory
@@ -14,8 +13,10 @@ import com.freeletics.khonshu.codegen.util.destinationNavigator
 import com.freeletics.khonshu.codegen.util.forScope
 import com.freeletics.khonshu.codegen.util.hostNavigator
 import com.freeletics.khonshu.codegen.util.internalNavigatorApi
+import com.freeletics.khonshu.codegen.util.launchInfo
 import com.freeletics.khonshu.codegen.util.multibinds
 import com.freeletics.khonshu.codegen.util.optIn
+import com.freeletics.khonshu.codegen.util.propertyName
 import com.freeletics.khonshu.codegen.util.providesFunction
 import com.freeletics.khonshu.codegen.util.providesParameter
 import com.freeletics.khonshu.codegen.util.savedStateHandle
@@ -72,15 +73,23 @@ internal class GraphGenerator(
         val properties = mutableListOf<PropertySpec>()
         properties += simplePropertySpec(data.stateMachine)
 
-        if (data is HostData) {
-            properties += simplePropertySpec(hostNavigator)
-            properties += simplePropertySpec(savedStateHandle).toBuilder()
-                .addAnnotation(forScope(data.scope))
-                .build()
-        } else {
-            properties += simplePropertySpec(destinationNavigator).toBuilder()
-                .addAnnotation(forScope(data.scope))
-                .build()
+        when (data) {
+            is HostData -> {
+                properties += simplePropertySpec(hostNavigator)
+                properties += simplePropertySpec(launchInfo)
+                properties += simplePropertySpec(savedStateHandle).toBuilder()
+                    .addAnnotation(forScope(data.scope))
+                    .build()
+            }
+            is DestinationData -> {
+                properties += simplePropertySpec(destinationNavigator).toBuilder()
+                    .addAnnotation(forScope(data.scope))
+                    .build()
+                properties += simplePropertySpec(
+                    "stackEntry",
+                    stackEntry.parameterizedBy(data.navigation.route),
+                )
+            }
         }
 
         properties += data.composableParameter.map {
@@ -124,7 +133,6 @@ internal class GraphGenerator(
                     "stackEntry",
                     stackEntry.parameterizedBy(data.navigation.route),
                 )
-                .addAnnotation(forScope(data.scope))
                 .build()
             add(
                 providesFunction(
@@ -168,11 +176,8 @@ internal class GraphGenerator(
                 if (data is DestinationData) {
                     addParameter(
                         providesParameter(
-                            ParameterSpec.builder(
-                                "stackEntry",
-                                stackEntry.parameterizedBy(data.navigation.route),
-                            ).build(),
-                            forScope(data.scope),
+                            "stackEntry",
+                            stackEntry.parameterizedBy(data.navigation.route),
                         ),
                     )
                 } else {
@@ -183,7 +188,7 @@ internal class GraphGenerator(
                             forScope(data.scope),
                         ),
                     )
-                    addParameter(providesParameter(data.navigation.asParameter()))
+                    addParameter(providesParameter(launchInfo.propertyName, launchInfo))
                 }
             }
             .returns(graphClassName).build()

--- a/codegen-compiler/src/jvmMain/kotlin/com/freeletics/khonshu/codegen/util/KotlinPoet.kt
+++ b/codegen-compiler/src/jvmMain/kotlin/com/freeletics/khonshu/codegen/util/KotlinPoet.kt
@@ -28,20 +28,10 @@ internal val ClassName.propertyName: String get() {
 
 internal fun providesParameter(
     name: String,
-    className: ClassName,
+    className: TypeName,
     annotation: AnnotationSpec? = null,
 ): ParameterSpec {
     return ParameterSpec.builder(name, className)
-        .addAnnotation(provides())
-        .apply { if (annotation != null) addAnnotation(annotation) }
-        .build()
-}
-
-internal fun providesParameter(
-    spec: ParameterSpec,
-    annotation: AnnotationSpec? = null,
-): ParameterSpec {
-    return spec.toBuilder()
         .addAnnotation(provides())
         .apply { if (annotation != null) addAnnotation(annotation) }
         .build()
@@ -70,6 +60,10 @@ internal fun navHostParameter(parameter: ComposableParameter): ParameterSpec {
 
 internal fun simplePropertySpec(className: ClassName): PropertySpec {
     return PropertySpec.builder(className.propertyName, className).build()
+}
+
+internal fun simplePropertySpec(name: String, typeName: TypeName): PropertySpec {
+    return PropertySpec.builder(name, typeName).build()
 }
 
 internal fun contributesGraphExtension(
@@ -152,13 +146,6 @@ internal fun suppressLint(vararg ids: String): AnnotationSpec {
     return AnnotationSpec.builder(suppressLint)
         .addMember(member.build())
         .build()
-}
-
-internal fun Navigation?.asParameter(): ParameterSpec {
-    if (this != null) {
-        return ParameterSpec.builder(route.propertyName, route).build()
-    }
-    return ParameterSpec.builder(launchInfo.propertyName, launchInfo).build()
 }
 
 internal fun Navigation?.asClassName(): ClassName {

--- a/sample/simple/gradle.properties
+++ b/sample/simple/gradle.properties
@@ -6,7 +6,6 @@ android.useAndroidX=true
 
 fgp.defaultPackageName=com.freeletics.sample
 fgp.defaultPackageName.simple=com.freeletics.simple
-fgp.kotlin.warningsAsErrors=false
 fgp.kotlin.extraWarnings=false
 fgp.kotlin.targets.android=true
 fgp.kotlin.targets.jvm=true


### PR DESCRIPTION
We're now adding getters to the generated graph interfaces for the parameters we path to the graph extension to avoid the warnings that these are unused. We also add `Set<NavDestination<*>>` to the destinations scope to avoid a warning about the multibinding being unused. In both cases we want these to be available even if not used.

I also removed `ForScope` from `StackEntry` since it's already parameterized.