### PR TITLE
StackEntryState: update putPlatformValue to verify if all collection types are supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ Change Log
 
 ### Navigation
 
-- Fixed `StackEntryState` ignoring the `KSerializer` when saving a value that is also `Parcelable`
-  or `Serializable`. This fixes crash on Android when storing a `List` of `@Serializable` classes.
+- Fixed crash on Android when saving a `List` of `@Serializable` classes in `StackEntryState`.
 
 ## 0.37.1 *(2026-06-24)*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Change Log
 - Update AGP to 9.3.1.
 - Update Java/Kotlin compilers Java compatibility target to 17 - required with AGP 9.3.0.
 
+### Navigation
+
+- Fixed `StackEntryState` ignoring the `KSerializer` when saving a value that is also `Parcelable`
+  or `Serializable`. This fixes crash on Android when storing a `List` of `@Serializable` classes.
+
 ## 0.37.1 *(2026-06-24)*
 
 - Compiled without enabling Kotlin 2.4.0 experimental compiler flags.

--- a/navigation/src/androidHostTest/kotlin/com/freeletics/khonshu/navigation/StackEntryWriterAndroidTest.kt
+++ b/navigation/src/androidHostTest/kotlin/com/freeletics/khonshu/navigation/StackEntryWriterAndroidTest.kt
@@ -1,0 +1,28 @@
+package com.freeletics.khonshu.navigation
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.serialization.Serializable
+import org.junit.Test
+
+class StackEntryWriterAndroidTest {
+    @Test
+    fun `platform values can be written`() {
+        assertThat(canWriteToParcel(null)).isTrue()
+        assertThat(canWriteToParcel("test")).isTrue()
+        assertThat(canWriteToParcel(listOf("test", null))).isTrue()
+        assertThat(canWriteToParcel(arrayOf("test"))).isTrue()
+        assertThat(canWriteToParcel(mapOf("key" to "test"))).isTrue()
+    }
+
+    @Test
+    fun `values requiring serializer can not be written`() {
+        assertThat(canWriteToParcel(TestClass(2))).isFalse()
+        assertThat(canWriteToParcel(listOf(TestClass(2)))).isFalse()
+        assertThat(canWriteToParcel(listOf(listOf(TestClass(2))))).isFalse()
+        assertThat(canWriteToParcel(arrayOf(TestClass(2)))).isFalse()
+        assertThat(canWriteToParcel(mapOf("key" to TestClass(2)))).isFalse()
+    }
+}
+
+@Serializable
+private data class TestClass(val value: Int)

--- a/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/StackEntryState.android.kt
+++ b/navigation/src/androidMain/kotlin/com/freeletics/khonshu/navigation/StackEntryState.android.kt
@@ -10,10 +10,22 @@ internal actual fun SavedStateWriter.putPlatformValue(key: String, value: Any): 
             putParcelable(key, value)
             true
         }
-        is Serializable -> {
+        is Serializable if canWriteToParcel(value) -> {
             putJavaSerializable(key, value)
             true
         }
         else -> false
     }
+}
+
+/**
+ * A collection is [Serializable] while its elements might not be, so it can only be written as a
+ * platform value when the platform supports all elements.
+ */
+internal fun canWriteToParcel(value: Any?): Boolean = when (value) {
+    null -> true
+    is Collection<*> -> value.all { canWriteToParcel(it) }
+    is Array<*> -> value.all { canWriteToParcel(it) }
+    is Map<*, *> -> value.all { canWriteToParcel(it.key) && canWriteToParcel(it.value) }
+    else -> value is Parcelable || value is Serializable
 }

--- a/navigation/src/commonMain/kotlin/com/freeletics/khonshu/navigation/StackEntryState.kt
+++ b/navigation/src/commonMain/kotlin/com/freeletics/khonshu/navigation/StackEntryState.kt
@@ -137,10 +137,11 @@ private fun <T : Any> SavedStateWriter.put(key: String, value: T?, serializer: K
             // noinspection RestrictedApi
             putSavedState(key, value.savedStateProvider().saveState())
         }
-        else -> if (serializer != null) {
-            putKotlinSerializable(serializer, key, value)
-        } else {
-            require(putPlatformValue(key, value)) { "Did not find serializer for $value" }
+        else -> {
+            if (!putPlatformValue(key, value)) {
+                val serializer = requireNotNull(serializer) { "Did not find serializer for $value" }
+                putKotlinSerializable(serializer, key, value)
+            }
         }
     }
 }

--- a/navigation/src/commonMain/kotlin/com/freeletics/khonshu/navigation/StackEntryState.kt
+++ b/navigation/src/commonMain/kotlin/com/freeletics/khonshu/navigation/StackEntryState.kt
@@ -137,11 +137,10 @@ private fun <T : Any> SavedStateWriter.put(key: String, value: T?, serializer: K
             // noinspection RestrictedApi
             putSavedState(key, value.savedStateProvider().saveState())
         }
-        else -> {
-            if (!putPlatformValue(key, value)) {
-                val serializer = requireNotNull(serializer) { "Did not find serializer for $value" }
-                putKotlinSerializable(serializer, key, value)
-            }
+        else -> if (serializer != null) {
+            putKotlinSerializable(serializer, key, value)
+        } else {
+            require(putPlatformValue(key, value)) { "Did not find serializer for $value" }
         }
     }
 }

--- a/navigation/src/jvmTest/kotlin/com/freeletics/khonshu/navigation/StackEntryStateTest.kt
+++ b/navigation/src/jvmTest/kotlin/com/freeletics/khonshu/navigation/StackEntryStateTest.kt
@@ -19,6 +19,7 @@ class StackEntryStateTest {
         state["float"] = 0.1f
         state["boolean"] = false
         state["kotlin serialization"] = TestClass(2)
+        state["kotlin serialization list"] = listOf(TestClass(3), TestClass(4))
         state.savedStateHandle()["c"] = "d"
 
         val savedState = state.saveState().read { toMap() }
@@ -31,6 +32,9 @@ class StackEntryStateTest {
         assertThat(savedState["float"]).isEqualTo(0.1f)
         assertThat(savedState["boolean"]).isEqualTo(false)
         assertThat((savedState["kotlin serialization"] as SavedState).read { toMap() }).isEqualTo(mapOf("value" to 2))
+        val list = (savedState["kotlin serialization list"] as SavedState).read { toMap() }
+        assertThat((list["0"] as SavedState).read { toMap() }).isEqualTo(mapOf("value" to 3))
+        assertThat((list["1"] as SavedState).read { toMap() }).isEqualTo(mapOf("value" to 4))
         assertThat(
             (savedState["khonshu-internal-saved-state-handle"] as SavedState).read {
                 toMap()
@@ -49,6 +53,7 @@ class StackEntryStateTest {
         original["float"] = 0.1f
         original["boolean"] = false
         original["kotlin serialization"] = TestClass(2)
+        original["kotlin serialization list"] = listOf(TestClass(3), TestClass(4))
         original[KEY_SAVED_STATE_HANDLE] = savedState(mapOf("c" to "d"))
 
         val state = StackEntryState(original.saveState())
@@ -61,6 +66,8 @@ class StackEntryStateTest {
         assertThat(state.get<Float>("float")).isEqualTo(0.1f)
         assertThat(state.get<Boolean>("boolean")).isEqualTo(false)
         assertThat(state.get<TestClass>("kotlin serialization")).isEqualTo(TestClass(2))
+        assertThat(state.get<List<TestClass>>("kotlin serialization list"))
+            .isEqualTo(listOf(TestClass(3), TestClass(4)))
         assertThat(state.savedStateHandle().get<String>("c")).isEqualTo("d")
     }
 }


### PR DESCRIPTION
This fixes crash on Android when trying to store `List` of  `kotlinx.serialization.Serializable` values since `List` itself can either be `@Serializable` or `@Parcelable`.

Test in `StackEntryStateTest` doesn't really verify Android's behaviour since it's on JVM and only tests List serialization. It would pass even without fix since `putPlatformValue` is always `false` on JVM now. New test verifies Android codepath but without building platform classes.