### PR TITLE
Fix `TextResource` arg serialization indices

### DIFF
--- a/text-resource/src/androidHostTest/kotlin/com/freeletics/khonshu/androidHostTest/TextResourceTest.kt
+++ b/text-resource/src/androidHostTest/kotlin/com/freeletics/khonshu/androidHostTest/TextResourceTest.kt
@@ -2,7 +2,14 @@ package com.freeletics.khonshu.text
 
 import com.google.common.truth.Truth.assertThat
 import kotlin.test.Test
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerializationStrategy
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.AbstractEncoder
+import kotlinx.serialization.encoding.CompositeEncoder
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.EmptySerializersModule
+import kotlinx.serialization.modules.SerializersModule
 
 class TextResourceTest {
     val textResource = TextResource.join(
@@ -40,5 +47,47 @@ class TextResourceTest {
     @Test
     fun deserialize() {
         assertThat(Json.decodeFromString<TextResource>(json)).isEqualTo(textResource)
+    }
+
+    @Test
+    fun `serialize uses the actual element index for each arg`() {
+        val encoder = RecordingEncoder()
+
+        AnyArraySerializer.serialize(
+            encoder,
+            arrayOf<Any>(
+                "string",
+                1,
+                2L,
+                3.0f,
+                4.0,
+                TextResource("nested"),
+            ),
+        )
+
+        assertThat(encoder.indices).containsExactly(0, 1, 2, 3, 4, 5).inOrder()
+    }
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+private class RecordingEncoder : AbstractEncoder() {
+    val indices = mutableListOf<Int>()
+
+    override val serializersModule: SerializersModule = EmptySerializersModule()
+
+    override fun beginCollection(
+        descriptor: SerialDescriptor,
+        collectionSize: Int,
+    ): CompositeEncoder = this
+
+    override fun endStructure(descriptor: SerialDescriptor) = Unit
+
+    override fun <T> encodeSerializableElement(
+        descriptor: SerialDescriptor,
+        index: Int,
+        serializer: SerializationStrategy<T>,
+        value: T,
+    ) {
+        indices += index
     }
 }

--- a/text-resource/src/androidMain/kotlin/com/freeletics/khonshu/text/TextResource.kt
+++ b/text-resource/src/androidMain/kotlin/com/freeletics/khonshu/text/TextResource.kt
@@ -311,17 +311,17 @@ internal object AnyArraySerializer : KSerializer<Array<out Any>> {
 
     override fun serialize(encoder: Encoder, value: Array<out Any>) {
         encoder.encodeCollection(descriptor, value.size) {
-            value.forEach {
-                val wrapped = when (it) {
-                    is Int -> IntArg(it)
-                    is Long -> LongArg(it)
-                    is Float -> FloatArg(it)
-                    is Double -> DoubleArg(it)
-                    is String -> StringArg(it)
-                    is TextResource -> TextResourceArg(it)
-                    else -> error("Unknown arg $it")
+            value.forEachIndexed { index, arg ->
+                val wrapped = when (arg) {
+                    is Int -> IntArg(arg)
+                    is Long -> LongArg(arg)
+                    is Float -> FloatArg(arg)
+                    is Double -> DoubleArg(arg)
+                    is String -> StringArg(arg)
+                    is TextResource -> TextResourceArg(arg)
+                    else -> error("Unknown arg $arg")
                 }
-                encodeSerializableElement(descriptor, 1, Arg.serializer(), wrapped)
+                encodeSerializableElement(descriptor, index, Arg.serializer(), wrapped)
             }
         }
     }


### PR DESCRIPTION
Fixes `TextResource` argument serialization for arrays with multiple elements.

`AnyArraySerializer` was encoding every array element with a hardcoded index of `1`, which could break encoding/decoding when multiple arguments were provided. The serializer now uses the actual element index via `forEachIndexed`.