### PR TITLE
support codegen for iOS

### DIFF
--- a/codegen-compiler-test/src/test/kotlin/androidx/compose/ui/window/ComposeUIViewController.kt
+++ b/codegen-compiler-test/src/test/kotlin/androidx/compose/ui/window/ComposeUIViewController.kt
@@ -1,0 +1,6 @@
+package androidx.compose.ui.window
+
+import androidx.compose.runtime.Composable
+import platform.UIKit.UIViewController
+
+fun ComposeUIViewController(content: @Composable () -> Unit): UIViewController = UIViewController()

--- a/codegen-compiler-test/src/test/kotlin/androidx/compose/ui/window/ComposeUIViewController.kt
+++ b/codegen-compiler-test/src/test/kotlin/androidx/compose/ui/window/ComposeUIViewController.kt
@@ -1,3 +1,4 @@
+@file:Suppress("ktlint:standard:function-naming")
 package androidx.compose.ui.window
 
 import androidx.compose.runtime.Composable

--- a/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/HostViewControllerCodegenTest.kt
+++ b/codegen-compiler-test/src/test/kotlin/com/freeletics/khonshu/codegen/codegen/HostViewControllerCodegenTest.kt
@@ -1,0 +1,1170 @@
+@file:Suppress("RedundantVisibilityModifier", "TestFunctionName")
+
+package com.freeletics.khonshu.codegen.codegen
+
+import com.freeletics.khonshu.codegen.ComposableParameter
+import com.freeletics.khonshu.codegen.HostViewControllerData
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.INT
+import com.squareup.kotlinpoet.LambdaTypeName
+import com.squareup.kotlinpoet.MAP
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.SET
+import com.squareup.kotlinpoet.STRING
+import com.squareup.kotlinpoet.UNIT
+import com.squareup.kotlinpoet.asClassName
+import dev.zacsweers.metro.AppScope
+import org.intellij.lang.annotations.Language
+import org.junit.Test
+
+internal class HostViewControllerCodegenTest {
+    private val data = HostViewControllerData(
+        baseName = "Test",
+        packageName = "com.test",
+        scope = ClassName("com.test", "TestScreen"),
+        parentScope = ClassName("com.test.parent", "TestParentScope"),
+        stateMachine = ClassName("com.test", "TestStateMachine"),
+        navHostParameter = ComposableParameter(
+            "navHost",
+            ClassName("com.freeletics.khonshu.codegen", "SimpleNavHost"),
+        ),
+        stateMachineClass = ClassName("com.freeletics.khonshu.statemachine", "StateMachine"),
+        stateParameter = ComposableParameter("state", ClassName("com.test", "TestState")),
+        sendActionParameter = ComposableParameter(
+            "sendAction",
+            LambdaTypeName.get(null, ClassName("com.test", "TestAction"), returnType = UNIT),
+        ),
+        composableParameter = emptyList(),
+    )
+
+    @Test
+    fun `generates code for NavHostViewControllerData`() {
+        @Language("kotlin")
+        val source =
+            """
+            package com.test
+
+            import androidx.compose.runtime.Composable
+            import androidx.compose.ui.Modifier
+            import com.freeletics.khonshu.codegen.NavHostViewController
+            import com.freeletics.khonshu.codegen.SimpleNavHost
+            import com.freeletics.khonshu.navigation.NavRoot
+            import com.test.parent.TestParentScope
+
+            @NavHostViewController(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+              stateMachine = TestStateMachine::class,
+            )
+            @Composable
+            @Suppress("unused_parameter")
+            public fun Test(
+              state: TestState,
+              sendAction: (TestAction) -> Unit,
+              navHost: SimpleNavHost,
+            ) {
+                navHost(Modifier) { _, _ -> }
+            }
+            """.trimIndent()
+
+        @Language("kotlin")
+        val expected =
+            """
+            package com.test
+
+            import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.CompositionLocalProvider
+            import androidx.compose.runtime.remember
+            import androidx.compose.runtime.rememberCoroutineScope
+            import androidx.compose.runtime.retain.retain
+            import androidx.compose.ui.window.ComposeUIViewController
+            import androidx.lifecycle.SavedStateHandle
+            import com.freeletics.khonshu.codegen.ActivityScope
+            import com.freeletics.khonshu.codegen.GlobalGraphProvider
+            import com.freeletics.khonshu.codegen.SimpleNavHost
+            import com.freeletics.khonshu.codegen.`internal`.HostGraphProvider
+            import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
+            import com.freeletics.khonshu.codegen.`internal`.LocalHostGraphProvider
+            import com.freeletics.khonshu.codegen.`internal`.asComposeState
+            import com.freeletics.khonshu.navigation.HostNavigator
+            import com.freeletics.khonshu.navigation.NavDestination
+            import com.freeletics.khonshu.navigation.NavHost
+            import com.freeletics.khonshu.navigation.NavRoot
+            import com.freeletics.khonshu.navigation.`internal`.InternalNavigationCodegenApi
+            import com.freeletics.khonshu.navigation.createHostNavigator
+            import com.freeletics.khonshu.navigation.deeplinks.LaunchInfo
+            import com.test.parent.TestParentScope
+            import dev.zacsweers.metro.ContributesTo
+            import dev.zacsweers.metro.ForScope
+            import dev.zacsweers.metro.GraphExtension
+            import dev.zacsweers.metro.Multibinds
+            import dev.zacsweers.metro.Provides
+            import dev.zacsweers.metro.SingleIn
+            import kotlin.AutoCloseable
+            import kotlin.OptIn
+            import kotlin.Unit
+            import kotlin.collections.Set
+            import kotlin.reflect.KClass
+            import kotlinx.coroutines.launch
+            import platform.UIKit.UIViewController
+
+            @OptIn(InternalCodegenApi::class)
+            @GraphExtension(
+              scope = TestScreen::class,
+              additionalScopes = [ActivityScope::class],
+            )
+            public interface KhonshuTestGraph : AutoCloseable {
+              public val testStateMachine: TestStateMachine
+
+              public val hostNavigator: HostNavigator
+
+              @ForScope(TestScreen::class)
+              public val savedStateHandle: SavedStateHandle
+
+              @ForScope(TestScreen::class)
+              public val closeables: Set<AutoCloseable>
+
+              @Multibinds(allowEmpty = true)
+              @ForScope(TestScreen::class)
+              public fun bindCloseables(): Set<AutoCloseable>
+
+              override fun close() {
+                closeables.forEach {
+                  it.close()
+                }
+              }
+
+              @ContributesTo(TestParentScope::class)
+              @GraphExtension.Factory
+              public interface Factory {
+                public fun createKhonshuTestGraph(@Provides @ForScope(TestScreen::class) savedStateHandle: SavedStateHandle, @Provides launchInfo: LaunchInfo): KhonshuTestGraph
+              }
+            }
+
+            @OptIn(InternalCodegenApi::class, InternalNavigationCodegenApi::class)
+            public class KhonshuTestGraphProvider(
+              private val graph: KhonshuTestGraph,
+              private val globalGraphProvider: GlobalGraphProvider,
+            ) : HostGraphProvider {
+              override fun <C> provide(scope: KClass<*>): C {
+                if (scope != TestScreen::class && scope != ActivityScope::class) {
+                  return globalGraphProvider.getGraph(scope)
+                }
+                @Suppress("UNCHECKED_CAST")
+                return graph as C
+              }
+            }
+
+            @ContributesTo(TestScreen::class)
+            public interface KhonshuTestHostGraph {
+              @Provides
+              @SingleIn(TestScreen::class)
+              @OptIn(InternalNavigationCodegenApi::class)
+              public fun provideHostNavigator(
+                startRoot: NavRoot,
+                @ForScope(TestScreen::class) savedStateHandle: SavedStateHandle,
+                destinations: Set<NavDestination<*>>,
+              ): HostNavigator = createHostNavigator(startRoot, destinations, savedStateHandle)
+            }
+
+            @OptIn(InternalCodegenApi::class, InternalNavigationCodegenApi::class)
+            public class KhonshuTestViewController(
+              private val globalGraphProvider: GlobalGraphProvider,
+              private val launchInfo: LaunchInfo,
+            ) {
+              public fun viewController(): UIViewController = ComposeUIViewController {
+                val graph = retain {
+                  val parentGraph = globalGraphProvider.getGraph<KhonshuTestGraph.Factory>(TestParentScope::class)
+                  val savedStateHandle = SavedStateHandle.createHandle(null, null)
+                  parentGraph.createKhonshuTestGraph(savedStateHandle, launchInfo)
+                }
+                val graphProvider = remember(graph) {
+                  KhonshuTestGraphProvider(graph, globalGraphProvider)
+                }
+                KhonshuTest(graph) { modifier, destinationChangedCallback ->
+                  CompositionLocalProvider(LocalHostGraphProvider provides graphProvider) {
+                    NavHost(
+                      navigator = remember(graph) { graph.hostNavigator },
+                      modifier = modifier,
+                      destinationChangedCallback = destinationChangedCallback,
+                    )
+                  }
+                }
+              }
+            }
+
+            @Composable
+            @OptIn(InternalCodegenApi::class)
+            private fun KhonshuTest(graph: KhonshuTestGraph, navHost: SimpleNavHost) {
+              val stateMachine = remember { graph.testStateMachine }
+              val scope = rememberCoroutineScope()
+              val sendAction: (TestAction) -> Unit = remember(stateMachine, scope) {
+                { scope.launch { stateMachine.dispatch(it) } }
+              }
+              val state = stateMachine.asComposeState()
+              val currentState = state.value
+              if (currentState != null) {
+                Test(
+                  state = currentState,
+                  sendAction = sendAction,
+                  navHost = navHost,
+                )
+              }
+            }
+
+            """.trimIndent()
+
+        test(data, "com/test/Test.kt", source, expected)
+    }
+
+    @Test
+    fun `generates code for NavHostViewControllerData with default values`() {
+        val withDefaultValues = data.copy(
+            parentScope = AppScope::class.asClassName(),
+        )
+
+        @Language("kotlin")
+        val source =
+            """
+            package com.test
+
+            import androidx.compose.runtime.Composable
+            import androidx.compose.ui.Modifier
+            import com.freeletics.khonshu.codegen.ActivityScope
+            import com.freeletics.khonshu.codegen.NavHostViewController
+            import com.freeletics.khonshu.codegen.SimpleNavHost
+            import com.freeletics.khonshu.navigation.NavRoot
+
+            @NavHostViewController(
+              scope = TestScreen::class,
+              stateMachine = TestStateMachine::class,
+            )
+            @Composable
+            @Suppress("unused_parameter")
+            public fun Test(
+              state: TestState,
+              sendAction: (TestAction) -> Unit,
+              navHost: SimpleNavHost,
+            ) {
+                navHost(Modifier) { _, _ -> }
+            }
+            """.trimIndent()
+
+        @Language("kotlin")
+        val expected =
+            """
+            package com.test
+
+            import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.CompositionLocalProvider
+            import androidx.compose.runtime.remember
+            import androidx.compose.runtime.rememberCoroutineScope
+            import androidx.compose.runtime.retain.retain
+            import androidx.compose.ui.window.ComposeUIViewController
+            import androidx.lifecycle.SavedStateHandle
+            import com.freeletics.khonshu.codegen.ActivityScope
+            import com.freeletics.khonshu.codegen.GlobalGraphProvider
+            import com.freeletics.khonshu.codegen.SimpleNavHost
+            import com.freeletics.khonshu.codegen.`internal`.HostGraphProvider
+            import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
+            import com.freeletics.khonshu.codegen.`internal`.LocalHostGraphProvider
+            import com.freeletics.khonshu.codegen.`internal`.asComposeState
+            import com.freeletics.khonshu.navigation.HostNavigator
+            import com.freeletics.khonshu.navigation.NavDestination
+            import com.freeletics.khonshu.navigation.NavHost
+            import com.freeletics.khonshu.navigation.NavRoot
+            import com.freeletics.khonshu.navigation.`internal`.InternalNavigationCodegenApi
+            import com.freeletics.khonshu.navigation.createHostNavigator
+            import com.freeletics.khonshu.navigation.deeplinks.LaunchInfo
+            import dev.zacsweers.metro.AppScope
+            import dev.zacsweers.metro.ContributesTo
+            import dev.zacsweers.metro.ForScope
+            import dev.zacsweers.metro.GraphExtension
+            import dev.zacsweers.metro.Multibinds
+            import dev.zacsweers.metro.Provides
+            import dev.zacsweers.metro.SingleIn
+            import kotlin.AutoCloseable
+            import kotlin.OptIn
+            import kotlin.Unit
+            import kotlin.collections.Set
+            import kotlin.reflect.KClass
+            import kotlinx.coroutines.launch
+            import platform.UIKit.UIViewController
+
+            @OptIn(InternalCodegenApi::class)
+            @GraphExtension(
+              scope = TestScreen::class,
+              additionalScopes = [ActivityScope::class],
+            )
+            public interface KhonshuTestGraph : AutoCloseable {
+              public val testStateMachine: TestStateMachine
+
+              public val hostNavigator: HostNavigator
+
+              @ForScope(TestScreen::class)
+              public val savedStateHandle: SavedStateHandle
+
+              @ForScope(TestScreen::class)
+              public val closeables: Set<AutoCloseable>
+
+              @Multibinds(allowEmpty = true)
+              @ForScope(TestScreen::class)
+              public fun bindCloseables(): Set<AutoCloseable>
+
+              override fun close() {
+                closeables.forEach {
+                  it.close()
+                }
+              }
+
+              @ContributesTo(AppScope::class)
+              @GraphExtension.Factory
+              public interface Factory {
+                public fun createKhonshuTestGraph(@Provides @ForScope(TestScreen::class) savedStateHandle: SavedStateHandle, @Provides launchInfo: LaunchInfo): KhonshuTestGraph
+              }
+            }
+
+            @OptIn(InternalCodegenApi::class, InternalNavigationCodegenApi::class)
+            public class KhonshuTestGraphProvider(
+              private val graph: KhonshuTestGraph,
+              private val globalGraphProvider: GlobalGraphProvider,
+            ) : HostGraphProvider {
+              override fun <C> provide(scope: KClass<*>): C {
+                if (scope != TestScreen::class && scope != ActivityScope::class) {
+                  return globalGraphProvider.getGraph(scope)
+                }
+                @Suppress("UNCHECKED_CAST")
+                return graph as C
+              }
+            }
+
+            @ContributesTo(TestScreen::class)
+            public interface KhonshuTestHostGraph {
+              @Provides
+              @SingleIn(TestScreen::class)
+              @OptIn(InternalNavigationCodegenApi::class)
+              public fun provideHostNavigator(
+                startRoot: NavRoot,
+                @ForScope(TestScreen::class) savedStateHandle: SavedStateHandle,
+                destinations: Set<NavDestination<*>>,
+              ): HostNavigator = createHostNavigator(startRoot, destinations, savedStateHandle)
+            }
+
+            @OptIn(InternalCodegenApi::class, InternalNavigationCodegenApi::class)
+            public class KhonshuTestViewController(
+              private val globalGraphProvider: GlobalGraphProvider,
+              private val launchInfo: LaunchInfo,
+            ) {
+              public fun viewController(): UIViewController = ComposeUIViewController {
+                val graph = retain {
+                  val parentGraph = globalGraphProvider.getGraph<KhonshuTestGraph.Factory>(AppScope::class)
+                  val savedStateHandle = SavedStateHandle.createHandle(null, null)
+                  parentGraph.createKhonshuTestGraph(savedStateHandle, launchInfo)
+                }
+                val graphProvider = remember(graph) {
+                  KhonshuTestGraphProvider(graph, globalGraphProvider)
+                }
+                KhonshuTest(graph) { modifier, destinationChangedCallback ->
+                  CompositionLocalProvider(LocalHostGraphProvider provides graphProvider) {
+                    NavHost(
+                      navigator = remember(graph) { graph.hostNavigator },
+                      modifier = modifier,
+                      destinationChangedCallback = destinationChangedCallback,
+                    )
+                  }
+                }
+              }
+            }
+
+            @Composable
+            @OptIn(InternalCodegenApi::class)
+            private fun KhonshuTest(graph: KhonshuTestGraph, navHost: SimpleNavHost) {
+              val stateMachine = remember { graph.testStateMachine }
+              val scope = rememberCoroutineScope()
+              val sendAction: (TestAction) -> Unit = remember(stateMachine, scope) {
+                { scope.launch { stateMachine.dispatch(it) } }
+              }
+              val state = stateMachine.asComposeState()
+              val currentState = state.value
+              if (currentState != null) {
+                Test(
+                  state = currentState,
+                  sendAction = sendAction,
+                  navHost = navHost,
+                )
+              }
+            }
+
+            """.trimIndent()
+
+        test(withDefaultValues, "com/test/Test.kt", source, expected)
+    }
+
+    @Test
+    fun `generates code for NavHostViewControllerData with Composable Dependencies`() {
+        val withInjectedParameters = data.copy(
+            baseName = "Test2",
+            composableParameter = listOf(
+                ComposableParameter(
+                    name = "testClass",
+                    typeName = ClassName("com.test", "TestClass"),
+                ),
+                ComposableParameter(
+                    name = "jvmTest",
+                    typeName = ClassName("com.test.other", "TestClass2"),
+                ),
+                ComposableParameter(
+                    name = "testSet",
+                    typeName = SET.parameterizedBy(STRING),
+                ),
+                ComposableParameter(
+                    name = "testMap",
+                    typeName = MAP.parameterizedBy(STRING, INT),
+                ),
+            ),
+        )
+
+        @Language("kotlin")
+        val source =
+            """
+            package com.test
+
+            import androidx.compose.runtime.Composable
+            import androidx.compose.ui.Modifier
+            import com.freeletics.khonshu.codegen.NavHostViewController
+            import com.freeletics.khonshu.codegen.SimpleNavHost
+            import com.freeletics.khonshu.navigation.NavRoot
+            import com.test.other.TestClass2
+            import com.test.parent.TestParentScope
+
+            @NavHostViewController(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+              stateMachine = TestStateMachine::class,
+            )
+            @Composable
+            @Suppress("unused_parameter")
+            public fun Test2(
+                state: TestState,
+                sendAction: (TestAction) -> Unit,
+                testClass: TestClass,
+                jvmTest: TestClass2,
+                testSet: Set<String>,
+                testMap: Map<String, Int>,
+                navHost: SimpleNavHost,
+            ) {
+                navHost(Modifier) { _, _ -> }
+            }
+            """.trimIndent()
+
+        @Language("kotlin")
+        val expected =
+            """
+            package com.test
+
+            import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.CompositionLocalProvider
+            import androidx.compose.runtime.remember
+            import androidx.compose.runtime.rememberCoroutineScope
+            import androidx.compose.runtime.retain.retain
+            import androidx.compose.ui.window.ComposeUIViewController
+            import androidx.lifecycle.SavedStateHandle
+            import com.freeletics.khonshu.codegen.ActivityScope
+            import com.freeletics.khonshu.codegen.GlobalGraphProvider
+            import com.freeletics.khonshu.codegen.SimpleNavHost
+            import com.freeletics.khonshu.codegen.`internal`.HostGraphProvider
+            import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
+            import com.freeletics.khonshu.codegen.`internal`.LocalHostGraphProvider
+            import com.freeletics.khonshu.codegen.`internal`.asComposeState
+            import com.freeletics.khonshu.navigation.HostNavigator
+            import com.freeletics.khonshu.navigation.NavDestination
+            import com.freeletics.khonshu.navigation.NavHost
+            import com.freeletics.khonshu.navigation.NavRoot
+            import com.freeletics.khonshu.navigation.`internal`.InternalNavigationCodegenApi
+            import com.freeletics.khonshu.navigation.createHostNavigator
+            import com.freeletics.khonshu.navigation.deeplinks.LaunchInfo
+            import com.test.other.TestClass2
+            import com.test.parent.TestParentScope
+            import dev.zacsweers.metro.ContributesTo
+            import dev.zacsweers.metro.ForScope
+            import dev.zacsweers.metro.GraphExtension
+            import dev.zacsweers.metro.Multibinds
+            import dev.zacsweers.metro.Provides
+            import dev.zacsweers.metro.SingleIn
+            import kotlin.AutoCloseable
+            import kotlin.Int
+            import kotlin.OptIn
+            import kotlin.String
+            import kotlin.Unit
+            import kotlin.collections.Map
+            import kotlin.collections.Set
+            import kotlin.reflect.KClass
+            import kotlinx.coroutines.launch
+            import platform.UIKit.UIViewController
+
+            @OptIn(InternalCodegenApi::class)
+            @GraphExtension(
+              scope = TestScreen::class,
+              additionalScopes = [ActivityScope::class],
+            )
+            public interface KhonshuTest2Graph : AutoCloseable {
+              public val testStateMachine: TestStateMachine
+
+              public val hostNavigator: HostNavigator
+
+              @ForScope(TestScreen::class)
+              public val savedStateHandle: SavedStateHandle
+
+              public val testClass: TestClass
+
+              public val jvmTest: TestClass2
+
+              public val testSet: Set<String>
+
+              public val testMap: Map<String, Int>
+
+              @ForScope(TestScreen::class)
+              public val closeables: Set<AutoCloseable>
+
+              @Multibinds(allowEmpty = true)
+              @ForScope(TestScreen::class)
+              public fun bindCloseables(): Set<AutoCloseable>
+
+              override fun close() {
+                closeables.forEach {
+                  it.close()
+                }
+              }
+
+              @ContributesTo(TestParentScope::class)
+              @GraphExtension.Factory
+              public interface Factory {
+                public fun createKhonshuTest2Graph(@Provides @ForScope(TestScreen::class) savedStateHandle: SavedStateHandle, @Provides launchInfo: LaunchInfo): KhonshuTest2Graph
+              }
+            }
+
+            @OptIn(InternalCodegenApi::class, InternalNavigationCodegenApi::class)
+            public class KhonshuTest2GraphProvider(
+              private val graph: KhonshuTest2Graph,
+              private val globalGraphProvider: GlobalGraphProvider,
+            ) : HostGraphProvider {
+              override fun <C> provide(scope: KClass<*>): C {
+                if (scope != TestScreen::class && scope != ActivityScope::class) {
+                  return globalGraphProvider.getGraph(scope)
+                }
+                @Suppress("UNCHECKED_CAST")
+                return graph as C
+              }
+            }
+
+            @ContributesTo(TestScreen::class)
+            public interface KhonshuTest2HostGraph {
+              @Provides
+              @SingleIn(TestScreen::class)
+              @OptIn(InternalNavigationCodegenApi::class)
+              public fun provideHostNavigator(
+                startRoot: NavRoot,
+                @ForScope(TestScreen::class) savedStateHandle: SavedStateHandle,
+                destinations: Set<NavDestination<*>>,
+              ): HostNavigator = createHostNavigator(startRoot, destinations, savedStateHandle)
+            }
+
+            @OptIn(InternalCodegenApi::class, InternalNavigationCodegenApi::class)
+            public class KhonshuTest2ViewController(
+              private val globalGraphProvider: GlobalGraphProvider,
+              private val launchInfo: LaunchInfo,
+            ) {
+              public fun viewController(): UIViewController = ComposeUIViewController {
+                val graph = retain {
+                  val parentGraph = globalGraphProvider.getGraph<KhonshuTest2Graph.Factory>(TestParentScope::class)
+                  val savedStateHandle = SavedStateHandle.createHandle(null, null)
+                  parentGraph.createKhonshuTest2Graph(savedStateHandle, launchInfo)
+                }
+                val graphProvider = remember(graph) {
+                  KhonshuTest2GraphProvider(graph, globalGraphProvider)
+                }
+                KhonshuTest2(graph) { modifier, destinationChangedCallback ->
+                  CompositionLocalProvider(LocalHostGraphProvider provides graphProvider) {
+                    NavHost(
+                      navigator = remember(graph) { graph.hostNavigator },
+                      modifier = modifier,
+                      destinationChangedCallback = destinationChangedCallback,
+                    )
+                  }
+                }
+              }
+            }
+
+            @Composable
+            @OptIn(InternalCodegenApi::class)
+            private fun KhonshuTest2(graph: KhonshuTest2Graph, navHost: SimpleNavHost) {
+              val testClass = remember { graph.testClass }
+              val jvmTest = remember { graph.jvmTest }
+              val testSet = remember { graph.testSet }
+              val testMap = remember { graph.testMap }
+              val stateMachine = remember { graph.testStateMachine }
+              val scope = rememberCoroutineScope()
+              val sendAction: (TestAction) -> Unit = remember(stateMachine, scope) {
+                { scope.launch { stateMachine.dispatch(it) } }
+              }
+              val state = stateMachine.asComposeState()
+              val currentState = state.value
+              if (currentState != null) {
+                Test2(
+                  testClass = testClass,
+                  jvmTest = jvmTest,
+                  testSet = testSet,
+                  testMap = testMap,
+                  state = currentState,
+                  sendAction = sendAction,
+                  navHost = navHost,
+                )
+              }
+            }
+
+            """.trimIndent()
+
+        test(withInjectedParameters, "com/test/Test2.kt", source, expected)
+    }
+
+    @Test
+    fun `generates code for NavHostViewControllerData without sendAction`() {
+        val withoutSendAction = data.copy(
+            sendActionParameter = null,
+        )
+
+        @Language("kotlin")
+        val source =
+            """
+            package com.test
+
+            import androidx.compose.runtime.Composable
+            import androidx.compose.ui.Modifier
+            import com.freeletics.khonshu.codegen.NavHostViewController
+            import com.freeletics.khonshu.codegen.SimpleNavHost
+            import com.freeletics.khonshu.navigation.NavRoot
+            import com.test.parent.TestParentScope
+
+            @NavHostViewController(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+              stateMachine = TestStateMachine::class,
+            )
+            @Composable
+            @Suppress("unused_parameter")
+            public fun Test(
+              state: TestState,
+              navHost: SimpleNavHost,
+            ) {
+                navHost(Modifier) { _, _ -> }
+            }
+            """.trimIndent()
+
+        @Language("kotlin")
+        val expected =
+            """
+            package com.test
+
+            import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.CompositionLocalProvider
+            import androidx.compose.runtime.remember
+            import androidx.compose.runtime.retain.retain
+            import androidx.compose.ui.window.ComposeUIViewController
+            import androidx.lifecycle.SavedStateHandle
+            import com.freeletics.khonshu.codegen.ActivityScope
+            import com.freeletics.khonshu.codegen.GlobalGraphProvider
+            import com.freeletics.khonshu.codegen.SimpleNavHost
+            import com.freeletics.khonshu.codegen.`internal`.HostGraphProvider
+            import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
+            import com.freeletics.khonshu.codegen.`internal`.LocalHostGraphProvider
+            import com.freeletics.khonshu.codegen.`internal`.asComposeState
+            import com.freeletics.khonshu.navigation.HostNavigator
+            import com.freeletics.khonshu.navigation.NavDestination
+            import com.freeletics.khonshu.navigation.NavHost
+            import com.freeletics.khonshu.navigation.NavRoot
+            import com.freeletics.khonshu.navigation.`internal`.InternalNavigationCodegenApi
+            import com.freeletics.khonshu.navigation.createHostNavigator
+            import com.freeletics.khonshu.navigation.deeplinks.LaunchInfo
+            import com.test.parent.TestParentScope
+            import dev.zacsweers.metro.ContributesTo
+            import dev.zacsweers.metro.ForScope
+            import dev.zacsweers.metro.GraphExtension
+            import dev.zacsweers.metro.Multibinds
+            import dev.zacsweers.metro.Provides
+            import dev.zacsweers.metro.SingleIn
+            import kotlin.AutoCloseable
+            import kotlin.OptIn
+            import kotlin.collections.Set
+            import kotlin.reflect.KClass
+            import platform.UIKit.UIViewController
+
+            @OptIn(InternalCodegenApi::class)
+            @GraphExtension(
+              scope = TestScreen::class,
+              additionalScopes = [ActivityScope::class],
+            )
+            public interface KhonshuTestGraph : AutoCloseable {
+              public val testStateMachine: TestStateMachine
+
+              public val hostNavigator: HostNavigator
+
+              @ForScope(TestScreen::class)
+              public val savedStateHandle: SavedStateHandle
+
+              @ForScope(TestScreen::class)
+              public val closeables: Set<AutoCloseable>
+
+              @Multibinds(allowEmpty = true)
+              @ForScope(TestScreen::class)
+              public fun bindCloseables(): Set<AutoCloseable>
+
+              override fun close() {
+                closeables.forEach {
+                  it.close()
+                }
+              }
+
+              @ContributesTo(TestParentScope::class)
+              @GraphExtension.Factory
+              public interface Factory {
+                public fun createKhonshuTestGraph(@Provides @ForScope(TestScreen::class) savedStateHandle: SavedStateHandle, @Provides launchInfo: LaunchInfo): KhonshuTestGraph
+              }
+            }
+
+            @OptIn(InternalCodegenApi::class, InternalNavigationCodegenApi::class)
+            public class KhonshuTestGraphProvider(
+              private val graph: KhonshuTestGraph,
+              private val globalGraphProvider: GlobalGraphProvider,
+            ) : HostGraphProvider {
+              override fun <C> provide(scope: KClass<*>): C {
+                if (scope != TestScreen::class && scope != ActivityScope::class) {
+                  return globalGraphProvider.getGraph(scope)
+                }
+                @Suppress("UNCHECKED_CAST")
+                return graph as C
+              }
+            }
+
+            @ContributesTo(TestScreen::class)
+            public interface KhonshuTestHostGraph {
+              @Provides
+              @SingleIn(TestScreen::class)
+              @OptIn(InternalNavigationCodegenApi::class)
+              public fun provideHostNavigator(
+                startRoot: NavRoot,
+                @ForScope(TestScreen::class) savedStateHandle: SavedStateHandle,
+                destinations: Set<NavDestination<*>>,
+              ): HostNavigator = createHostNavigator(startRoot, destinations, savedStateHandle)
+            }
+
+            @OptIn(InternalCodegenApi::class, InternalNavigationCodegenApi::class)
+            public class KhonshuTestViewController(
+              private val globalGraphProvider: GlobalGraphProvider,
+              private val launchInfo: LaunchInfo,
+            ) {
+              public fun viewController(): UIViewController = ComposeUIViewController {
+                val graph = retain {
+                  val parentGraph = globalGraphProvider.getGraph<KhonshuTestGraph.Factory>(TestParentScope::class)
+                  val savedStateHandle = SavedStateHandle.createHandle(null, null)
+                  parentGraph.createKhonshuTestGraph(savedStateHandle, launchInfo)
+                }
+                val graphProvider = remember(graph) {
+                  KhonshuTestGraphProvider(graph, globalGraphProvider)
+                }
+                KhonshuTest(graph) { modifier, destinationChangedCallback ->
+                  CompositionLocalProvider(LocalHostGraphProvider provides graphProvider) {
+                    NavHost(
+                      navigator = remember(graph) { graph.hostNavigator },
+                      modifier = modifier,
+                      destinationChangedCallback = destinationChangedCallback,
+                    )
+                  }
+                }
+              }
+            }
+
+            @Composable
+            @OptIn(InternalCodegenApi::class)
+            private fun KhonshuTest(graph: KhonshuTestGraph, navHost: SimpleNavHost) {
+              val stateMachine = remember { graph.testStateMachine }
+              val state = stateMachine.asComposeState()
+              val currentState = state.value
+              if (currentState != null) {
+                Test(
+                  state = currentState,
+                  navHost = navHost,
+                )
+              }
+            }
+
+            """.trimIndent()
+
+        test(withoutSendAction, "com/test/Test.kt", source, expected)
+    }
+
+    @Test
+    fun `generates code for NavHostViewControllerData without state`() {
+        val withoutSendAction = data.copy(
+            stateParameter = null,
+        )
+
+        @Language("kotlin")
+        val source =
+            """
+            package com.test
+
+            import androidx.compose.runtime.Composable
+            import androidx.compose.ui.Modifier
+            import com.freeletics.khonshu.codegen.NavHostViewController
+            import com.freeletics.khonshu.codegen.SimpleNavHost
+            import com.freeletics.khonshu.navigation.NavRoot
+            import com.test.parent.TestParentScope
+
+            @NavHostViewController(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+              stateMachine = TestStateMachine::class,
+            )
+            @Composable
+            @Suppress("unused_parameter")
+            public fun Test(
+              sendAction: (TestAction) -> Unit,
+              navHost: SimpleNavHost,
+            ) {
+                navHost(Modifier) { _, _ -> }
+            }
+            """.trimIndent()
+
+        @Language("kotlin")
+        val expected =
+            """
+            package com.test
+
+            import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.CompositionLocalProvider
+            import androidx.compose.runtime.remember
+            import androidx.compose.runtime.rememberCoroutineScope
+            import androidx.compose.runtime.retain.retain
+            import androidx.compose.ui.window.ComposeUIViewController
+            import androidx.lifecycle.SavedStateHandle
+            import com.freeletics.khonshu.codegen.ActivityScope
+            import com.freeletics.khonshu.codegen.GlobalGraphProvider
+            import com.freeletics.khonshu.codegen.SimpleNavHost
+            import com.freeletics.khonshu.codegen.`internal`.HostGraphProvider
+            import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
+            import com.freeletics.khonshu.codegen.`internal`.LocalHostGraphProvider
+            import com.freeletics.khonshu.codegen.`internal`.asComposeState
+            import com.freeletics.khonshu.navigation.HostNavigator
+            import com.freeletics.khonshu.navigation.NavDestination
+            import com.freeletics.khonshu.navigation.NavHost
+            import com.freeletics.khonshu.navigation.NavRoot
+            import com.freeletics.khonshu.navigation.`internal`.InternalNavigationCodegenApi
+            import com.freeletics.khonshu.navigation.createHostNavigator
+            import com.freeletics.khonshu.navigation.deeplinks.LaunchInfo
+            import com.test.parent.TestParentScope
+            import dev.zacsweers.metro.ContributesTo
+            import dev.zacsweers.metro.ForScope
+            import dev.zacsweers.metro.GraphExtension
+            import dev.zacsweers.metro.Multibinds
+            import dev.zacsweers.metro.Provides
+            import dev.zacsweers.metro.SingleIn
+            import kotlin.AutoCloseable
+            import kotlin.OptIn
+            import kotlin.Unit
+            import kotlin.collections.Set
+            import kotlin.reflect.KClass
+            import kotlinx.coroutines.launch
+            import platform.UIKit.UIViewController
+
+            @OptIn(InternalCodegenApi::class)
+            @GraphExtension(
+              scope = TestScreen::class,
+              additionalScopes = [ActivityScope::class],
+            )
+            public interface KhonshuTestGraph : AutoCloseable {
+              public val testStateMachine: TestStateMachine
+
+              public val hostNavigator: HostNavigator
+
+              @ForScope(TestScreen::class)
+              public val savedStateHandle: SavedStateHandle
+
+              @ForScope(TestScreen::class)
+              public val closeables: Set<AutoCloseable>
+
+              @Multibinds(allowEmpty = true)
+              @ForScope(TestScreen::class)
+              public fun bindCloseables(): Set<AutoCloseable>
+
+              override fun close() {
+                closeables.forEach {
+                  it.close()
+                }
+              }
+
+              @ContributesTo(TestParentScope::class)
+              @GraphExtension.Factory
+              public interface Factory {
+                public fun createKhonshuTestGraph(@Provides @ForScope(TestScreen::class) savedStateHandle: SavedStateHandle, @Provides launchInfo: LaunchInfo): KhonshuTestGraph
+              }
+            }
+
+            @OptIn(InternalCodegenApi::class, InternalNavigationCodegenApi::class)
+            public class KhonshuTestGraphProvider(
+              private val graph: KhonshuTestGraph,
+              private val globalGraphProvider: GlobalGraphProvider,
+            ) : HostGraphProvider {
+              override fun <C> provide(scope: KClass<*>): C {
+                if (scope != TestScreen::class && scope != ActivityScope::class) {
+                  return globalGraphProvider.getGraph(scope)
+                }
+                @Suppress("UNCHECKED_CAST")
+                return graph as C
+              }
+            }
+
+            @ContributesTo(TestScreen::class)
+            public interface KhonshuTestHostGraph {
+              @Provides
+              @SingleIn(TestScreen::class)
+              @OptIn(InternalNavigationCodegenApi::class)
+              public fun provideHostNavigator(
+                startRoot: NavRoot,
+                @ForScope(TestScreen::class) savedStateHandle: SavedStateHandle,
+                destinations: Set<NavDestination<*>>,
+              ): HostNavigator = createHostNavigator(startRoot, destinations, savedStateHandle)
+            }
+
+            @OptIn(InternalCodegenApi::class, InternalNavigationCodegenApi::class)
+            public class KhonshuTestViewController(
+              private val globalGraphProvider: GlobalGraphProvider,
+              private val launchInfo: LaunchInfo,
+            ) {
+              public fun viewController(): UIViewController = ComposeUIViewController {
+                val graph = retain {
+                  val parentGraph = globalGraphProvider.getGraph<KhonshuTestGraph.Factory>(TestParentScope::class)
+                  val savedStateHandle = SavedStateHandle.createHandle(null, null)
+                  parentGraph.createKhonshuTestGraph(savedStateHandle, launchInfo)
+                }
+                val graphProvider = remember(graph) {
+                  KhonshuTestGraphProvider(graph, globalGraphProvider)
+                }
+                KhonshuTest(graph) { modifier, destinationChangedCallback ->
+                  CompositionLocalProvider(LocalHostGraphProvider provides graphProvider) {
+                    NavHost(
+                      navigator = remember(graph) { graph.hostNavigator },
+                      modifier = modifier,
+                      destinationChangedCallback = destinationChangedCallback,
+                    )
+                  }
+                }
+              }
+            }
+
+            @Composable
+            @OptIn(InternalCodegenApi::class)
+            private fun KhonshuTest(graph: KhonshuTestGraph, navHost: SimpleNavHost) {
+              val stateMachine = remember { graph.testStateMachine }
+              val scope = rememberCoroutineScope()
+              val sendAction: (TestAction) -> Unit = remember(stateMachine, scope) {
+                { scope.launch { stateMachine.dispatch(it) } }
+              }
+              val state = stateMachine.asComposeState()
+              val currentState = state.value
+              if (currentState != null) {
+                Test(
+                  sendAction = sendAction,
+                  navHost = navHost,
+                )
+              }
+            }
+
+            """.trimIndent()
+
+        test(withoutSendAction, "com/test/Test.kt", source, expected)
+    }
+
+    @Test
+    fun `generates code for NavHostViewControllerData with lambda parameter`() {
+        // nothing changes on the data side
+        val withLambdaParameter = data
+
+        @Language("kotlin")
+        val source =
+            """
+            package com.test
+
+            import androidx.compose.runtime.Composable
+            import androidx.compose.ui.Modifier
+            import com.freeletics.khonshu.codegen.NavHostViewController
+            import com.freeletics.khonshu.codegen.SimpleNavHost
+            import com.freeletics.khonshu.navigation.BaseRoute
+            import com.freeletics.khonshu.navigation.NavRoot
+            import com.test.parent.TestParentScope
+
+            @NavHostViewController(
+              scope = TestScreen::class,
+              parentScope = TestParentScope::class,
+              stateMachine = TestStateMachine::class,
+            )
+            @Composable
+            @Suppress("unused_parameter")
+            public fun Test(
+              state: TestState,
+              sendAction: (TestAction) -> Unit,
+              navHost: @Composable (Modifier, ((NavRoot, BaseRoute) -> Unit)?) -> Unit,
+            ) {
+                navHost(Modifier)  { _, _ -> }
+            }
+            """.trimIndent()
+
+        @Language("kotlin")
+        val expected =
+            """
+            package com.test
+
+            import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.CompositionLocalProvider
+            import androidx.compose.runtime.remember
+            import androidx.compose.runtime.rememberCoroutineScope
+            import androidx.compose.runtime.retain.retain
+            import androidx.compose.ui.window.ComposeUIViewController
+            import androidx.lifecycle.SavedStateHandle
+            import com.freeletics.khonshu.codegen.ActivityScope
+            import com.freeletics.khonshu.codegen.GlobalGraphProvider
+            import com.freeletics.khonshu.codegen.SimpleNavHost
+            import com.freeletics.khonshu.codegen.`internal`.HostGraphProvider
+            import com.freeletics.khonshu.codegen.`internal`.InternalCodegenApi
+            import com.freeletics.khonshu.codegen.`internal`.LocalHostGraphProvider
+            import com.freeletics.khonshu.codegen.`internal`.asComposeState
+            import com.freeletics.khonshu.navigation.HostNavigator
+            import com.freeletics.khonshu.navigation.NavDestination
+            import com.freeletics.khonshu.navigation.NavHost
+            import com.freeletics.khonshu.navigation.NavRoot
+            import com.freeletics.khonshu.navigation.`internal`.InternalNavigationCodegenApi
+            import com.freeletics.khonshu.navigation.createHostNavigator
+            import com.freeletics.khonshu.navigation.deeplinks.LaunchInfo
+            import com.test.parent.TestParentScope
+            import dev.zacsweers.metro.ContributesTo
+            import dev.zacsweers.metro.ForScope
+            import dev.zacsweers.metro.GraphExtension
+            import dev.zacsweers.metro.Multibinds
+            import dev.zacsweers.metro.Provides
+            import dev.zacsweers.metro.SingleIn
+            import kotlin.AutoCloseable
+            import kotlin.OptIn
+            import kotlin.Unit
+            import kotlin.collections.Set
+            import kotlin.reflect.KClass
+            import kotlinx.coroutines.launch
+            import platform.UIKit.UIViewController
+
+            @OptIn(InternalCodegenApi::class)
+            @GraphExtension(
+              scope = TestScreen::class,
+              additionalScopes = [ActivityScope::class],
+            )
+            public interface KhonshuTestGraph : AutoCloseable {
+              public val testStateMachine: TestStateMachine
+
+              public val hostNavigator: HostNavigator
+
+              @ForScope(TestScreen::class)
+              public val savedStateHandle: SavedStateHandle
+
+              @ForScope(TestScreen::class)
+              public val closeables: Set<AutoCloseable>
+
+              @Multibinds(allowEmpty = true)
+              @ForScope(TestScreen::class)
+              public fun bindCloseables(): Set<AutoCloseable>
+
+              override fun close() {
+                closeables.forEach {
+                  it.close()
+                }
+              }
+
+              @ContributesTo(TestParentScope::class)
+              @GraphExtension.Factory
+              public interface Factory {
+                public fun createKhonshuTestGraph(@Provides @ForScope(TestScreen::class) savedStateHandle: SavedStateHandle, @Provides launchInfo: LaunchInfo): KhonshuTestGraph
+              }
+            }
+
+            @OptIn(InternalCodegenApi::class, InternalNavigationCodegenApi::class)
+            public class KhonshuTestGraphProvider(
+              private val graph: KhonshuTestGraph,
+              private val globalGraphProvider: GlobalGraphProvider,
+            ) : HostGraphProvider {
+              override fun <C> provide(scope: KClass<*>): C {
+                if (scope != TestScreen::class && scope != ActivityScope::class) {
+                  return globalGraphProvider.getGraph(scope)
+                }
+                @Suppress("UNCHECKED_CAST")
+                return graph as C
+              }
+            }
+
+            @ContributesTo(TestScreen::class)
+            public interface KhonshuTestHostGraph {
+              @Provides
+              @SingleIn(TestScreen::class)
+              @OptIn(InternalNavigationCodegenApi::class)
+              public fun provideHostNavigator(
+                startRoot: NavRoot,
+                @ForScope(TestScreen::class) savedStateHandle: SavedStateHandle,
+                destinations: Set<NavDestination<*>>,
+              ): HostNavigator = createHostNavigator(startRoot, destinations, savedStateHandle)
+            }
+
+            @OptIn(InternalCodegenApi::class, InternalNavigationCodegenApi::class)
+            public class KhonshuTestViewController(
+              private val globalGraphProvider: GlobalGraphProvider,
+              private val launchInfo: LaunchInfo,
+            ) {
+              public fun viewController(): UIViewController = ComposeUIViewController {
+                val graph = retain {
+                  val parentGraph = globalGraphProvider.getGraph<KhonshuTestGraph.Factory>(TestParentScope::class)
+                  val savedStateHandle = SavedStateHandle.createHandle(null, null)
+                  parentGraph.createKhonshuTestGraph(savedStateHandle, launchInfo)
+                }
+                val graphProvider = remember(graph) {
+                  KhonshuTestGraphProvider(graph, globalGraphProvider)
+                }
+                KhonshuTest(graph) { modifier, destinationChangedCallback ->
+                  CompositionLocalProvider(LocalHostGraphProvider provides graphProvider) {
+                    NavHost(
+                      navigator = remember(graph) { graph.hostNavigator },
+                      modifier = modifier,
+                      destinationChangedCallback = destinationChangedCallback,
+                    )
+                  }
+                }
+              }
+            }
+
+            @Composable
+            @OptIn(InternalCodegenApi::class)
+            private fun KhonshuTest(graph: KhonshuTestGraph, navHost: SimpleNavHost) {
+              val stateMachine = remember { graph.testStateMachine }
+              val scope = rememberCoroutineScope()
+              val sendAction: (TestAction) -> Unit = remember(stateMachine, scope) {
+                { scope.launch { stateMachine.dispatch(it) } }
+              }
+              val state = stateMachine.asComposeState()
+              val currentState = state.value
+              if (currentState != null) {
+                Test(
+                  state = currentState,
+                  sendAction = sendAction,
+                  navHost = navHost,
+                )
+              }
+            }
+
+            """.trimIndent()
+
+        test(withLambdaParameter, "com/test/Test.kt", source, expected)
+    }
+}

--- a/codegen-compiler-test/src/test/kotlin/platform/UIKit/UIViewController.kt
+++ b/codegen-compiler-test/src/test/kotlin/platform/UIKit/UIViewController.kt
@@ -1,3 +1,4 @@
+@file:Suppress("ktlint:standard:package-name")
 package platform.UIKit
 
 class UIViewController

--- a/codegen-compiler-test/src/test/kotlin/platform/UIKit/UIViewController.kt
+++ b/codegen-compiler-test/src/test/kotlin/platform/UIKit/UIViewController.kt
@@ -1,0 +1,3 @@
+package platform.UIKit
+
+class UIViewController

--- a/codegen-compiler/api/codegen-compiler.api
+++ b/codegen-compiler/api/codegen-compiler.api
@@ -92,6 +92,37 @@ public abstract interface class com/freeletics/khonshu/codegen/HostData : com/fr
 	public abstract fun getNavHostParameter ()Lcom/freeletics/khonshu/codegen/ComposableParameter;
 }
 
+public final class com/freeletics/khonshu/codegen/HostViewControllerData : com/freeletics/khonshu/codegen/HostData {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/squareup/kotlinpoet/ClassName;Lcom/squareup/kotlinpoet/ClassName;Lcom/squareup/kotlinpoet/ClassName;Lcom/squareup/kotlinpoet/ClassName;Lcom/freeletics/khonshu/codegen/ComposableParameter;Lcom/freeletics/khonshu/codegen/ComposableParameter;Lcom/freeletics/khonshu/codegen/ComposableParameter;Ljava/util/List;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lcom/squareup/kotlinpoet/ClassName;
+	public final fun component4 ()Lcom/squareup/kotlinpoet/ClassName;
+	public final fun component5 ()Lcom/squareup/kotlinpoet/ClassName;
+	public final fun component6 ()Lcom/squareup/kotlinpoet/ClassName;
+	public final fun component7 ()Lcom/freeletics/khonshu/codegen/ComposableParameter;
+	public final fun component8 ()Lcom/freeletics/khonshu/codegen/ComposableParameter;
+	public final fun component9 ()Lcom/freeletics/khonshu/codegen/ComposableParameter;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/squareup/kotlinpoet/ClassName;Lcom/squareup/kotlinpoet/ClassName;Lcom/squareup/kotlinpoet/ClassName;Lcom/squareup/kotlinpoet/ClassName;Lcom/freeletics/khonshu/codegen/ComposableParameter;Lcom/freeletics/khonshu/codegen/ComposableParameter;Lcom/freeletics/khonshu/codegen/ComposableParameter;Ljava/util/List;)Lcom/freeletics/khonshu/codegen/HostViewControllerData;
+	public static synthetic fun copy$default (Lcom/freeletics/khonshu/codegen/HostViewControllerData;Ljava/lang/String;Ljava/lang/String;Lcom/squareup/kotlinpoet/ClassName;Lcom/squareup/kotlinpoet/ClassName;Lcom/squareup/kotlinpoet/ClassName;Lcom/squareup/kotlinpoet/ClassName;Lcom/freeletics/khonshu/codegen/ComposableParameter;Lcom/freeletics/khonshu/codegen/ComposableParameter;Lcom/freeletics/khonshu/codegen/ComposableParameter;Ljava/util/List;ILjava/lang/Object;)Lcom/freeletics/khonshu/codegen/HostViewControllerData;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAdditionalScopes ()Ljava/util/List;
+	public fun getBaseName ()Ljava/lang/String;
+	public fun getComposableParameter ()Ljava/util/List;
+	public fun getNavHostParameter ()Lcom/freeletics/khonshu/codegen/ComposableParameter;
+	public fun getNavigation ()Lcom/freeletics/khonshu/codegen/Navigation;
+	public fun getPackageName ()Ljava/lang/String;
+	public fun getParentScope ()Lcom/squareup/kotlinpoet/ClassName;
+	public fun getScope ()Lcom/squareup/kotlinpoet/ClassName;
+	public fun getSendActionParameter ()Lcom/freeletics/khonshu/codegen/ComposableParameter;
+	public fun getStateMachine ()Lcom/squareup/kotlinpoet/ClassName;
+	public fun getStateMachineClass ()Lcom/squareup/kotlinpoet/ClassName;
+	public fun getStateParameter ()Lcom/freeletics/khonshu/codegen/ComposableParameter;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/freeletics/khonshu/codegen/HostWindowData : com/freeletics/khonshu/codegen/HostData {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/squareup/kotlinpoet/ClassName;Lcom/squareup/kotlinpoet/ClassName;Lcom/squareup/kotlinpoet/ClassName;Lcom/squareup/kotlinpoet/ClassName;Lcom/freeletics/khonshu/codegen/ComposableParameter;Lcom/freeletics/khonshu/codegen/ComposableParameter;Lcom/freeletics/khonshu/codegen/ComposableParameter;Ljava/util/List;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -154,6 +185,7 @@ public final class com/freeletics/khonshu/codegen/codegen/FileGenerator {
 	public final fun generate (Lcom/freeletics/khonshu/codegen/BaseData;)Lcom/squareup/kotlinpoet/FileSpec;
 	public final fun generate (Lcom/freeletics/khonshu/codegen/DestinationData;)Lcom/squareup/kotlinpoet/FileSpec;
 	public final fun generate (Lcom/freeletics/khonshu/codegen/HostActivityData;)Lcom/squareup/kotlinpoet/FileSpec;
+	public final fun generate (Lcom/freeletics/khonshu/codegen/HostViewControllerData;)Lcom/squareup/kotlinpoet/FileSpec;
 	public final fun generate (Lcom/freeletics/khonshu/codegen/HostWindowData;)Lcom/squareup/kotlinpoet/FileSpec;
 }
 

--- a/codegen-compiler/src/jvmMain/kotlin/com/freeletics/khonshu/codegen/Data.kt
+++ b/codegen-compiler/src/jvmMain/kotlin/com/freeletics/khonshu/codegen/Data.kt
@@ -82,6 +82,22 @@ public data class HostWindowData(
     override val navigation: Navigation? = null
 }
 
+public data class HostViewControllerData(
+    override val baseName: String,
+    override val packageName: String,
+    override val scope: ClassName,
+    override val parentScope: ClassName,
+    override val stateMachine: ClassName,
+    override val stateMachineClass: ClassName,
+    override val navHostParameter: ComposableParameter,
+    override val stateParameter: ComposableParameter?,
+    override val sendActionParameter: ComposableParameter?,
+    override val composableParameter: List<ComposableParameter>,
+) : HostData {
+    override val additionalScopes: List<ClassName> = listOf(activityScope)
+    override val navigation: Navigation? = null
+}
+
 public data class Navigation(
     val route: ClassName,
     val parentScopeIsRoute: Boolean,

--- a/codegen-compiler/src/jvmMain/kotlin/com/freeletics/khonshu/codegen/KhonshuSymbolProcessor.kt
+++ b/codegen-compiler/src/jvmMain/kotlin/com/freeletics/khonshu/codegen/KhonshuSymbolProcessor.kt
@@ -3,6 +3,7 @@ package com.freeletics.khonshu.codegen
 import com.freeletics.khonshu.codegen.codegen.FileGenerator
 import com.freeletics.khonshu.codegen.parser.toDestinationData
 import com.freeletics.khonshu.codegen.parser.toHostActivityData
+import com.freeletics.khonshu.codegen.parser.toHostViewControllerData
 import com.freeletics.khonshu.codegen.parser.toHostWindowData
 import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.KSPLogger
@@ -36,6 +37,9 @@ public class KhonshuSymbolProcessor(
         }
         resolver.generateCodeForAnnotation<NavHostWindow> {
             toHostWindowData(it, logger)
+        }
+        resolver.generateCodeForAnnotation<NavHostViewController> {
+            toHostViewControllerData(it, logger)
         }
         return emptyList()
     }

--- a/codegen-compiler/src/jvmMain/kotlin/com/freeletics/khonshu/codegen/codegen/FileGenerator.kt
+++ b/codegen-compiler/src/jvmMain/kotlin/com/freeletics/khonshu/codegen/codegen/FileGenerator.kt
@@ -3,6 +3,7 @@ package com.freeletics.khonshu.codegen.codegen
 import com.freeletics.khonshu.codegen.BaseData
 import com.freeletics.khonshu.codegen.DestinationData
 import com.freeletics.khonshu.codegen.HostActivityData
+import com.freeletics.khonshu.codegen.HostViewControllerData
 import com.freeletics.khonshu.codegen.HostWindowData
 import com.squareup.kotlinpoet.FileSpec
 
@@ -12,6 +13,7 @@ public class FileGenerator {
             is DestinationData -> generate(data)
             is HostActivityData -> generate(data)
             is HostWindowData -> generate(data)
+            is HostViewControllerData -> generate(data)
         }
     }
 
@@ -50,15 +52,31 @@ public class FileGenerator {
     public fun generate(data: HostWindowData): FileSpec {
         val graph = GraphGenerator(data)
         val graphProvider = HostGraphProviderGenerator(data)
+        val graphComposable = GraphComposableGenerator(data)
         val activityModule = HostGraphContributionGenerator(data)
         val window = HostWindowGenerator(data)
-        val graphComposable = GraphComposableGenerator(data)
 
         return FileSpec.builder(data.packageName, "Khonshu${data.baseName}")
             .addType(graph.generate())
             .addType(graphProvider.generate())
             .addType(activityModule.generate())
             .addType(window.generate())
+            .addFunction(graphComposable.generate())
+            .build()
+    }
+
+    public fun generate(data: HostViewControllerData): FileSpec {
+        val graph = GraphGenerator(data)
+        val graphProvider = HostGraphProviderGenerator(data)
+        val graphComposable = GraphComposableGenerator(data)
+        val activityModule = HostGraphContributionGenerator(data)
+        val viewController = HostViewControllerGenerator(data)
+
+        return FileSpec.builder(data.packageName, "Khonshu${data.baseName}")
+            .addType(graph.generate())
+            .addType(graphProvider.generate())
+            .addType(activityModule.generate())
+            .addType(viewController.generate())
             .addFunction(graphComposable.generate())
             .build()
     }

--- a/codegen-compiler/src/jvmMain/kotlin/com/freeletics/khonshu/codegen/codegen/HostViewControllerGenerator.kt
+++ b/codegen-compiler/src/jvmMain/kotlin/com/freeletics/khonshu/codegen/codegen/HostViewControllerGenerator.kt
@@ -1,0 +1,93 @@
+package com.freeletics.khonshu.codegen.codegen
+
+import com.freeletics.khonshu.codegen.BaseData
+import com.freeletics.khonshu.codegen.HostViewControllerData
+import com.freeletics.khonshu.codegen.util.InternalCodegenApi
+import com.freeletics.khonshu.codegen.util.composeUiViewController
+import com.freeletics.khonshu.codegen.util.compositionLocalProvider
+import com.freeletics.khonshu.codegen.util.globalGraphProvider
+import com.freeletics.khonshu.codegen.util.internalNavigatorApi
+import com.freeletics.khonshu.codegen.util.launchInfo
+import com.freeletics.khonshu.codegen.util.localHostGraphProvider
+import com.freeletics.khonshu.codegen.util.navHost
+import com.freeletics.khonshu.codegen.util.optIn
+import com.freeletics.khonshu.codegen.util.remember
+import com.freeletics.khonshu.codegen.util.retain
+import com.freeletics.khonshu.codegen.util.savedStateHandle
+import com.freeletics.khonshu.codegen.util.uiViewController
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier.PRIVATE
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.TypeSpec
+
+internal val Generator<out BaseData>.viewControllerName
+    get() = "Khonshu${data.baseName}ViewController"
+
+internal class HostViewControllerGenerator(
+    override val data: HostViewControllerData,
+) : Generator<HostViewControllerData>() {
+    internal fun generate(): TypeSpec {
+        return TypeSpec.Companion.classBuilder(viewControllerName)
+            .addAnnotation(optIn(InternalCodegenApi, internalNavigatorApi))
+            .primaryConstructor(constructor())
+            .addProperty(globalGraphProviderProperty())
+            .addProperty(launchInfoProperty())
+            .addFunction(viewControllerFun())
+            .build()
+    }
+
+    private fun globalGraphProviderProperty(): PropertySpec {
+        return PropertySpec.builder("globalGraphProvider", globalGraphProvider)
+            .addModifiers(PRIVATE)
+            .initializer("globalGraphProvider")
+            .build()
+    }
+
+    private fun launchInfoProperty(): PropertySpec {
+        return PropertySpec.builder("launchInfo", launchInfo)
+            .addModifiers(PRIVATE)
+            .initializer("launchInfo")
+            .build()
+    }
+
+    private fun constructor(): FunSpec {
+        return FunSpec.constructorBuilder()
+            .addParameter("globalGraphProvider", globalGraphProvider)
+            .addParameter("launchInfo", launchInfo)
+            .build()
+    }
+
+    private fun viewControllerFun(): FunSpec {
+        return FunSpec.builder("viewController")
+            .returns(uiViewController)
+            // TODO: ComposeUIViewControllerConfiguration parameter
+            .beginControlFlow("return %M", composeUiViewController)
+            .beginControlFlow("val graph = %M", retain)
+            .addStatement(
+                "val parentGraph = globalGraphProvider.getGraph<%T>(%T::class)",
+                graphFactoryClassName,
+                data.parentScope,
+            )
+            .addStatement("val savedStateHandle = %T.createHandle(null, null)", savedStateHandle)
+            .addStatement("parentGraph.%L(savedStateHandle, launchInfo)", graphFactoryCreateFunctionName)
+            .endControlFlow()
+            .beginControlFlow("val graphProvider = %M(graph)", remember)
+            .addStatement("%T(graph, globalGraphProvider)", graphProviderClassName)
+            .endControlFlow()
+            .beginControlFlow("%L(graph) { modifier, destinationChangedCallback ->", composableName)
+            .beginControlFlow(
+                "%M(%M provides graphProvider)",
+                compositionLocalProvider,
+                localHostGraphProvider,
+            )
+            .addStatement("%M(", navHost)
+            .addStatement("  navigator = %M(graph) { graph.hostNavigator },", remember)
+            .addStatement("  modifier = modifier,")
+            .addStatement("  destinationChangedCallback = destinationChangedCallback,")
+            .addStatement(")")
+            .endControlFlow()
+            .endControlFlow()
+            .endControlFlow()
+            .build()
+    }
+}

--- a/codegen-compiler/src/jvmMain/kotlin/com/freeletics/khonshu/codegen/parser/KspParser.kt
+++ b/codegen-compiler/src/jvmMain/kotlin/com/freeletics/khonshu/codegen/parser/KspParser.kt
@@ -3,6 +3,7 @@ package com.freeletics.khonshu.codegen.parser
 import com.freeletics.khonshu.codegen.ComposableParameter
 import com.freeletics.khonshu.codegen.DestinationData
 import com.freeletics.khonshu.codegen.HostActivityData
+import com.freeletics.khonshu.codegen.HostViewControllerData
 import com.freeletics.khonshu.codegen.HostWindowData
 import com.freeletics.khonshu.codegen.Navigation
 import com.freeletics.khonshu.codegen.util.activityScope
@@ -103,6 +104,28 @@ internal fun KSFunctionDeclaration.toHostWindowData(
     val navHostParameter = navHostParameter(logger) ?: return null
 
     return HostWindowData(
+        baseName = simpleName.asString(),
+        packageName = packageName.asString(),
+        scope = annotation.scope,
+        parentScope = annotation.parentScope,
+        stateMachine = annotation.stateMachine,
+        navHostParameter = navHostParameter,
+        composableParameter = getInjectedParameters(stateParameter, actionParameter, navHostParameter.typeName),
+        stateMachineClass = stateMachineClass,
+        stateParameter = getParameterWithType(stateParameter),
+        sendActionParameter = getParameterWithType(actionParameter),
+    )
+}
+
+internal fun KSFunctionDeclaration.toHostViewControllerData(
+    annotation: KSAnnotation,
+    logger: KSPLogger,
+): HostViewControllerData? {
+    val (stateMachineClass, stateParameter, actionParameter) = annotation.stateMachineParameters(logger) ?: return null
+
+    val navHostParameter = navHostParameter(logger) ?: return null
+
+    return HostViewControllerData(
         baseName = simpleName.asString(),
         packageName = packageName.asString(),
         scope = annotation.scope,

--- a/codegen-compiler/src/jvmMain/kotlin/com/freeletics/khonshu/codegen/util/External.kt
+++ b/codegen-compiler/src/jvmMain/kotlin/com/freeletics/khonshu/codegen/util/External.kt
@@ -90,6 +90,8 @@ internal val retain = MemberName("androidx.compose.runtime.retain", "retain")
 internal val compositionLocalProvider = MemberName("androidx.compose.runtime", "CompositionLocalProvider")
 internal val rememberCoroutineScope = MemberName("androidx.compose.runtime", "rememberCoroutineScope")
 internal val window = MemberName("androidx.compose.ui.window", "Window")
+internal val composeUiViewController = MemberName("androidx.compose.ui.window", "ComposeUIViewController")
+internal val uiViewController = ClassName("platform.UIKit", "UIViewController")
 
 // Android
 internal val suppressLint = ClassName("android.annotation", "SuppressLint")

--- a/codegen/api/android/codegen.api
+++ b/codegen/api/android/codegen.api
@@ -19,6 +19,12 @@ public abstract interface annotation class com/freeletics/khonshu/codegen/NavHos
 	public abstract fun stateMachine ()Ljava/lang/Class;
 }
 
+public abstract interface annotation class com/freeletics/khonshu/codegen/NavHostViewController : java/lang/annotation/Annotation {
+	public abstract fun parentScope ()Ljava/lang/Class;
+	public abstract fun scope ()Ljava/lang/Class;
+	public abstract fun stateMachine ()Ljava/lang/Class;
+}
+
 public abstract interface annotation class com/freeletics/khonshu/codegen/NavHostWindow : java/lang/annotation/Annotation {
 	public abstract fun parentScope ()Ljava/lang/Class;
 	public abstract fun scope ()Ljava/lang/Class;

--- a/codegen/api/codegen.klib.api
+++ b/codegen/api/codegen.klib.api
@@ -1,0 +1,67 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <khonshu:codegen>
+open annotation class com.freeletics.khonshu.codegen.internal/InternalCodegenApi : kotlin/Annotation { // com.freeletics.khonshu.codegen.internal/InternalCodegenApi|null[0]
+    constructor <init>() // com.freeletics.khonshu.codegen.internal/InternalCodegenApi.<init>|<init>(){}[0]
+}
+
+open annotation class com.freeletics.khonshu.codegen/NavDestination : kotlin/Annotation { // com.freeletics.khonshu.codegen/NavDestination|null[0]
+    constructor <init>(kotlin.reflect/KClass<out com.freeletics.khonshu.navigation/BaseRoute>, kotlin.reflect/KClass<*> = ..., kotlin.reflect/KClass<*>, kotlin.reflect/KClass<*> = ...) // com.freeletics.khonshu.codegen/NavDestination.<init>|<init>(kotlin.reflect.KClass<out|com.freeletics.khonshu.navigation.BaseRoute>;kotlin.reflect.KClass<*>;kotlin.reflect.KClass<*>;kotlin.reflect.KClass<*>){}[0]
+
+    final val destinationScope // com.freeletics.khonshu.codegen/NavDestination.destinationScope|{}destinationScope[0]
+        final fun <get-destinationScope>(): kotlin.reflect/KClass<*> // com.freeletics.khonshu.codegen/NavDestination.destinationScope.<get-destinationScope>|<get-destinationScope>(){}[0]
+    final val parentScope // com.freeletics.khonshu.codegen/NavDestination.parentScope|{}parentScope[0]
+        final fun <get-parentScope>(): kotlin.reflect/KClass<*> // com.freeletics.khonshu.codegen/NavDestination.parentScope.<get-parentScope>|<get-parentScope>(){}[0]
+    final val route // com.freeletics.khonshu.codegen/NavDestination.route|{}route[0]
+        final fun <get-route>(): kotlin.reflect/KClass<out com.freeletics.khonshu.navigation/BaseRoute> // com.freeletics.khonshu.codegen/NavDestination.route.<get-route>|<get-route>(){}[0]
+    final val stateMachine // com.freeletics.khonshu.codegen/NavDestination.stateMachine|{}stateMachine[0]
+        final fun <get-stateMachine>(): kotlin.reflect/KClass<*> // com.freeletics.khonshu.codegen/NavDestination.stateMachine.<get-stateMachine>|<get-stateMachine>(){}[0]
+}
+
+open annotation class com.freeletics.khonshu.codegen/NavHostActivity : kotlin/Annotation { // com.freeletics.khonshu.codegen/NavHostActivity|null[0]
+    constructor <init>(kotlin.reflect/KClass<*>, kotlin.reflect/KClass<*> = ..., kotlin.reflect/KClass<*>, kotlin.reflect/KClass<*>) // com.freeletics.khonshu.codegen/NavHostActivity.<init>|<init>(kotlin.reflect.KClass<*>;kotlin.reflect.KClass<*>;kotlin.reflect.KClass<*>;kotlin.reflect.KClass<*>){}[0]
+
+    final val activityBaseClass // com.freeletics.khonshu.codegen/NavHostActivity.activityBaseClass|{}activityBaseClass[0]
+        final fun <get-activityBaseClass>(): kotlin.reflect/KClass<*> // com.freeletics.khonshu.codegen/NavHostActivity.activityBaseClass.<get-activityBaseClass>|<get-activityBaseClass>(){}[0]
+    final val parentScope // com.freeletics.khonshu.codegen/NavHostActivity.parentScope|{}parentScope[0]
+        final fun <get-parentScope>(): kotlin.reflect/KClass<*> // com.freeletics.khonshu.codegen/NavHostActivity.parentScope.<get-parentScope>|<get-parentScope>(){}[0]
+    final val scope // com.freeletics.khonshu.codegen/NavHostActivity.scope|{}scope[0]
+        final fun <get-scope>(): kotlin.reflect/KClass<*> // com.freeletics.khonshu.codegen/NavHostActivity.scope.<get-scope>|<get-scope>(){}[0]
+    final val stateMachine // com.freeletics.khonshu.codegen/NavHostActivity.stateMachine|{}stateMachine[0]
+        final fun <get-stateMachine>(): kotlin.reflect/KClass<*> // com.freeletics.khonshu.codegen/NavHostActivity.stateMachine.<get-stateMachine>|<get-stateMachine>(){}[0]
+}
+
+open annotation class com.freeletics.khonshu.codegen/NavHostViewController : kotlin/Annotation { // com.freeletics.khonshu.codegen/NavHostViewController|null[0]
+    constructor <init>(kotlin.reflect/KClass<*> = ..., kotlin.reflect/KClass<*> = ..., kotlin.reflect/KClass<*>) // com.freeletics.khonshu.codegen/NavHostViewController.<init>|<init>(kotlin.reflect.KClass<*>;kotlin.reflect.KClass<*>;kotlin.reflect.KClass<*>){}[0]
+
+    final val parentScope // com.freeletics.khonshu.codegen/NavHostViewController.parentScope|{}parentScope[0]
+        final fun <get-parentScope>(): kotlin.reflect/KClass<*> // com.freeletics.khonshu.codegen/NavHostViewController.parentScope.<get-parentScope>|<get-parentScope>(){}[0]
+    final val scope // com.freeletics.khonshu.codegen/NavHostViewController.scope|{}scope[0]
+        final fun <get-scope>(): kotlin.reflect/KClass<*> // com.freeletics.khonshu.codegen/NavHostViewController.scope.<get-scope>|<get-scope>(){}[0]
+    final val stateMachine // com.freeletics.khonshu.codegen/NavHostViewController.stateMachine|{}stateMachine[0]
+        final fun <get-stateMachine>(): kotlin.reflect/KClass<*> // com.freeletics.khonshu.codegen/NavHostViewController.stateMachine.<get-stateMachine>|<get-stateMachine>(){}[0]
+}
+
+open annotation class com.freeletics.khonshu.codegen/NavHostWindow : kotlin/Annotation { // com.freeletics.khonshu.codegen/NavHostWindow|null[0]
+    constructor <init>(kotlin.reflect/KClass<*> = ..., kotlin.reflect/KClass<*> = ..., kotlin.reflect/KClass<*>) // com.freeletics.khonshu.codegen/NavHostWindow.<init>|<init>(kotlin.reflect.KClass<*>;kotlin.reflect.KClass<*>;kotlin.reflect.KClass<*>){}[0]
+
+    final val parentScope // com.freeletics.khonshu.codegen/NavHostWindow.parentScope|{}parentScope[0]
+        final fun <get-parentScope>(): kotlin.reflect/KClass<*> // com.freeletics.khonshu.codegen/NavHostWindow.parentScope.<get-parentScope>|<get-parentScope>(){}[0]
+    final val scope // com.freeletics.khonshu.codegen/NavHostWindow.scope|{}scope[0]
+        final fun <get-scope>(): kotlin.reflect/KClass<*> // com.freeletics.khonshu.codegen/NavHostWindow.scope.<get-scope>|<get-scope>(){}[0]
+    final val stateMachine // com.freeletics.khonshu.codegen/NavHostWindow.stateMachine|{}stateMachine[0]
+        final fun <get-stateMachine>(): kotlin.reflect/KClass<*> // com.freeletics.khonshu.codegen/NavHostWindow.stateMachine.<get-stateMachine>|<get-stateMachine>(){}[0]
+}
+
+abstract interface com.freeletics.khonshu.codegen/GlobalGraphProvider { // com.freeletics.khonshu.codegen/GlobalGraphProvider|null[0]
+    abstract fun <#A1: kotlin/Any?> getGraph(kotlin.reflect/KClass<*>): #A1 // com.freeletics.khonshu.codegen/GlobalGraphProvider.getGraph|getGraph(kotlin.reflect.KClass<*>){0§<kotlin.Any?>}[0]
+}
+
+abstract interface com.freeletics.khonshu.codegen/Overlay // com.freeletics.khonshu.codegen/Overlay|null[0]
+
+sealed interface com.freeletics.khonshu.codegen/ActivityScope // com.freeletics.khonshu.codegen/ActivityScope|null[0]

--- a/codegen/api/jvm/codegen.api
+++ b/codegen/api/jvm/codegen.api
@@ -19,6 +19,12 @@ public abstract interface annotation class com/freeletics/khonshu/codegen/NavHos
 	public abstract fun stateMachine ()Ljava/lang/Class;
 }
 
+public abstract interface annotation class com/freeletics/khonshu/codegen/NavHostViewController : java/lang/annotation/Annotation {
+	public abstract fun parentScope ()Ljava/lang/Class;
+	public abstract fun scope ()Ljava/lang/Class;
+	public abstract fun stateMachine ()Ljava/lang/Class;
+}
+
 public abstract interface annotation class com/freeletics/khonshu/codegen/NavHostWindow : java/lang/annotation/Annotation {
 	public abstract fun parentScope ()Ljava/lang/Class;
 	public abstract fun scope ()Ljava/lang/Class;

--- a/codegen/codegen.gradle.kts
+++ b/codegen/codegen.gradle.kts
@@ -14,6 +14,7 @@ freeletics {
     multiplatform {
         addJvmTarget()
         addAndroidTarget()
+        addIosTargets()
     }
 }
 

--- a/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/NavHostViewController.kt
+++ b/codegen/src/commonMain/kotlin/com/freeletics/khonshu/codegen/NavHostViewController.kt
@@ -1,0 +1,23 @@
+package com.freeletics.khonshu.codegen
+
+import dev.zacsweers.metro.AppScope
+import kotlin.reflect.KClass
+
+/**
+ * Add this annotation to a [androidx.compose.runtime.Composable] function. It is required that
+ * the annotated function has `State` as first parameter and `(Action) -> Unit` as second parameter,
+ * where `State` and `Action` match the given `StateMachine`. It should also have a parameter of
+ * type `SimpleNavHost`, which is a `NavHost` composable that should be placed within the annotated composable.
+ *
+ * This will trigger the generation of
+ * - an `Activity` that extends [activityBaseClass] and displays the annotated composable
+ * - a wrapper Composable that sets up the annotated Composable with the given [stateMachine]
+ * - a Metro graph extension that uses [scope] as scope marker and [parentScope] as `scope` for its factory
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+public annotation class NavHostViewController(
+    val scope: KClass<*> = ActivityScope::class,
+    val parentScope: KClass<*> = AppScope::class,
+    val stateMachine: KClass<*>,
+)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,9 +66,9 @@ androidx-activity = { module = "androidx.activity:activity", version.ref = "andr
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-annotations = { module = "androidx.annotation:annotation", version.ref = "androidx-annotations" }
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
-androidx-lifecycle-common = { module = "androidx.lifecycle:lifecycle-common", version.ref = "androidx-lifecycle" }
-androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime", version.ref = "androidx-lifecycle" }
-androidx-lifecycle-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
+androidx-lifecycle-common = { module = "org.jetbrains.androidx.lifecycle:lifecycle-common", version.ref = "androidx-lifecycle" }
+androidx-lifecycle-runtime = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime", version.ref = "androidx-lifecycle" }
+androidx-lifecycle-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-testing = { module = "androidx.lifecycle:lifecycle-runtime-testing", version.ref = "androidx-lifecycle" }
 androidx-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
 androidx-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }


### PR DESCRIPTION
Similar to the desktop codegen this adds an equivalent of the Activtity codegen to generate an entry point for using codegen with a nav host in an iOS app. Other than the generation of the different class there aren't really changes and even that class is mostly the same.